### PR TITLE
fix(cursor): default scope to user to match claude-code adapter

### DIFF
--- a/adapters/cursor.yaml
+++ b/adapters/cursor.yaml
@@ -6,5 +6,5 @@ detect:
 install_targets:
   user: ~/.cursor/skills
   project: .cursor/skills
-default_scope: project
+default_scope: user
 transform: passthrough

--- a/cli/internal/platform/builtin/cursor.yaml
+++ b/cli/internal/platform/builtin/cursor.yaml
@@ -6,5 +6,5 @@ detect:
 install_targets:
   user: ~/.cursor/skills
   project: .cursor/skills
-default_scope: project
+default_scope: user
 transform: passthrough


### PR DESCRIPTION
## Summary
- Cursor adapter `default_scope` changed from `project` to `user`
- Both Claude Code and Cursor now default to user-scope installs (`~/.cursor/skills` and `~/.claude/skills` respectively)
- Project scope still available via `--scope project` on both platforms

## Test plan
- [ ] `humblskills install <skill>` on a Cursor environment installs to `~/.cursor/skills` by default
- [ ] `humblskills install <skill> --scope project` still installs to `.cursor/skills`
- [ ] `humblskills doctor` shows correct default scope for Cursor adapter

🤖 Generated with [Claude Code](https://claude.com/claude-code)