### PR TITLE
Phase 3: install / uninstall / list / search

### DIFF
--- a/cli/cmd/humblskills/install.go
+++ b/cli/cmd/humblskills/install.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/spf13/cobra"
+
+	"github.com/jjfantini/humblSKILLS/cli/internal/install"
+	"github.com/jjfantini/humblSKILLS/cli/internal/platform"
+	"github.com/jjfantini/humblSKILLS/cli/internal/registry"
+)
+
+type installFlags struct {
+	platforms []string
+	scope     string
+	force     bool
+}
+
+func newInstallCmd(app *App) *cobra.Command {
+	var f installFlags
+	cmd := &cobra.Command{
+		Use:   "install <skill>",
+		Short: "Install a skill (and its deps) onto every detected platform",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runInstall(app, args[0], f)
+		},
+	}
+	cmd.Flags().StringSliceVar(&f.platforms, "platform", nil, "restrict install to these adapters (default: all detected)")
+	cmd.Flags().StringVar(&f.scope, "scope", "", "install scope (user|project; default: adapter's default)")
+	cmd.Flags().BoolVar(&f.force, "force", false, "reinstall even if already up-to-date")
+	return cmd
+}
+
+func runInstall(app *App, skill string, f installFlags) error {
+	adapters, err := app.Adapters()
+	if err != nil {
+		return fmt.Errorf("load adapters: %w", err)
+	}
+
+	reg, _, err := registry.NewFetcher(app.Config.RegistryURL, app.Config.CacheDir).Load()
+	if err != nil {
+		return fmt.Errorf("load registry: %w", err)
+	}
+
+	selected, err := selectPlatforms(adapters, f.platforms)
+	if err != nil {
+		return err
+	}
+	if len(selected) == 0 {
+		return fmt.Errorf("no platforms selected — run 'humblskills doctor' to see what's detected")
+	}
+
+	plan, err := install.Plan(reg, skill)
+	if err != nil {
+		return err
+	}
+
+	app.UI.Detail("plan:")
+	for _, s := range plan {
+		tag := "root"
+		if s.IsDep {
+			tag = "dep"
+		}
+		app.UI.Detail("  %s %s@%s", tag, s.Skill.Name, s.Skill.Version)
+	}
+
+	engine := install.NewEngine(app.Config.CacheDir, app.Config.ManifestPath)
+	res, err := engine.Execute(reg, plan, install.ExecuteOpts{
+		Adapters:  adapters,
+		Platforms: selected,
+		Scope:     f.scope,
+		Force:     f.force,
+	})
+	if err != nil {
+		return err
+	}
+
+	if app.Config.JSON {
+		return app.UI.JSON(res)
+	}
+
+	printInstall(app, res)
+	return nil
+}
+
+// selectPlatforms returns the adapter names to install onto. If the user
+// passed --platform, it's the intersection of that list with the declared
+// adapters; otherwise it's every detected adapter.
+func selectPlatforms(adapters []platform.Adapter, requested []string) ([]string, error) {
+	known := platform.NameSet(adapters)
+	if len(requested) > 0 {
+		out := make([]string, 0, len(requested))
+		for _, r := range requested {
+			if _, ok := known[r]; !ok {
+				return nil, fmt.Errorf("unknown platform %q", r)
+			}
+			out = append(out, r)
+		}
+		return out, nil
+	}
+
+	detected := platform.Detect(adapters)
+	out := make([]string, 0, len(detected))
+	for _, d := range detected {
+		if d.Detected {
+			out = append(out, d.Name)
+		}
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+func printInstall(app *App, r install.Result) {
+	if len(r.Results) == 0 {
+		app.UI.Warn("nothing to do — skill(s) declared no matching platforms")
+		return
+	}
+	var installed, replaced, skipped, forced []install.TargetResult
+	for _, t := range r.Results {
+		switch t.Outcome {
+		case install.OutcomeInstalled:
+			installed = append(installed, t)
+		case install.OutcomeReplaced:
+			replaced = append(replaced, t)
+		case install.OutcomeSkipped:
+			skipped = append(skipped, t)
+		case install.OutcomeForced:
+			forced = append(forced, t)
+		}
+	}
+	for _, t := range installed {
+		app.UI.Success("installed %s → %s [%s/%s]", t.Skill, t.Path, t.Platform, t.Scope)
+	}
+	for _, t := range replaced {
+		app.UI.Success("replaced %s → %s [%s/%s]", t.Skill, t.Path, t.Platform, t.Scope)
+	}
+	for _, t := range forced {
+		app.UI.Success("reinstalled %s → %s [%s/%s]", t.Skill, t.Path, t.Platform, t.Scope)
+	}
+	for _, t := range skipped {
+		app.UI.Detail("already up-to-date: %s [%s/%s]", t.Skill, t.Platform, t.Scope)
+	}
+	if len(installed)+len(replaced)+len(forced) == 0 {
+		app.UI.Info("%d target%s already up-to-date (use --force to reinstall)", len(skipped), plural(len(skipped)))
+	}
+}

--- a/cli/cmd/humblskills/list.go
+++ b/cli/cmd/humblskills/list.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"sort"
+
+	"github.com/spf13/cobra"
+
+	"github.com/jjfantini/humblSKILLS/cli/internal/manifest"
+)
+
+func newListCmd(app *App) *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List installed skills",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			m, err := manifest.Load(app.Config.ManifestPath)
+			if err != nil {
+				return err
+			}
+			if app.Config.JSON {
+				return app.UI.JSON(m)
+			}
+			if len(m.Installations) == 0 {
+				app.UI.Info("no skills installed — try 'humblskills install <name>'")
+				return nil
+			}
+			installs := append([]manifest.Installation(nil), m.Installations...)
+			sort.Slice(installs, func(i, j int) bool {
+				if installs[i].Skill != installs[j].Skill {
+					return installs[i].Skill < installs[j].Skill
+				}
+				if installs[i].Platform != installs[j].Platform {
+					return installs[i].Platform < installs[j].Platform
+				}
+				return installs[i].Scope < installs[j].Scope
+			})
+			for _, inst := range installs {
+				app.UI.Info("%s@%s  [%s/%s]  %s", inst.Skill, inst.Version, inst.Platform, inst.Scope, inst.Path)
+			}
+			return nil
+		},
+	}
+}

--- a/cli/cmd/humblskills/root.go
+++ b/cli/cmd/humblskills/root.go
@@ -73,6 +73,10 @@ func newRootCmd() *cobra.Command {
 		newVersionCmd(app),
 		newDoctorCmd(app),
 		newRegistryCmd(app),
+		newInstallCmd(app),
+		newUninstallCmd(app),
+		newListCmd(app),
+		newSearchCmd(app),
 	)
 
 	return cmd

--- a/cli/cmd/humblskills/search.go
+++ b/cli/cmd/humblskills/search.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/jjfantini/humblSKILLS/cli/internal/registry"
+)
+
+func newSearchCmd(app *App) *cobra.Command {
+	return &cobra.Command{
+		Use:   "search [query]",
+		Short: "Search the registry by name, description, or tag",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			reg, _, err := registry.NewFetcher(app.Config.RegistryURL, app.Config.CacheDir).Load()
+			if err != nil {
+				return err
+			}
+			query := ""
+			if len(args) == 1 {
+				query = strings.ToLower(args[0])
+			}
+
+			var hits []registry.Skill
+			for _, s := range reg.Skills {
+				if query == "" || matches(s, query) {
+					hits = append(hits, s)
+				}
+			}
+			sort.Slice(hits, func(i, j int) bool { return hits[i].Name < hits[j].Name })
+
+			if app.Config.JSON {
+				return app.UI.JSON(struct {
+					Query   string           `json:"query,omitempty"`
+					Results []registry.Skill `json:"results"`
+				}{query, hits})
+			}
+			if len(hits) == 0 {
+				app.UI.Warn("no skills matched %q", query)
+				return nil
+			}
+			for _, s := range hits {
+				app.UI.Info("%s@%s — %s", s.Name, s.Version, s.Description)
+				if len(s.Tags) > 0 {
+					app.UI.Detail("  tags: %s", strings.Join(s.Tags, ", "))
+				}
+				if len(s.Platforms) > 0 {
+					app.UI.Detail("  platforms: %s", strings.Join(s.Platforms, ", "))
+				}
+			}
+			return nil
+		},
+	}
+}
+
+func matches(s registry.Skill, q string) bool {
+	if strings.Contains(strings.ToLower(s.Name), q) {
+		return true
+	}
+	if strings.Contains(strings.ToLower(s.Description), q) {
+		return true
+	}
+	for _, t := range s.Tags {
+		if strings.Contains(strings.ToLower(t), q) {
+			return true
+		}
+	}
+	return false
+}

--- a/cli/cmd/humblskills/uninstall.go
+++ b/cli/cmd/humblskills/uninstall.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/jjfantini/humblSKILLS/cli/internal/install"
+)
+
+func newUninstallCmd(app *App) *cobra.Command {
+	return &cobra.Command{
+		Use:   "uninstall <skill>",
+		Short: "Remove an installed skill from every target",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			engine := install.NewEngine(app.Config.CacheDir, app.Config.ManifestPath)
+			res, err := engine.Uninstall(args[0])
+			if err != nil {
+				return err
+			}
+			if app.Config.JSON {
+				return app.UI.JSON(struct {
+					Results []install.TargetResult `json:"results"`
+				}{res})
+			}
+			if len(res) == 0 {
+				app.UI.Warn("%s is not installed", args[0])
+				return nil
+			}
+			for _, t := range res {
+				app.UI.Success("removed %s [%s/%s]", t.Skill, t.Platform, t.Scope)
+			}
+			return nil
+		},
+	}
+}

--- a/cli/internal/fetch/tarball.go
+++ b/cli/internal/fetch/tarball.go
@@ -1,0 +1,234 @@
+// Package fetch downloads skill source from GitHub as pinned tarballs and
+// extracts individual skill directories into staging paths.
+package fetch
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// DefaultHTTPTimeout is the HTTP request timeout for tarball downloads.
+const DefaultHTTPTimeout = 60 * time.Second
+
+// Fetcher downloads GitHub tarballs and caches them on disk, keyed by SHA so
+// the cache entry is immutable and can be reused indefinitely.
+type Fetcher struct {
+	CacheDir string
+	HTTP     *http.Client
+}
+
+// NewFetcher returns a Fetcher with sensible defaults. cacheDir should be the
+// humblskills-specific cache directory (e.g. $XDG_CACHE_HOME/humblskills).
+func NewFetcher(cacheDir string) *Fetcher {
+	return &Fetcher{
+		CacheDir: cacheDir,
+		HTTP:     &http.Client{Timeout: DefaultHTTPTimeout},
+	}
+}
+
+// Fetch ensures the tarball for repo@sha is present on disk and returns its
+// path. repo may be fully qualified ("github.com/owner/name") or bare
+// ("owner/name"). Only GitHub is supported in v0.1.
+func (f *Fetcher) Fetch(repo, sha string) (string, error) {
+	owner, name, err := splitRepo(repo)
+	if err != nil {
+		return "", err
+	}
+	if sha == "" {
+		return "", errors.New("fetch: empty sha")
+	}
+
+	dest := f.tarPath(owner, name, sha)
+	if _, err := os.Stat(dest); err == nil {
+		return dest, nil
+	}
+
+	url := fmt.Sprintf("https://codeload.github.com/%s/%s/tar.gz/%s", owner, name, sha)
+	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+		return "", fmt.Errorf("create tar cache dir: %w", err)
+	}
+
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return "", fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("User-Agent", "humblskills-cli")
+
+	resp, err := f.HTTP.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("fetch %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", fmt.Errorf("fetch %s: HTTP %d", url, resp.StatusCode)
+	}
+
+	tmp := dest + ".tmp"
+	out, err := os.Create(tmp)
+	if err != nil {
+		return "", fmt.Errorf("create tmp tar: %w", err)
+	}
+	if _, err := io.Copy(out, resp.Body); err != nil {
+		_ = out.Close()
+		_ = os.Remove(tmp)
+		return "", fmt.Errorf("write tmp tar: %w", err)
+	}
+	if err := out.Close(); err != nil {
+		_ = os.Remove(tmp)
+		return "", err
+	}
+	if err := os.Rename(tmp, dest); err != nil {
+		_ = os.Remove(tmp)
+		return "", fmt.Errorf("finalise tar: %w", err)
+	}
+	return dest, nil
+}
+
+// Extract unpacks files under skillPath (repo-relative, e.g. "skills/foo")
+// from the gzipped tarball at tarPath into destDir. The top-level directory
+// added by GitHub ("{owner}-{repo}-{short_sha}/") is stripped automatically.
+// Symlinks and entries escaping destDir are rejected.
+func Extract(tarPath, skillPath, destDir string) error {
+	f, err := os.Open(tarPath)
+	if err != nil {
+		return fmt.Errorf("open tarball: %w", err)
+	}
+	defer f.Close()
+
+	gz, err := gzip.NewReader(f)
+	if err != nil {
+		return fmt.Errorf("gzip open: %w", err)
+	}
+	defer gz.Close()
+
+	skillPath = path.Clean(strings.TrimSuffix(skillPath, "/"))
+	if skillPath == "" || skillPath == "." {
+		return errors.New("extract: empty skill path")
+	}
+
+	destDirAbs, err := filepath.Abs(destDir)
+	if err != nil {
+		return fmt.Errorf("abs dest: %w", err)
+	}
+	if err := os.MkdirAll(destDirAbs, 0o755); err != nil {
+		return fmt.Errorf("create dest: %w", err)
+	}
+
+	tr := tar.NewReader(gz)
+	prefix := ""
+	matched := 0
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("tar read: %w", err)
+		}
+		// Skip PAX extended headers, which don't carry real files but do
+		// sometimes appear first in GitHub-generated tarballs and would
+		// otherwise poison our top-level-prefix detection.
+		if hdr.Typeflag == tar.TypeXGlobalHeader || hdr.Typeflag == tar.TypeXHeader {
+			continue
+		}
+		name := path.Clean(hdr.Name)
+		if name == "." || strings.HasPrefix(name, "..") {
+			return fmt.Errorf("refusing unsafe tar entry %q", hdr.Name)
+		}
+		if prefix == "" {
+			i := strings.IndexByte(name, '/')
+			if i < 0 {
+				prefix = name
+			} else {
+				prefix = name[:i]
+			}
+		}
+		target := prefix + "/" + skillPath
+		rel, ok := trimPrefix(name, target)
+		if !ok {
+			continue
+		}
+
+		outPath := filepath.Join(destDirAbs, filepath.FromSlash(rel))
+		if !strings.HasPrefix(outPath, destDirAbs+string(filepath.Separator)) && outPath != destDirAbs {
+			return fmt.Errorf("refusing path traversal: %s", hdr.Name)
+		}
+
+		switch hdr.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(outPath, os.FileMode(hdr.Mode)&0o777|0o700); err != nil {
+				return fmt.Errorf("mkdir %s: %w", outPath, err)
+			}
+		case tar.TypeReg, tar.TypeRegA:
+			if err := os.MkdirAll(filepath.Dir(outPath), 0o755); err != nil {
+				return fmt.Errorf("mkdir parent %s: %w", outPath, err)
+			}
+			if err := writeFile(outPath, tr, os.FileMode(hdr.Mode)&0o777); err != nil {
+				return err
+			}
+			matched++
+		case tar.TypeSymlink, tar.TypeLink:
+			return fmt.Errorf("symlink/hardlink not supported in skill tree: %s", hdr.Name)
+		default:
+			// Skip other entry types (char device, fifo, ...).
+		}
+	}
+	if matched == 0 {
+		return fmt.Errorf("no files found under %q in tarball", skillPath)
+	}
+	return nil
+}
+
+// trimPrefix returns the portion of name after prefix + "/", or reports false
+// if name isn't under prefix. prefix is treated as a directory path.
+func trimPrefix(name, prefix string) (string, bool) {
+	if name == prefix {
+		return "", false // directory entry for the skill root itself
+	}
+	if strings.HasPrefix(name, prefix+"/") {
+		return name[len(prefix)+1:], true
+	}
+	return "", false
+}
+
+func writeFile(path string, r io.Reader, mode os.FileMode) error {
+	if mode == 0 {
+		mode = 0o644
+	}
+	out, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode)
+	if err != nil {
+		return fmt.Errorf("create %s: %w", path, err)
+	}
+	if _, err := io.Copy(out, r); err != nil {
+		_ = out.Close()
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	return out.Close()
+}
+
+func (f *Fetcher) tarPath(owner, name, sha string) string {
+	fname := fmt.Sprintf("%s-%s-%s.tar.gz", owner, name, sha)
+	return filepath.Join(f.CacheDir, "tars", fname)
+}
+
+func splitRepo(repo string) (owner, name string, err error) {
+	r := strings.TrimSpace(repo)
+	r = strings.TrimPrefix(r, "https://")
+	r = strings.TrimPrefix(r, "http://")
+	r = strings.TrimPrefix(r, "github.com/")
+	r = strings.TrimSuffix(r, ".git")
+	parts := strings.Split(r, "/")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", fmt.Errorf("unsupported repo %q (expected github.com/owner/name)", repo)
+	}
+	return parts[0], parts[1], nil
+}

--- a/cli/internal/fetch/tarball_test.go
+++ b/cli/internal/fetch/tarball_test.go
@@ -1,0 +1,174 @@
+package fetch
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// makeTarball writes a gzipped tarball that mimics the layout of a
+// GitHub-generated archive: a single top-level directory containing the repo
+// contents.
+func makeTarball(t *testing.T, prefix string, files map[string]string) string {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+
+	addDir := func(name string) {
+		if err := tw.WriteHeader(&tar.Header{
+			Name:     name + "/",
+			Typeflag: tar.TypeDir,
+			Mode:     0o755,
+		}); err != nil {
+			t.Fatalf("tar dir %s: %v", name, err)
+		}
+	}
+	addDir(prefix)
+	for p, body := range files {
+		full := prefix + "/" + p
+		if err := tw.WriteHeader(&tar.Header{
+			Name:     full,
+			Typeflag: tar.TypeReg,
+			Mode:     0o644,
+			Size:     int64(len(body)),
+		}); err != nil {
+			t.Fatalf("tar hdr %s: %v", p, err)
+		}
+		if _, err := tw.Write([]byte(body)); err != nil {
+			t.Fatalf("tar body %s: %v", p, err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	path := filepath.Join(t.TempDir(), "archive.tar.gz")
+	if err := os.WriteFile(path, buf.Bytes(), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestExtract_BasicSkill(t *testing.T) {
+	tarPath := makeTarball(t, "jj-humblSKILLS-abc1234", map[string]string{
+		"README.md":                           "repo readme",
+		"skills/foo/SKILL.md":                 "# foo",
+		"skills/foo/nested/helper.py":         "print('hi')",
+		"skills/bar/SKILL.md":                 "# bar",
+	})
+
+	dest := filepath.Join(t.TempDir(), "out")
+	if err := Extract(tarPath, "skills/foo", dest); err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+
+	skill, err := os.ReadFile(filepath.Join(dest, "SKILL.md"))
+	if err != nil {
+		t.Fatalf("read SKILL.md: %v", err)
+	}
+	if string(skill) != "# foo" {
+		t.Errorf("got %q", skill)
+	}
+	helper, err := os.ReadFile(filepath.Join(dest, "nested", "helper.py"))
+	if err != nil {
+		t.Fatalf("read helper: %v", err)
+	}
+	if string(helper) != "print('hi')" {
+		t.Errorf("got %q", helper)
+	}
+
+	// bar shouldn't leak into foo's dest.
+	if _, err := os.Stat(filepath.Join(dest, "..", "bar")); err == nil {
+		t.Error("bar leaked outside dest")
+	}
+}
+
+func TestExtract_SkipsPaxGlobalHeader(t *testing.T) {
+	// GitHub's codeload tarballs prefix the archive with a pax_global_header
+	// entry. The extractor must not treat it as the top-level directory.
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+
+	_ = tw.WriteHeader(&tar.Header{Name: "pax_global_header", Typeflag: tar.TypeXGlobalHeader, Size: 0})
+	_ = tw.WriteHeader(&tar.Header{Name: "repo-abc/", Typeflag: tar.TypeDir, Mode: 0o755})
+	body := "# hi\n"
+	_ = tw.WriteHeader(&tar.Header{Name: "repo-abc/skills/foo/SKILL.md", Typeflag: tar.TypeReg, Mode: 0o644, Size: int64(len(body))})
+	_, _ = tw.Write([]byte(body))
+	_ = tw.Close()
+	_ = gz.Close()
+
+	tarPath := filepath.Join(t.TempDir(), "with-pax.tar.gz")
+	if err := os.WriteFile(tarPath, buf.Bytes(), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dest := filepath.Join(t.TempDir(), "out")
+	if err := Extract(tarPath, "skills/foo", dest); err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	b, err := os.ReadFile(filepath.Join(dest, "SKILL.md"))
+	if err != nil || string(b) != body {
+		t.Errorf("read SKILL.md: %v %q", err, b)
+	}
+}
+
+func TestExtract_UnknownSkill(t *testing.T) {
+	tarPath := makeTarball(t, "x-repo-sha", map[string]string{
+		"skills/foo/SKILL.md": "# foo",
+	})
+	err := Extract(tarPath, "skills/ghost", filepath.Join(t.TempDir(), "out"))
+	if err == nil {
+		t.Fatal("expected error for missing skill")
+	}
+}
+
+func TestExtract_RejectsSymlink(t *testing.T) {
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	_ = tw.WriteHeader(&tar.Header{Name: "pfx/", Typeflag: tar.TypeDir, Mode: 0o755})
+	_ = tw.WriteHeader(&tar.Header{
+		Name:     "pfx/skills/foo/link",
+		Typeflag: tar.TypeSymlink,
+		Linkname: "../../../etc/passwd",
+	})
+	_ = tw.Close()
+	_ = gz.Close()
+
+	tarPath := filepath.Join(t.TempDir(), "evil.tar.gz")
+	if err := os.WriteFile(tarPath, buf.Bytes(), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := Extract(tarPath, "skills/foo", filepath.Join(t.TempDir(), "out")); err == nil {
+		t.Fatal("expected symlink rejection")
+	}
+}
+
+func TestSplitRepo(t *testing.T) {
+	cases := map[string][2]string{
+		"github.com/jjfantini/humblSKILLS":         {"jjfantini", "humblSKILLS"},
+		"jjfantini/humblSKILLS":                    {"jjfantini", "humblSKILLS"},
+		"https://github.com/jjfantini/humblSKILLS": {"jjfantini", "humblSKILLS"},
+		"github.com/jjfantini/humblSKILLS.git":     {"jjfantini", "humblSKILLS"},
+	}
+	for in, want := range cases {
+		o, n, err := splitRepo(in)
+		if err != nil {
+			t.Errorf("%s: %v", in, err)
+			continue
+		}
+		if o != want[0] || n != want[1] {
+			t.Errorf("%s: got %s/%s", in, o, n)
+		}
+	}
+	if _, _, err := splitRepo("invalid"); err == nil {
+		t.Error("expected error for bad repo")
+	}
+}

--- a/cli/internal/install/engine.go
+++ b/cli/internal/install/engine.go
@@ -1,0 +1,348 @@
+package install
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/jjfantini/humblSKILLS/cli/internal/fetch"
+	"github.com/jjfantini/humblSKILLS/cli/internal/manifest"
+	"github.com/jjfantini/humblSKILLS/cli/internal/platform"
+	"github.com/jjfantini/humblSKILLS/cli/internal/registry"
+)
+
+// Outcome classifies what happened for one (skill, platform, scope) triple.
+type Outcome string
+
+const (
+	// OutcomeInstalled means the target did not previously exist.
+	OutcomeInstalled Outcome = "installed"
+	// OutcomeReplaced means the target existed but content or source_sha drifted.
+	OutcomeReplaced Outcome = "replaced"
+	// OutcomeSkipped means the target is already up-to-date.
+	OutcomeSkipped Outcome = "skipped"
+	// OutcomeForced means --force replaced an up-to-date target anyway.
+	OutcomeForced Outcome = "forced"
+)
+
+// TargetResult is the outcome of installing one skill onto one adapter+scope.
+type TargetResult struct {
+	Skill    string  `json:"skill"`
+	Platform string  `json:"platform"`
+	Scope    string  `json:"scope"`
+	Path     string  `json:"path"`
+	Outcome  Outcome `json:"outcome"`
+}
+
+// Result aggregates every target outcome produced by one install run.
+type Result struct {
+	Results []TargetResult `json:"results"`
+}
+
+// Engine installs skills by fetching tarballs, verifying dir_sha, and copying
+// into each requested target.
+type Engine struct {
+	Fetcher      *fetch.Fetcher
+	ManifestPath string
+	StagingDir   string
+	Now          func() time.Time
+}
+
+// NewEngine returns an Engine configured with sane defaults. cacheDir is used
+// both for tarball caching and for staging extracted skill trees.
+func NewEngine(cacheDir, manifestPath string) *Engine {
+	return &Engine{
+		Fetcher:      fetch.NewFetcher(cacheDir),
+		ManifestPath: manifestPath,
+		StagingDir:   filepath.Join(cacheDir, "staging"),
+		Now:          time.Now,
+	}
+}
+
+// ExecuteOpts configures one Execute call.
+type ExecuteOpts struct {
+	// Adapters is the full set of runtime adapters; only those in Platforms
+	// will receive installs.
+	Adapters []platform.Adapter
+	// Platforms are the adapter names to install onto (order preserved).
+	Platforms []string
+	// Scope selects the install target scope for every adapter. Empty means
+	// the adapter's DefaultScope.
+	Scope string
+	// Force causes existing targets to be replaced even when the manifest
+	// shows they're up-to-date.
+	Force bool
+}
+
+// Execute runs the plan: fetch each skill, verify its content hash, and place
+// it into every requested target, updating the manifest in place.
+func (e *Engine) Execute(reg *registry.Registry, plan []Step, opts ExecuteOpts) (Result, error) {
+	var res Result
+	if reg == nil {
+		return res, fmt.Errorf("execute: nil registry")
+	}
+	if len(plan) == 0 {
+		return res, nil
+	}
+
+	adapterIndex := make(map[string]platform.Adapter, len(opts.Adapters))
+	for _, a := range opts.Adapters {
+		adapterIndex[a.Name] = a
+	}
+	for _, name := range opts.Platforms {
+		if _, ok := adapterIndex[name]; !ok {
+			return res, fmt.Errorf("unknown adapter %q", name)
+		}
+	}
+
+	m, err := manifest.Load(e.ManifestPath)
+	if err != nil {
+		return res, fmt.Errorf("load manifest: %w", err)
+	}
+
+	for _, step := range plan {
+		stepRes, err := e.installOne(reg, step, opts, adapterIndex, m)
+		if err != nil {
+			return res, fmt.Errorf("%s: %w", step.Skill.Name, err)
+		}
+		res.Results = append(res.Results, stepRes...)
+	}
+
+	if err := manifest.Save(e.ManifestPath, m); err != nil {
+		return res, fmt.Errorf("save manifest: %w", err)
+	}
+	return res, nil
+}
+
+func (e *Engine) installOne(
+	reg *registry.Registry,
+	step Step,
+	opts ExecuteOpts,
+	adapterIndex map[string]platform.Adapter,
+	m *manifest.Manifest,
+) ([]TargetResult, error) {
+	skill := step.Skill
+
+	// Decide which targets this skill needs. A skill's platforms[] list acts
+	// as an opt-in whitelist; only adapters in both requested-platforms and
+	// skill.Platforms get an install.
+	allow := map[string]struct{}{}
+	if len(skill.Platforms) == 0 {
+		for _, p := range opts.Platforms {
+			allow[p] = struct{}{}
+		}
+	} else {
+		for _, p := range skill.Platforms {
+			allow[p] = struct{}{}
+		}
+	}
+
+	type pending struct {
+		adapter platform.Adapter
+		target  platform.Target
+	}
+	var pendings []pending
+	for _, p := range opts.Platforms {
+		if _, ok := allow[p]; !ok {
+			continue
+		}
+		adapter := adapterIndex[p]
+		scope := opts.Scope
+		if scope == "" {
+			scope = adapter.DefaultScope
+		}
+		t, err := adapter.Target(scope)
+		if err != nil {
+			return nil, err
+		}
+		pendings = append(pendings, pending{adapter: adapter, target: t})
+	}
+	if len(pendings) == 0 {
+		return nil, nil
+	}
+
+	// Pre-compute which targets actually need the extract + copy. If none do,
+	// we skip the tarball fetch entirely so repeated no-op installs are fast.
+	type planTarget struct {
+		pending pending
+		out     Outcome
+		final   string
+	}
+	var toWrite []planTarget
+	var skipped []TargetResult
+	for _, pg := range pendings {
+		dest := filepath.Join(pg.target.Path, skill.Name)
+		existing := m.FindOne(skill.Name, pg.adapter.Name, pg.target.Scope)
+		upToDate := existing != nil &&
+			existing.Version == skill.Version &&
+			existing.SourceSHA == reg.Source.SHA &&
+			existing.RegistryRef == skill.DirSHA
+		if _, err := os.Stat(dest); err != nil {
+			upToDate = false
+		}
+
+		switch {
+		case upToDate && !opts.Force:
+			skipped = append(skipped, TargetResult{
+				Skill: skill.Name, Platform: pg.adapter.Name, Scope: pg.target.Scope,
+				Path: dest, Outcome: OutcomeSkipped,
+			})
+		case upToDate && opts.Force:
+			toWrite = append(toWrite, planTarget{pending: pg, out: OutcomeForced, final: dest})
+		case existing != nil:
+			toWrite = append(toWrite, planTarget{pending: pg, out: OutcomeReplaced, final: dest})
+		default:
+			toWrite = append(toWrite, planTarget{pending: pg, out: OutcomeInstalled, final: dest})
+		}
+	}
+
+	if len(toWrite) == 0 {
+		return skipped, nil
+	}
+
+	staging := filepath.Join(e.StagingDir, skill.Name+"-"+shortSHA(reg.Source.SHA))
+	if err := os.RemoveAll(staging); err != nil {
+		return nil, fmt.Errorf("clean staging: %w", err)
+	}
+
+	tarPath, err := e.Fetcher.Fetch(reg.Source.Repo, reg.Source.SHA)
+	if err != nil {
+		return nil, err
+	}
+	if err := fetch.Extract(tarPath, skill.Path, staging); err != nil {
+		return nil, fmt.Errorf("extract: %w", err)
+	}
+
+	gotSHA, err := registry.DirSHA(staging)
+	if err != nil {
+		return nil, fmt.Errorf("hash staging: %w", err)
+	}
+	if gotSHA != skill.DirSHA {
+		return nil, fmt.Errorf("dir_sha mismatch for %s: want %s got %s", skill.Name, skill.DirSHA, gotSHA)
+	}
+
+	results := append([]TargetResult(nil), skipped...)
+	for _, pt := range toWrite {
+		if err := replaceDir(staging, pt.final); err != nil {
+			return nil, fmt.Errorf("place %s: %w", pt.final, err)
+		}
+		m.Upsert(manifest.Installation{
+			Skill:       skill.Name,
+			Version:     skill.Version,
+			Platform:    pt.pending.adapter.Name,
+			Scope:       pt.pending.target.Scope,
+			Path:        pt.final,
+			InstalledAt: e.Now().UTC(),
+			SourceSHA:   reg.Source.SHA,
+			RegistryRef: skill.DirSHA,
+		})
+		results = append(results, TargetResult{
+			Skill:    skill.Name,
+			Platform: pt.pending.adapter.Name,
+			Scope:    pt.pending.target.Scope,
+			Path:     pt.final,
+			Outcome:  pt.out,
+		})
+	}
+	return results, nil
+}
+
+// Uninstall removes every on-disk target for skill and deletes its manifest
+// entries. Missing directories are tolerated — the manifest is still cleaned
+// up so subsequent installs are idempotent.
+func (e *Engine) Uninstall(skill string) ([]TargetResult, error) {
+	m, err := manifest.Load(e.ManifestPath)
+	if err != nil {
+		return nil, fmt.Errorf("load manifest: %w", err)
+	}
+	entries := m.FindAll(skill)
+	if len(entries) == 0 {
+		return nil, nil
+	}
+	var results []TargetResult
+	for _, e := range entries {
+		if err := os.RemoveAll(e.Path); err != nil {
+			return results, fmt.Errorf("remove %s: %w", e.Path, err)
+		}
+		results = append(results, TargetResult{
+			Skill: e.Skill, Platform: e.Platform, Scope: e.Scope,
+			Path: e.Path, Outcome: "removed",
+		})
+	}
+	m.Remove(skill)
+	if err := manifest.Save(e.ManifestPath, m); err != nil {
+		return results, fmt.Errorf("save manifest: %w", err)
+	}
+	return results, nil
+}
+
+// replaceDir copies src to dst, replacing dst if it already exists. The copy
+// is recursive; we do not attempt true atomicity across the rename.
+func replaceDir(src, dst string) error {
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return err
+	}
+	if err := os.RemoveAll(dst); err != nil {
+		return err
+	}
+	return copyTree(src, dst)
+}
+
+func copyTree(src, dst string) error {
+	info, err := os.Stat(src)
+	if err != nil {
+		return err
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("copy: %s is not a directory", src)
+	}
+	return filepath.Walk(src, func(p string, fi os.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		rel, err := filepath.Rel(src, p)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(dst, rel)
+		if fi.IsDir() {
+			return os.MkdirAll(target, fi.Mode()&0o777|0o700)
+		}
+		if fi.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("symlink in staging tree: %s", p)
+		}
+		return copyFile(p, target, fi.Mode()&0o777)
+	})
+}
+
+func copyFile(src, dst string, mode os.FileMode) error {
+	if mode == 0 {
+		mode = 0o644
+	}
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return err
+	}
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		_ = out.Close()
+		return err
+	}
+	return out.Close()
+}
+
+func shortSHA(sha string) string {
+	if len(sha) > 12 {
+		return sha[:12]
+	}
+	return sha
+}

--- a/cli/internal/install/engine_test.go
+++ b/cli/internal/install/engine_test.go
@@ -1,0 +1,220 @@
+package install
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/jjfantini/humblSKILLS/cli/internal/manifest"
+	"github.com/jjfantini/humblSKILLS/cli/internal/platform"
+	"github.com/jjfantini/humblSKILLS/cli/internal/registry"
+)
+
+// seedTarball writes a fake GitHub-style tarball into cacheDir in the exact
+// location the Fetcher expects, so Execute's Fetch call becomes a cache hit.
+func seedTarball(t *testing.T, cacheDir, owner, name, sha, repoPrefix string, files map[string]string) {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+
+	if err := tw.WriteHeader(&tar.Header{Name: repoPrefix + "/", Typeflag: tar.TypeDir, Mode: 0o755}); err != nil {
+		t.Fatal(err)
+	}
+	for p, body := range files {
+		if err := tw.WriteHeader(&tar.Header{
+			Name: repoPrefix + "/" + p, Typeflag: tar.TypeReg,
+			Mode: 0o644, Size: int64(len(body)),
+		}); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := tw.Write([]byte(body)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	dir := filepath.Join(cacheDir, "tars")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	fname := owner + "-" + name + "-" + sha + ".tar.gz"
+	if err := os.WriteFile(filepath.Join(dir, fname), buf.Bytes(), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// expectedDirSHA extracts a copy of the skill tree to a temp dir and computes
+// its dir_sha so the test's registry entry matches exactly what the engine
+// will compute on its own.
+func expectedDirSHA(t *testing.T, files map[string]string) string {
+	t.Helper()
+	dir := t.TempDir()
+	for p, body := range files {
+		full := filepath.Join(dir, p)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	sha, err := registry.DirSHA(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return sha
+}
+
+func TestEngine_InstallReplaceSkipForce(t *testing.T) {
+	root := t.TempDir()
+	cacheDir := filepath.Join(root, "cache")
+	installRoot := filepath.Join(root, "home", ".claude", "skills")
+	manifestPath := filepath.Join(root, "manifest.json")
+
+	// Skill files (relative to repo root inside the tarball).
+	skillFiles := map[string]string{
+		"skills/foo/SKILL.md":      "# foo\n",
+		"skills/foo/data/notes.md": "hello\n",
+	}
+	onlyFoo := map[string]string{
+		"SKILL.md":      "# foo\n",
+		"data/notes.md": "hello\n",
+	}
+	dirSHA := expectedDirSHA(t, onlyFoo)
+
+	owner, name, sha := "example", "repo", "deadbeef000000"
+	seedTarball(t, cacheDir, owner, name, sha, owner+"-"+name+"-abc1234", skillFiles)
+
+	reg := &registry.Registry{
+		SchemaVersion: registry.SchemaVersion,
+		Source:        registry.Source{Repo: "github.com/example/repo", SHA: sha},
+		Skills: []registry.Skill{{
+			Name: "foo", Version: "0.1.0", Path: "skills/foo",
+			Platforms: []string{"test"}, DirSHA: dirSHA,
+		}},
+	}
+
+	adapter := platform.Adapter{
+		Name:           "test",
+		InstallTargets: map[string]string{"user": installRoot},
+		DefaultScope:   "user",
+	}
+
+	engine := NewEngine(cacheDir, manifestPath)
+	engine.Now = func() time.Time { return time.Unix(1700000000, 0).UTC() }
+
+	plan, err := Plan(reg, "foo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := engine.Execute(reg, plan, ExecuteOpts{
+		Adapters:  []platform.Adapter{adapter},
+		Platforms: []string{"test"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Results) != 1 || res.Results[0].Outcome != OutcomeInstalled {
+		t.Fatalf("first run: %+v", res.Results)
+	}
+	if _, err := os.Stat(filepath.Join(installRoot, "foo", "SKILL.md")); err != nil {
+		t.Fatalf("skill not placed: %v", err)
+	}
+
+	// Second run without --force: skipped.
+	res2, err := engine.Execute(reg, plan, ExecuteOpts{
+		Adapters:  []platform.Adapter{adapter},
+		Platforms: []string{"test"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res2.Results[0].Outcome != OutcomeSkipped {
+		t.Errorf("expected skipped, got %s", res2.Results[0].Outcome)
+	}
+
+	// Third run with --force: forced.
+	res3, err := engine.Execute(reg, plan, ExecuteOpts{
+		Adapters:  []platform.Adapter{adapter},
+		Platforms: []string{"test"},
+		Force:     true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res3.Results[0].Outcome != OutcomeForced {
+		t.Errorf("expected forced, got %s", res3.Results[0].Outcome)
+	}
+
+	m, err := manifest.Load(manifestPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	inst := m.FindOne("foo", "test", "user")
+	if inst == nil || inst.Version != "0.1.0" || inst.SourceSHA != sha {
+		t.Errorf("manifest wrong: %+v", inst)
+	}
+
+	// Uninstall wipes the dir and the manifest entry.
+	out, err := engine.Uninstall("foo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(out) != 1 {
+		t.Fatalf("uninstall results: %+v", out)
+	}
+	if _, err := os.Stat(filepath.Join(installRoot, "foo")); err == nil {
+		t.Error("skill dir should be gone")
+	}
+	m, _ = manifest.Load(manifestPath)
+	if m.Find("foo") != nil {
+		t.Error("manifest should be empty")
+	}
+}
+
+func TestEngine_DirSHAMismatchFails(t *testing.T) {
+	root := t.TempDir()
+	cacheDir := filepath.Join(root, "cache")
+	installRoot := filepath.Join(root, "home")
+	manifestPath := filepath.Join(root, "manifest.json")
+
+	owner, name, sha := "example", "repo", "cafebabe000000"
+	seedTarball(t, cacheDir, owner, name, sha, "example-repo-abc1234", map[string]string{
+		"skills/foo/SKILL.md": "content\n",
+	})
+
+	reg := &registry.Registry{
+		SchemaVersion: registry.SchemaVersion,
+		Source:        registry.Source{Repo: "github.com/example/repo", SHA: sha},
+		Skills: []registry.Skill{{
+			Name: "foo", Version: "0.1.0", Path: "skills/foo",
+			Platforms: []string{"test"},
+			DirSHA:    "0000000000000000000000000000000000000000000000000000000000000000",
+		}},
+	}
+	adapter := platform.Adapter{
+		Name:           "test",
+		InstallTargets: map[string]string{"user": installRoot},
+		DefaultScope:   "user",
+	}
+
+	engine := NewEngine(cacheDir, manifestPath)
+	plan, _ := Plan(reg, "foo")
+	_, err := engine.Execute(reg, plan, ExecuteOpts{
+		Adapters:  []platform.Adapter{adapter},
+		Platforms: []string{"test"},
+	})
+	if err == nil {
+		t.Fatal("expected dir_sha mismatch error")
+	}
+}

--- a/cli/internal/install/planner.go
+++ b/cli/internal/install/planner.go
@@ -1,0 +1,90 @@
+// Package install orchestrates resolving, fetching, and placing skills onto
+// agent platforms.
+package install
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/jjfantini/humblSKILLS/cli/internal/frontmatter"
+	"github.com/jjfantini/humblSKILLS/cli/internal/registry"
+	"github.com/jjfantini/humblSKILLS/cli/internal/resolver"
+)
+
+// Step is one entry in an install plan: a skill that needs fetching and
+// placing, along with whether it was requested directly or pulled in as a
+// transitive dependency.
+type Step struct {
+	Skill registry.Skill
+	IsDep bool
+}
+
+// Plan returns the topo-sorted list of skills required to install `root`,
+// with dependencies first and the root itself last. Missing or unsatisfiable
+// deps surface as errors.
+func Plan(reg *registry.Registry, root string) ([]Step, error) {
+	if reg == nil {
+		return nil, fmt.Errorf("plan: nil registry")
+	}
+
+	index := make(map[string]registry.Skill, len(reg.Skills))
+	for _, s := range reg.Skills {
+		index[s.Name] = s
+	}
+	if _, ok := index[root]; !ok {
+		return nil, fmt.Errorf("skill %q not in registry", root)
+	}
+
+	g := resolver.New()
+	visited := make(map[string]bool)
+	if err := walk(root, index, g, visited); err != nil {
+		return nil, err
+	}
+
+	order, err := g.TopoSort()
+	if err != nil {
+		return nil, fmt.Errorf("plan: %w", err)
+	}
+
+	out := make([]Step, 0, len(order))
+	for _, name := range order {
+		s := index[name]
+		out = append(out, Step{Skill: s, IsDep: name != root})
+	}
+	return out, nil
+}
+
+func walk(name string, index map[string]registry.Skill, g *resolver.Graph, visited map[string]bool) error {
+	if visited[name] {
+		return nil
+	}
+	visited[name] = true
+
+	s, ok := index[name]
+	if !ok {
+		return fmt.Errorf("dep %q not in registry", name)
+	}
+	g.AddNode(name)
+
+	// Sort requires for deterministic graph shape.
+	reqs := append([]string(nil), s.Requires...)
+	sort.Strings(reqs)
+	for _, raw := range reqs {
+		dep, err := frontmatter.ParseDep(raw)
+		if err != nil {
+			return fmt.Errorf("%s: parse dep %q: %w", name, raw, err)
+		}
+		depSkill, ok := index[dep.Name]
+		if !ok {
+			return fmt.Errorf("%s: dep %q not in registry", name, raw)
+		}
+		if !dep.Satisfies(depSkill.Version) {
+			return fmt.Errorf("%s: dep %q unsatisfied (registry has %s)", name, raw, depSkill.Version)
+		}
+		g.AddEdge(name, dep.Name)
+		if err := walk(dep.Name, index, g, visited); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/cli/internal/install/planner_test.go
+++ b/cli/internal/install/planner_test.go
@@ -1,0 +1,80 @@
+package install
+
+import (
+	"testing"
+
+	"github.com/jjfantini/humblSKILLS/cli/internal/registry"
+)
+
+func reg(skills ...registry.Skill) *registry.Registry {
+	return &registry.Registry{
+		SchemaVersion: registry.SchemaVersion,
+		Source:        registry.Source{Repo: "github.com/example/repo", SHA: "deadbeef"},
+		Skills:        skills,
+	}
+}
+
+func TestPlan_Simple(t *testing.T) {
+	r := reg(
+		registry.Skill{Name: "a", Version: "0.1.0"},
+	)
+	steps, err := Plan(r, "a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(steps) != 1 || steps[0].Skill.Name != "a" || steps[0].IsDep {
+		t.Errorf("unexpected plan: %+v", steps)
+	}
+}
+
+func TestPlan_TransitiveDeps(t *testing.T) {
+	r := reg(
+		registry.Skill{Name: "a", Version: "0.1.0", Requires: []string{"b"}},
+		registry.Skill{Name: "b", Version: "0.1.0", Requires: []string{"c@>=0.1.0"}},
+		registry.Skill{Name: "c", Version: "0.2.0"},
+		registry.Skill{Name: "unrelated", Version: "1.0.0"},
+	)
+	steps, err := Plan(r, "a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := []string{}
+	for _, s := range steps {
+		got = append(got, s.Skill.Name)
+	}
+	want := []string{"c", "b", "a"}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("order[%d]=%s want %s (full=%v)", i, got[i], want[i], got)
+		}
+	}
+	for _, s := range steps {
+		if (s.Skill.Name == "a") == s.IsDep {
+			t.Errorf("IsDep wrong for %s", s.Skill.Name)
+		}
+	}
+}
+
+func TestPlan_MissingDep(t *testing.T) {
+	r := reg(registry.Skill{Name: "a", Requires: []string{"ghost"}})
+	if _, err := Plan(r, "a"); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestPlan_UnsatisfiedPin(t *testing.T) {
+	r := reg(
+		registry.Skill{Name: "a", Requires: []string{"b@>=1.0.0"}},
+		registry.Skill{Name: "b", Version: "0.1.0"},
+	)
+	if _, err := Plan(r, "a"); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestPlan_UnknownRoot(t *testing.T) {
+	r := reg(registry.Skill{Name: "a"})
+	if _, err := Plan(r, "ghost"); err == nil {
+		t.Fatal("expected error")
+	}
+}

--- a/cli/internal/manifest/manifest.go
+++ b/cli/internal/manifest/manifest.go
@@ -102,8 +102,9 @@ func Save(path string, m *Manifest) error {
 	return nil
 }
 
-// Find returns a pointer to the Installation matching the given skill name,
-// or nil if not installed.
+// Find returns a pointer to the first Installation matching the given skill
+// name, or nil if not installed. Use FindAll when a skill may be installed on
+// multiple (platform, scope) pairs.
 func (m *Manifest) Find(skill string) *Installation {
 	for i := range m.Installations {
 		if m.Installations[i].Skill == skill {
@@ -111,4 +112,69 @@ func (m *Manifest) Find(skill string) *Installation {
 		}
 	}
 	return nil
+}
+
+// FindAll returns pointers to every Installation of the given skill, across
+// platforms and scopes.
+func (m *Manifest) FindAll(skill string) []*Installation {
+	var out []*Installation
+	for i := range m.Installations {
+		if m.Installations[i].Skill == skill {
+			out = append(out, &m.Installations[i])
+		}
+	}
+	return out
+}
+
+// FindOne returns the Installation pinned to exactly (skill, platform, scope),
+// or nil if none matches.
+func (m *Manifest) FindOne(skill, platform, scope string) *Installation {
+	for i := range m.Installations {
+		e := &m.Installations[i]
+		if e.Skill == skill && e.Platform == platform && e.Scope == scope {
+			return e
+		}
+	}
+	return nil
+}
+
+// Upsert inserts or replaces the Installation keyed on (skill, platform,
+// scope).
+func (m *Manifest) Upsert(inst Installation) {
+	for i := range m.Installations {
+		e := &m.Installations[i]
+		if e.Skill == inst.Skill && e.Platform == inst.Platform && e.Scope == inst.Scope {
+			m.Installations[i] = inst
+			return
+		}
+	}
+	m.Installations = append(m.Installations, inst)
+}
+
+// Remove drops every Installation matching skill (all platforms and scopes)
+// and returns how many were removed.
+func (m *Manifest) Remove(skill string) int {
+	kept := m.Installations[:0]
+	removed := 0
+	for _, e := range m.Installations {
+		if e.Skill == skill {
+			removed++
+			continue
+		}
+		kept = append(kept, e)
+	}
+	m.Installations = kept
+	return removed
+}
+
+// RemoveOne drops exactly the Installation pinned to (skill, platform, scope).
+// Returns true if an entry was removed.
+func (m *Manifest) RemoveOne(skill, platform, scope string) bool {
+	for i, e := range m.Installations {
+		if e.Skill == skill && e.Platform == platform && e.Scope == scope {
+			m.Installations = append(m.Installations[:i], m.Installations[i+1:]...)
+			return true
+		}
+	}
+	return false
 }

--- a/cli/internal/manifest/manifest_test.go
+++ b/cli/internal/manifest/manifest_test.go
@@ -82,6 +82,38 @@ func TestFind(t *testing.T) {
 	}
 }
 
+func TestFindAllFindOneUpsertRemove(t *testing.T) {
+	m := &Manifest{}
+	m.Upsert(Installation{Skill: "a", Platform: "claude-code", Scope: "user", Version: "0.1.0"})
+	m.Upsert(Installation{Skill: "a", Platform: "cursor", Scope: "user", Version: "0.1.0"})
+	m.Upsert(Installation{Skill: "b", Platform: "claude-code", Scope: "project"})
+
+	if all := m.FindAll("a"); len(all) != 2 {
+		t.Fatalf("FindAll(a) = %d", len(all))
+	}
+	if e := m.FindOne("a", "claude-code", "user"); e == nil || e.Version != "0.1.0" {
+		t.Fatalf("FindOne missed: %+v", e)
+	}
+	// Upsert replaces instead of appending.
+	m.Upsert(Installation{Skill: "a", Platform: "claude-code", Scope: "user", Version: "0.2.0"})
+	if len(m.Installations) != 3 {
+		t.Errorf("upsert duplicated: %d", len(m.Installations))
+	}
+	if e := m.FindOne("a", "claude-code", "user"); e == nil || e.Version != "0.2.0" {
+		t.Errorf("upsert didn't replace: %+v", e)
+	}
+
+	if !m.RemoveOne("a", "cursor", "user") {
+		t.Error("RemoveOne returned false")
+	}
+	if got := m.Remove("a"); got != 1 {
+		t.Errorf("Remove(a) = %d", got)
+	}
+	if len(m.Installations) != 1 || m.Installations[0].Skill != "b" {
+		t.Errorf("unexpected state: %+v", m.Installations)
+	}
+}
+
 func TestDefaultPath_NonEmpty(t *testing.T) {
 	p, err := DefaultPath()
 	if err != nil {


### PR DESCRIPTION
## Summary
- Makes \`humblskills\` actually install skills. Fetches pinned tarballs from GitHub, verifies \`dir_sha\`, places content into every detected platform, and records the outcome in the manifest.
- Idempotent: re-running \`install foo\` is a no-op when already up-to-date; drift triggers replacement; \`--force\` reinstalls unconditionally.
- Dep-aware: \`Plan()\` walks the registry's dep DAG and installs deps first. No ref-counting in v0.1 — \`uninstall\` only removes the named skill.

### New packages
- \`internal/fetch\`: GitHub tarball downloader (cached by SHA on disk, immutable entries) + extractor that strips the archive's top-level dir, skips PAX global headers, and refuses symlinks or \`..\` traversal.
- \`internal/install\`: \`Plan()\` returns a deps-first \`[]Step\`. \`Engine.Execute()\` fetches → extracts to staging → verifies \`dir_sha\` against the registry → copies into each \`(platform, scope)\` target → upserts manifest.

### Manifest changes
- New tuple-aware helpers: \`FindAll\`, \`FindOne\`, \`Upsert\`, \`Remove\`, \`RemoveOne\`. Keeps existing \`Find\` for single-platform lookups.

### Commands
- \`humblskills install <skill> [--platform X...] [--scope Y] [--force]\` — installs into every detected platform by default.
- \`humblskills uninstall <skill>\` — removes every target recorded for the skill.
- \`humblskills list\` — prints manifest entries grouped by skill/platform/scope. Supports \`--json\`.
- \`humblskills search [query]\` — matches against name, description, tags. Supports \`--json\`.

### Gotcha fixed mid-review
- GitHub's \`codeload\` tarballs start with a \`pax_global_header\` entry. My first extractor draft picked that up as the top-level directory and produced \"no files found\". Now skipped explicitly, with a regression test.

## Test plan
- [x] \`make vet && make test\` — new planner, engine, extract, manifest tests all pass.
- [x] End-to-end smoke against the hosted registry: \`install skill-example-with-dep\` resolves the dep, dir_sha verifies, second run is \`skipped\`, \`--force\` \`forced\`, \`uninstall\` cleans up on-disk targets and manifest entries.
- [x] \`make registry-check\` and \`make adapters-check\` clean.
- [ ] CI matrix (ubuntu/macos/windows × Go 1.23) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)