### PR TITLE
refactor: remove unused post_install frontmatter field

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ agent platform you use — Claude Code, Cursor, Codex, and friends.
 
 1. **Skill registry** — a monorepo of agent skills authored in the
    agentskills.io format with light humblSKILLS frontmatter extensions
-   (`requires`, `platforms`, `post_install`, `tags`).
+   (`requires`, `platforms`, `tags`).
 2. **`humblskills` CLI** — fetches a skill directory and drops it in the right
    place for your agent platform. Zero servers, zero accounts, zero telemetry.
 

--- a/cli/cmd/build-registry/main.go
+++ b/cli/cmd/build-registry/main.go
@@ -79,7 +79,7 @@ func run(skillsDir, adaptersDir, outFile, repo, ref, sha string, check bool) err
 
 	var verrs []string
 	for _, p := range parsed {
-		if err := p.fm.Validate(p.dirName, p.fullPath, ctx); err != nil {
+		if err := p.fm.Validate(p.dirName, ctx); err != nil {
 			verrs = append(verrs, err.Error())
 		}
 	}
@@ -105,7 +105,6 @@ func run(skillsDir, adaptersDir, outFile, repo, ref, sha string, check bool) err
 			Platforms:   p.fm.Platforms,
 			Requires:    p.fm.Requires,
 			Path:        filepath.ToSlash(filepath.Join(filepath.Base(skillsDir), p.dirName)),
-			PostInstall: p.fm.PostInstall,
 			DirSHA:      dirSha,
 		})
 	}

--- a/cli/internal/frontmatter/frontmatter.go
+++ b/cli/internal/frontmatter/frontmatter.go
@@ -22,7 +22,6 @@ type Frontmatter struct {
 	Requires    []string `yaml:"requires,omitempty"`
 	Platforms   []string `yaml:"platforms,omitempty"`
 	Tags        []string `yaml:"tags,omitempty"`
-	PostInstall string   `yaml:"post_install,omitempty"`
 }
 
 // Parse splits the leading `---` YAML frontmatter block from the body and

--- a/cli/internal/frontmatter/validate.go
+++ b/cli/internal/frontmatter/validate.go
@@ -3,8 +3,6 @@ package frontmatter
 import (
 	"errors"
 	"fmt"
-	"os"
-	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -104,9 +102,8 @@ type ValidationContext struct {
 }
 
 // Validate checks every humblSKILLS-owned rule except DAG acyclicity (done by
-// the resolver). dirName is the skill directory's basename; skillPath is the
-// absolute path to that directory, used only to stat post_install.
-func (fm Frontmatter) Validate(dirName, skillPath string, ctx ValidationContext) error {
+// the resolver). dirName is the skill directory's basename.
+func (fm Frontmatter) Validate(dirName string, ctx ValidationContext) error {
 	var errs []string
 
 	switch {
@@ -155,18 +152,6 @@ func (fm Frontmatter) Validate(dirName, skillPath string, ctx ValidationContext)
 		}
 		if !dep.Satisfies(registered) {
 			errs = append(errs, fmt.Sprintf("dep %q unsatisfied by registered version %s", raw, registered))
-		}
-	}
-
-	if fm.PostInstall != "" {
-		clean := filepath.Clean(fm.PostInstall)
-		if filepath.IsAbs(clean) || strings.HasPrefix(clean, "..") || clean == ".." {
-			errs = append(errs, fmt.Sprintf("post_install %q must be a relative path inside the skill directory", fm.PostInstall))
-		} else {
-			full := filepath.Join(skillPath, clean)
-			if _, err := os.Stat(full); err != nil {
-				errs = append(errs, fmt.Sprintf("post_install %q not found: %v", fm.PostInstall, err))
-			}
 		}
 	}
 

--- a/cli/internal/frontmatter/validate_test.go
+++ b/cli/internal/frontmatter/validate_test.go
@@ -1,8 +1,6 @@
 package frontmatter
 
 import (
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -16,21 +14,20 @@ func ctxWith(skills map[string]string, adapters ...string) ValidationContext {
 }
 
 func TestValidate_Happy(t *testing.T) {
-	dir := t.TempDir()
 	fm := Frontmatter{
 		Name:        "foo",
 		Description: "desc",
 		Version:     "0.1.0",
 		Platforms:   []string{"claude-code"},
 	}
-	if err := fm.Validate("foo", dir, ctxWith(nil, "claude-code")); err != nil {
+	if err := fm.Validate("foo", ctxWith(nil, "claude-code")); err != nil {
 		t.Fatalf("unexpected: %v", err)
 	}
 }
 
 func TestValidate_NameRegex(t *testing.T) {
 	fm := Frontmatter{Name: "Foo_Bar", Description: "d", Version: "0.1.0"}
-	err := fm.Validate("Foo_Bar", "", ctxWith(nil))
+	err := fm.Validate("Foo_Bar", ctxWith(nil))
 	if err == nil || !strings.Contains(err.Error(), "must match") {
 		t.Fatalf("expected name regex error, got %v", err)
 	}
@@ -38,7 +35,7 @@ func TestValidate_NameRegex(t *testing.T) {
 
 func TestValidate_NameMatchesDir(t *testing.T) {
 	fm := Frontmatter{Name: "foo", Description: "d", Version: "0.1.0"}
-	err := fm.Validate("bar", "", ctxWith(nil))
+	err := fm.Validate("bar", ctxWith(nil))
 	if err == nil || !strings.Contains(err.Error(), "containing directory") {
 		t.Fatalf("expected dir-mismatch error, got %v", err)
 	}
@@ -46,7 +43,7 @@ func TestValidate_NameMatchesDir(t *testing.T) {
 
 func TestValidate_SemverBad(t *testing.T) {
 	fm := Frontmatter{Name: "foo", Description: "d", Version: "1.2"}
-	err := fm.Validate("foo", "", ctxWith(nil))
+	err := fm.Validate("foo", ctxWith(nil))
 	if err == nil || !strings.Contains(err.Error(), "not valid semver") {
 		t.Fatalf("expected semver error, got %v", err)
 	}
@@ -54,7 +51,7 @@ func TestValidate_SemverBad(t *testing.T) {
 
 func TestValidate_DepUnknown(t *testing.T) {
 	fm := Frontmatter{Name: "foo", Description: "d", Version: "0.1.0", Requires: []string{"ghost"}}
-	err := fm.Validate("foo", "", ctxWith(nil))
+	err := fm.Validate("foo", ctxWith(nil))
 	if err == nil || !strings.Contains(err.Error(), `unknown dep "ghost"`) {
 		t.Fatalf("expected unknown dep error, got %v", err)
 	}
@@ -67,7 +64,7 @@ func TestValidate_DepVersionUnsatisfied(t *testing.T) {
 		Version:     "0.1.0",
 		Requires:    []string{"bar@>=0.3.0"},
 	}
-	err := fm.Validate("foo", "", ctxWith(map[string]string{"bar": "0.2.0"}))
+	err := fm.Validate("foo", ctxWith(map[string]string{"bar": "0.2.0"}))
 	if err == nil || !strings.Contains(err.Error(), "unsatisfied") {
 		t.Fatalf("expected unsatisfied error, got %v", err)
 	}
@@ -80,7 +77,7 @@ func TestValidate_DepVersionSatisfied(t *testing.T) {
 		Version:     "0.1.0",
 		Requires:    []string{"bar@>=0.3.0"},
 	}
-	err := fm.Validate("foo", "", ctxWith(map[string]string{"bar": "0.3.1"}))
+	err := fm.Validate("foo", ctxWith(map[string]string{"bar": "0.3.1"}))
 	if err != nil {
 		t.Fatalf("unexpected: %v", err)
 	}
@@ -91,51 +88,9 @@ func TestValidate_UnknownPlatform(t *testing.T) {
 		Name: "foo", Description: "d", Version: "0.1.0",
 		Platforms: []string{"claude-code", "atari-2600"},
 	}
-	err := fm.Validate("foo", "", ctxWith(nil, "claude-code"))
+	err := fm.Validate("foo", ctxWith(nil, "claude-code"))
 	if err == nil || !strings.Contains(err.Error(), "atari-2600") {
 		t.Fatalf("expected unknown platform error, got %v", err)
-	}
-}
-
-func TestValidate_PostInstallEscape(t *testing.T) {
-	dir := t.TempDir()
-	fm := Frontmatter{
-		Name: "foo", Description: "d", Version: "0.1.0",
-		PostInstall: "../escape.sh",
-	}
-	err := fm.Validate("foo", dir, ctxWith(nil))
-	if err == nil || !strings.Contains(err.Error(), "inside the skill directory") {
-		t.Fatalf("expected escape error, got %v", err)
-	}
-}
-
-func TestValidate_PostInstallMissing(t *testing.T) {
-	dir := t.TempDir()
-	fm := Frontmatter{
-		Name: "foo", Description: "d", Version: "0.1.0",
-		PostInstall: "scripts/setup.sh",
-	}
-	err := fm.Validate("foo", dir, ctxWith(nil))
-	if err == nil || !strings.Contains(err.Error(), "not found") {
-		t.Fatalf("expected not-found error, got %v", err)
-	}
-}
-
-func TestValidate_PostInstallPresent(t *testing.T) {
-	dir := t.TempDir()
-	sub := filepath.Join(dir, "scripts")
-	if err := os.MkdirAll(sub, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(sub, "setup.sh"), []byte("#!/bin/sh\n"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	fm := Frontmatter{
-		Name: "foo", Description: "d", Version: "0.1.0",
-		PostInstall: "scripts/setup.sh",
-	}
-	if err := fm.Validate("foo", dir, ctxWith(nil)); err != nil {
-		t.Fatalf("unexpected: %v", err)
 	}
 }
 
@@ -144,7 +99,7 @@ func TestValidate_SelfDep(t *testing.T) {
 		Name: "foo", Description: "d", Version: "0.1.0",
 		Requires: []string{"foo"},
 	}
-	err := fm.Validate("foo", "", ctxWith(map[string]string{"foo": "0.1.0"}))
+	err := fm.Validate("foo", ctxWith(map[string]string{"foo": "0.1.0"}))
 	if err == nil || !strings.Contains(err.Error(), "cannot require itself") {
 		t.Fatalf("expected self-dep error, got %v", err)
 	}

--- a/cli/internal/registry/types.go
+++ b/cli/internal/registry/types.go
@@ -29,6 +29,5 @@ type Skill struct {
 	Platforms   []string `json:"platforms,omitempty"`
 	Requires    []string `json:"requires,omitempty"`
 	Path        string   `json:"path"`
-	PostInstall string   `json:"post_install,omitempty"`
 	DirSHA      string   `json:"dir_sha"`
 }


### PR DESCRIPTION
## Summary
- `post_install` was dead scaffolding: parsed, validated, and persisted to `registry.json`, but never executed by the install engine.
- Removing it now (no skill in the registry sets it) avoids hinting at a capability that doesn't exist, and sidesteps the security footgun of running author-supplied shell at install time.
- If a real need emerges later, it should be designed declaratively (manifest entries, permission claims) rather than arbitrary shell.

## Changes
- Drop `PostInstall` field from `Frontmatter` and `registry.Skill` structs
- Delete validation block in `frontmatter/validate.go` + now-unused `os` / `path/filepath` imports
- Simplify `Validate` signature: remove the `skillPath` param (only used for `post_install`)
- Remove the three `TestValidate_PostInstall*` tests
- Update README feature bullet

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` — all packages pass
- [x] `make registry-check` — semantic diff unchanged (no skill populated the field)
- [x] `make adapters-check`
- [x] `grep -r post_install|PostInstall` — zero hits

🤖 Generated with [Claude Code](https://claude.com/claude-code)