### PR TITLE
Phase 5: distribution (goreleaser, release workflow, install.sh)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,54 @@
+name: Release
+
+# We tag releases as plain semver (e.g. `v0.1.0`). The workflow also pushes a
+# sibling tag `cli/v0.1.0` on the same commit so Go's nested-module
+# resolution works for `go install github.com/jjfantini/humblSKILLS/cli/...`.
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  tag-cli-module:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Push sibling cli/* tag for go install
+        run: |
+          set -eu
+          ver="${GITHUB_REF_NAME}"                # e.g. v0.1.0
+          sibling="cli/${ver}"                    # e.g. cli/v0.1.0
+          if git rev-parse -q --verify "refs/tags/${sibling}" >/dev/null; then
+            echo "sibling tag ${sibling} already exists — skipping"
+            exit 0
+          fi
+          git tag "${sibling}" "${GITHUB_SHA}"
+          git push origin "${sibling}"
+
+  goreleaser:
+    needs: tag-cli-module
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.23"
+          cache-dependency-path: cli/go.sum
+
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,66 @@
+version: 2
+
+project_name: humblskills
+
+before:
+  hooks:
+    - go -C cli mod tidy
+
+builds:
+  - id: humblskills
+    # The CLI lives in a nested Go module (cli/go.mod); run the build from
+    # inside it so module resolution works.
+    dir: cli
+    main: ./cmd/humblskills
+    binary: humblskills
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w
+      - -X main.version={{ .Version }}
+      - -X main.commit={{ .ShortCommit }}
+
+archives:
+  - id: default
+    name_template: >-
+      {{ .ProjectName }}_{{ .Version }}_
+      {{- if eq .Os "darwin" }}macos
+      {{- else }}{{ .Os }}{{ end }}_
+      {{- .Arch }}
+    format_overrides:
+      - goos: windows
+        formats: [zip]
+
+checksum:
+  name_template: checksums.txt
+
+release:
+  github:
+    owner: jjfantini
+    name: humblSKILLS
+  draft: false
+  prerelease: auto
+  header: |
+    ## humblskills {{ .Version }}
+
+    Install:
+    - Shell: `curl -fsSL https://raw.githubusercontent.com/jjfantini/humblSKILLS/main/scripts/install.sh | sh`
+    - Go: `go install github.com/jjfantini/humblSKILLS/cli/cmd/humblskills@v{{ .Version }}`
+    - Or download an archive for your platform below.
+
+changelog:
+  sort: asc
+  use: github
+  filters:
+    exclude:
+      - "^docs:"
+      - "^chore:"
+      - "^test:"
+      - "Merge pull request"

--- a/README.md
+++ b/README.md
@@ -1,38 +1,89 @@
 # humblSKILLS
 
-A personal skill registry and a single-binary Go CLI (`humblskills`) that installs
-[agentskills.io](https://agentskills.io)-format skills into whichever agent platform
-you use — Claude Code, Cursor, Codex, and friends.
+A personal skill registry and a single-binary Go CLI (`humblskills`) that
+installs [agentskills.io](https://agentskills.io)-format skills into whichever
+agent platform you use — Claude Code, Cursor, Codex, and friends.
 
-## Mission
+## What's in this repo
 
-Two things in one repo:
-
-1. **Skill registry** — a monorepo of agent skills authored in the agentskills.io
-   format with light humblSKILLS frontmatter extensions (`requires`, `platforms`,
-   `post_install`, `tags`).
+1. **Skill registry** — a monorepo of agent skills authored in the
+   agentskills.io format with light humblSKILLS frontmatter extensions
+   (`requires`, `platforms`, `post_install`, `tags`).
 2. **`humblskills` CLI** — fetches a skill directory and drops it in the right
    place for your agent platform. Zero servers, zero accounts, zero telemetry.
 
-## Quickstart (coming with v0.1)
+## Install
 
+### Shell installer (Linux/macOS)
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/jjfantini/humblSKILLS/main/scripts/install.sh | sh
 ```
-brew install jjfantini/humbl/humblskills
-humblskills add                    # interactive picker
+
+Installs to `/usr/local/bin` by default (uses `sudo` if needed). Override
+with `INSTALL_DIR`:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/jjfantini/humblSKILLS/main/scripts/install.sh | INSTALL_DIR=$HOME/.local/bin sh
+```
+
+Pin a specific version with `VERSION=0.1.0 sh`.
+
+### Go
+
+```sh
+go install github.com/jjfantini/humblSKILLS/cli/cmd/humblskills@latest
+```
+
+### Direct download
+
+Grab the archive for your platform from the
+[releases page](https://github.com/jjfantini/humblSKILLS/releases/latest):
+
+- `humblskills_<version>_linux_amd64.tar.gz`
+- `humblskills_<version>_linux_arm64.tar.gz`
+- `humblskills_<version>_macos_amd64.tar.gz`
+- `humblskills_<version>_macos_arm64.tar.gz`
+- `humblskills_<version>_windows_amd64.zip`
+- `humblskills_<version>_windows_arm64.zip`
+
+Each release also publishes `checksums.txt` with SHA-256 sums.
+
+### Homebrew
+
+Coming soon.
+
+## Quickstart
+
+```sh
+humblskills doctor                    # verify the environment
+humblskills search                    # browse the registry
+humblskills install skill-example-hello
 humblskills list
+humblskills update                    # pick which drifted skills to upgrade
+humblskills update --all --yes        # non-interactive bulk upgrade
+humblskills uninstall skill-example-hello
 ```
 
-Install methods planned for v0.1:
+Every command accepts `--json` for machine-readable output and `--yes` to
+skip confirmation prompts.
 
-1. Homebrew tap: `brew install jjfantini/humbl/humblskills`
-2. Shell installer: `curl -fsSL https://raw.githubusercontent.com/jjfantini/humblSKILLS/main/scripts/install.sh | sh`
-3. `go install github.com/jjfantini/humblSKILLS/cli@latest`
-4. Direct download from GitHub Releases
+## Developing the CLI
 
-## Status
+The CLI source lives under [`cli/`](cli) as a nested Go module.
 
-Pre-v0.1. Implementation is phased: registry pipeline → CLI foundation →
-install path → polish → distribution.
+```sh
+make build           # builds ./bin/humblskills
+make test            # runs go test ./...
+make registry        # regenerates registry.json from skills/ + adapters/
+make sync-adapters   # mirrors adapters/ into the CLI's embed directory
+```
+
+Releases are cut by pushing a semver tag (e.g. `git tag v0.1.0 && git push
+origin v0.1.0`); the workflow in [`.github/workflows/release.yml`](.github/workflows/release.yml)
+runs GoReleaser, uploads archives + checksums to GitHub Releases, and also
+pushes a sibling `cli/v0.1.0` tag so `go install` works against the nested
+module.
 
 ## License
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,94 @@
+#!/bin/sh
+# humblskills installer. Fetches the latest (or pinned) release archive from
+# GitHub, verifies its SHA-256 against the published checksums.txt, and drops
+# the binary onto $PATH. POSIX sh; no bash-isms.
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/jjfantini/humblSKILLS/main/scripts/install.sh | sh
+#   curl -fsSL .../install.sh | VERSION=0.1.0 sh
+#   curl -fsSL .../install.sh | INSTALL_DIR=$HOME/.local/bin sh
+
+set -eu
+
+REPO="jjfantini/humblSKILLS"
+BIN="humblskills"
+PREFIX="${PREFIX:-/usr/local}"
+INSTALL_DIR="${INSTALL_DIR:-$PREFIX/bin}"
+VERSION="${VERSION:-}"
+
+log()  { printf '%s\n' "$*" >&2; }
+die()  { log "error: $*"; exit 1; }
+have() { command -v "$1" >/dev/null 2>&1; }
+
+have curl || die "curl is required"
+have tar  || die "tar is required"
+
+os=$(uname -s | tr '[:upper:]' '[:lower:]')
+case "$os" in
+  linux)  os_tag=linux ;;
+  darwin) os_tag=macos ;;
+  *) die "unsupported OS: $os — download a windows/* archive manually from the releases page" ;;
+esac
+
+arch=$(uname -m)
+case "$arch" in
+  x86_64|amd64)  arch_tag=amd64 ;;
+  arm64|aarch64) arch_tag=arm64 ;;
+  *) die "unsupported arch: $arch" ;;
+esac
+
+# Resolve VERSION from /releases/latest (plain v* tags, not the sibling
+# cli/v* tag that only exists for go install).
+if [ -z "$VERSION" ]; then
+  VERSION=$(curl -fsSL "https://api.github.com/repos/$REPO/releases/latest" \
+    | grep '"tag_name"' \
+    | head -n1 \
+    | sed -E 's/.*"tag_name"[[:space:]]*:[[:space:]]*"v([^"]+)".*/\1/')
+fi
+[ -n "$VERSION" ] || die "could not discover a release — pass VERSION=X.Y.Z"
+
+tag="v${VERSION}"
+archive="${BIN}_${VERSION}_${os_tag}_${arch_tag}.tar.gz"
+base="https://github.com/${REPO}/releases/download/${tag}"
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+log "downloading ${archive}"
+curl -fsSL "${base}/${archive}"     -o "${tmp}/${archive}"     || die "download failed: ${base}/${archive}"
+curl -fsSL "${base}/checksums.txt"  -o "${tmp}/checksums.txt"  || die "checksums download failed"
+
+# Verify. Prefer shasum on macOS, sha256sum on linux.
+want=$(grep "  ${archive}\$" "${tmp}/checksums.txt" | awk '{print $1}')
+[ -n "$want" ] || die "no checksum for ${archive} in checksums.txt"
+
+if have sha256sum; then
+  got=$(sha256sum "${tmp}/${archive}" | awk '{print $1}')
+elif have shasum; then
+  got=$(shasum -a 256 "${tmp}/${archive}" | awk '{print $1}')
+else
+  die "need sha256sum or shasum to verify checksum"
+fi
+[ "$want" = "$got" ] || die "checksum mismatch: want $want got $got"
+log "checksum verified"
+
+tar -xzf "${tmp}/${archive}" -C "${tmp}"
+
+if [ ! -d "$INSTALL_DIR" ]; then
+  log "creating $INSTALL_DIR"
+  mkdir -p "$INSTALL_DIR" 2>/dev/null || sudo mkdir -p "$INSTALL_DIR"
+fi
+
+if [ -w "$INSTALL_DIR" ]; then
+  install -m 0755 "${tmp}/${BIN}" "${INSTALL_DIR}/${BIN}"
+else
+  log "escalating to write to ${INSTALL_DIR}"
+  sudo install -m 0755 "${tmp}/${BIN}" "${INSTALL_DIR}/${BIN}"
+fi
+
+log ""
+log "installed ${BIN} ${VERSION} → ${INSTALL_DIR}/${BIN}"
+if ! printf '%s' ":$PATH:" | grep -q ":${INSTALL_DIR}:"; then
+  log "note: ${INSTALL_DIR} is not on your PATH — add it to your shell init"
+fi
+log "run: ${BIN} doctor"


### PR DESCRIPTION
## Summary
- **GoReleaser** config at repo root builds the nested CLI module for linux/macos/windows × amd64/arm64, producing `.tar.gz` / `.zip` archives plus `checksums.txt`. Version and short commit are injected via `-ldflags`.
- **Release workflow** (`.github/workflows/release.yml`) triggers on plain `v*` tags. It first pushes a sibling `cli/v*` tag so `go install github.com/jjfantini/humblSKILLS/cli/cmd/humblskills@v...` resolves correctly against the nested module, then runs GoReleaser.
- **`scripts/install.sh`** — POSIX shell, curl-installable. Detects OS/arch, pulls the right archive from the latest release, verifies SHA-256 against `checksums.txt`, installs to `/usr/local/bin` by default. Honours `VERSION` and `INSTALL_DIR` overrides.
- **README** documents shell install, `go install`, and direct download. Homebrew is deferred to a follow-up once the first release is out.

## Test plan
- [x] `goreleaser check` passes
- [x] `goreleaser release --snapshot --clean --skip=publish` builds all 6 targets and produces working archives (verified the macOS arm64 binary runs and reports the ldflag-injected version)
- [x] `scripts/install.sh` syntax-checks with `sh -n`
- [ ] CI green on this PR
- [ ] After merge: tag `v0.1.0` → release workflow cuts the first release

🤖 Generated with [Claude Code](https://claude.com/claude-code)