### PR TITLE
feat(cli): preserve user-owned content across skill updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ agent platform you use — Claude Code, Cursor, Codex, and friends.
 
 1. **Skill registry** — a monorepo of agent skills authored in the
    agentskills.io format with light humblSKILLS frontmatter extensions
-   (`requires`, `platforms`, `tags`).
+   (`requires`, `platforms`, `tags`, `preserve`).
 2. **`humblskills` CLI** — fetches a skill directory and drops it in the right
    place for your agent platform. Zero servers, zero accounts, zero telemetry.
 
@@ -72,6 +72,45 @@ humblskills uninstall skill-example-hello
 
 Every command accepts `--json` for machine-readable output and `--yes` to
 skip confirmation prompts.
+
+## Preserving user content across updates
+
+Smart skills often accumulate user-owned content over time — raw sources,
+append-only memory (`log.md`, `decisions.md`, `patterns.md`), LLM-curated
+wiki pages. By default `humblskills update` and `humblskills install`
+overwrite the skill directory with whatever the registry ships. Skills that
+need to keep user content around on update can declare a `preserve:` list in
+their SKILL.md frontmatter.
+
+Entries are relative paths inside the skill directory. A trailing `/` makes
+the entry a directory; anything else is a file. Globs are not supported.
+
+| Entry form      | Example              | Meaning on update                                    |
+| --------------- | -------------------- | ---------------------------------------------------- |
+| **File**        | `references/log.md`  | User wins. User's bytes survive the update.          |
+| **Directory**   | `references/wiki/`   | Deep merge. Staging wins per-file; user-only files kept. |
+
+Fresh installs always seed everything from the registry — preserve only kicks
+in when replacing an existing install. Running `humblskills uninstall` wipes
+everything, including preserved content.
+
+```yaml
+---
+name: my-smart-skill
+description: ...
+version: 0.2.0
+preserve:
+  - references/log.md
+  - references/patterns.md
+  - references/decisions.md
+  - references/raw/
+  - references/wiki/
+---
+```
+
+Skill authors who declare a preserve *directory* should note in their skill
+docs that any files shipped inside that directory may be overwritten on
+update — that's the deep-merge contract.
 
 ## Developing the CLI
 

--- a/cli/cmd/build-registry/main.go
+++ b/cli/cmd/build-registry/main.go
@@ -104,6 +104,7 @@ func run(skillsDir, adaptersDir, outFile, repo, ref, sha string, check bool) err
 			Tags:        p.fm.Tags,
 			Platforms:   p.fm.Platforms,
 			Requires:    p.fm.Requires,
+			Preserve:    p.fm.Preserve,
 			Path:        filepath.ToSlash(filepath.Join(filepath.Base(skillsDir), p.dirName)),
 			DirSHA:      dirSha,
 		})

--- a/cli/internal/frontmatter/frontmatter.go
+++ b/cli/internal/frontmatter/frontmatter.go
@@ -22,6 +22,7 @@ type Frontmatter struct {
 	Requires    []string `yaml:"requires,omitempty"`
 	Platforms   []string `yaml:"platforms,omitempty"`
 	Tags        []string `yaml:"tags,omitempty"`
+	Preserve    []string `yaml:"preserve,omitempty"`
 }
 
 // Parse splits the leading `---` YAML frontmatter block from the body and

--- a/cli/internal/frontmatter/validate.go
+++ b/cli/internal/frontmatter/validate.go
@@ -3,11 +3,15 @@ package frontmatter
 import (
 	"errors"
 	"fmt"
+	"path"
 	"regexp"
 	"strings"
 
 	"golang.org/x/mod/semver"
 )
+
+// winDriveRegex matches Windows drive-prefixed paths like "C:\foo" or "c:/bar".
+var winDriveRegex = regexp.MustCompile(`^[A-Za-z]:`)
 
 // NameRegex is the allowed shape for a skill name.
 var NameRegex = regexp.MustCompile(`^[a-z][a-z0-9-]*$`)
@@ -135,6 +139,10 @@ func (fm Frontmatter) Validate(dirName string, ctx ValidationContext) error {
 		}
 	}
 
+	if perrs := validatePreserve(fm.Preserve); len(perrs) > 0 {
+		errs = append(errs, perrs...)
+	}
+
 	for _, raw := range fm.Requires {
 		dep, err := ParseDep(raw)
 		if err != nil {
@@ -163,4 +171,109 @@ func (fm Frontmatter) Validate(dirName string, ctx ValidationContext) error {
 		label = dirName
 	}
 	return fmt.Errorf("%s: %s", label, strings.Join(errs, "; "))
+}
+
+// normalizePreserve returns the canonical form used for dedup/overlap checks.
+// It preserves the trailing slash (semantically: dir vs file) but strips
+// leading "./" and collapses repeated internal slashes. The return does not
+// attempt to resolve ".." — those are rejected earlier.
+func normalizePreserve(raw string) string {
+	s := strings.TrimSpace(raw)
+	s = strings.TrimPrefix(s, "./")
+	trailing := strings.HasSuffix(s, "/")
+	// path.Clean drops a trailing slash; recover it if present.
+	cleaned := path.Clean(s)
+	if cleaned == "." {
+		return ""
+	}
+	if trailing {
+		cleaned += "/"
+	}
+	return cleaned
+}
+
+// validatePreserve checks every entry in fm.Preserve for shape violations and
+// returns a list of error strings (empty on success).
+func validatePreserve(entries []string) []string {
+	var errs []string
+	seen := map[string]struct{}{}
+	// dirs accumulates normalized directory entries (with trailing slash kept)
+	// for overlap checks.
+	type norm struct{ raw, clean string }
+	var normalized []norm
+
+	for _, raw := range entries {
+		trimmed := strings.TrimSpace(raw)
+		if trimmed == "" {
+			errs = append(errs, fmt.Sprintf("preserve entry %q is empty", raw))
+			continue
+		}
+		if strings.HasPrefix(trimmed, "/") {
+			errs = append(errs, fmt.Sprintf("preserve entry %q must be a relative path (no leading /)", raw))
+			continue
+		}
+		if winDriveRegex.MatchString(trimmed) {
+			errs = append(errs, fmt.Sprintf("preserve entry %q must not be an absolute path", raw))
+			continue
+		}
+		// Reject ".." segments.
+		segments := strings.Split(trimmed, "/")
+		badSeg := false
+		for _, seg := range segments {
+			if seg == ".." {
+				errs = append(errs, fmt.Sprintf("preserve entry %q must not contain '..' segments", raw))
+				badSeg = true
+				break
+			}
+		}
+		if badSeg {
+			continue
+		}
+
+		clean := normalizePreserve(trimmed)
+		if clean == "" {
+			errs = append(errs, fmt.Sprintf("preserve entry %q normalizes to empty path", raw))
+			continue
+		}
+		if _, dup := seen[clean]; dup {
+			errs = append(errs, fmt.Sprintf("preserve entry %q is a duplicate", raw))
+			continue
+		}
+		seen[clean] = struct{}{}
+		normalized = append(normalized, norm{raw: raw, clean: clean})
+	}
+
+	// Overlap detection: one entry's path is a prefix of another's.
+	for i := 0; i < len(normalized); i++ {
+		for j := i + 1; j < len(normalized); j++ {
+			a, b := normalized[i], normalized[j]
+			if preserveOverlaps(a.clean, b.clean) {
+				errs = append(errs, fmt.Sprintf("preserve entries %q and %q overlap", a.raw, b.raw))
+			}
+		}
+	}
+
+	return errs
+}
+
+// preserveOverlaps reports whether a and b are in a prefix relationship (one
+// covers the other), using normalized forms (trailing slash preserved). Equal
+// strings are not considered overlapping here (dedup catches that).
+func preserveOverlaps(a, b string) bool {
+	if a == b {
+		return false
+	}
+	aPath := strings.TrimSuffix(a, "/")
+	bPath := strings.TrimSuffix(b, "/")
+	if aPath == bPath {
+		// One is "foo", the other "foo/". Treat as overlap.
+		return true
+	}
+	if strings.HasPrefix(bPath, aPath+"/") {
+		return true
+	}
+	if strings.HasPrefix(aPath, bPath+"/") {
+		return true
+	}
+	return false
 }

--- a/cli/internal/frontmatter/validate.go
+++ b/cli/internal/frontmatter/validate.go
@@ -197,10 +197,7 @@ func normalizePreserve(raw string) string {
 func validatePreserve(entries []string) []string {
 	var errs []string
 	seen := map[string]struct{}{}
-	// dirs accumulates normalized directory entries (with trailing slash kept)
-	// for overlap checks.
-	type norm struct{ raw, clean string }
-	var normalized []norm
+	var normalized []struct{ raw, clean string }
 
 	for _, raw := range entries {
 		trimmed := strings.TrimSpace(raw)
@@ -240,7 +237,7 @@ func validatePreserve(entries []string) []string {
 			continue
 		}
 		seen[clean] = struct{}{}
-		normalized = append(normalized, norm{raw: raw, clean: clean})
+		normalized = append(normalized, struct{ raw, clean string }{raw: raw, clean: clean})
 	}
 
 	// Overlap detection: one entry's path is a prefix of another's.

--- a/cli/internal/frontmatter/validate_test.go
+++ b/cli/internal/frontmatter/validate_test.go
@@ -140,6 +140,51 @@ func TestParseDep_Forms(t *testing.T) {
 	}
 }
 
+func TestValidate_PreserveHappy(t *testing.T) {
+	fm := Frontmatter{
+		Name:        "foo",
+		Description: "d",
+		Version:     "0.1.0",
+		Preserve:    []string{"references/log.md", "references/raw/", "references/wiki/"},
+	}
+	if err := fm.Validate("foo", ctxWith(nil)); err != nil {
+		t.Fatalf("unexpected: %v", err)
+	}
+}
+
+func TestValidate_PreserveRejects(t *testing.T) {
+	cases := []struct {
+		name    string
+		entries []string
+		want    string
+	}{
+		{"empty", []string{""}, "is empty"},
+		{"whitespace", []string{"   "}, "is empty"},
+		{"absolute", []string{"/abs/path"}, "relative path"},
+		{"parent-dir", []string{"../x"}, "'..' segments"},
+		{"parent-mid", []string{"foo/../bar"}, "'..' segments"},
+		{"windows-drive", []string{"C:\\x"}, "absolute path"},
+		{"duplicate", []string{"foo.md", "foo.md"}, "duplicate"},
+		{"overlap-dir-file", []string{"wiki/", "wiki/x.md"}, "overlap"},
+		{"overlap-file-dir", []string{"wiki", "wiki/"}, "overlap"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			fm := Frontmatter{
+				Name: "foo", Description: "d", Version: "0.1.0",
+				Preserve: c.entries,
+			}
+			err := fm.Validate("foo", ctxWith(nil))
+			if err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), c.want) {
+				t.Fatalf("error %q missing %q", err, c.want)
+			}
+		})
+	}
+}
+
 func TestDepSatisfies(t *testing.T) {
 	cases := []struct {
 		dep        string

--- a/cli/internal/install/engine.go
+++ b/cli/internal/install/engine.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/jjfantini/humblSKILLS/cli/internal/fetch"
@@ -166,10 +167,11 @@ func (e *Engine) installOne(
 	// Pre-compute which targets actually need the extract + copy. If none do,
 	// we skip the tarball fetch entirely so repeated no-op installs are fast.
 	type planTarget struct {
-		pending pending
-		out     Outcome
-		final   string
-		orphan  string // previous install path to clean up (project-scope move)
+		pending  pending
+		out      Outcome
+		final    string
+		orphan   string // previous install path to clean up (project-scope move)
+		existing *manifest.Installation
 	}
 	var toWrite []planTarget
 	var skipped []TargetResult
@@ -201,11 +203,11 @@ func (e *Engine) installOne(
 				Path: dest, Outcome: OutcomeSkipped,
 			})
 		case upToDate && opts.Force:
-			toWrite = append(toWrite, planTarget{pending: pg, out: OutcomeForced, final: dest, orphan: orphan})
+			toWrite = append(toWrite, planTarget{pending: pg, out: OutcomeForced, final: dest, orphan: orphan, existing: existing})
 		case existing != nil:
-			toWrite = append(toWrite, planTarget{pending: pg, out: OutcomeReplaced, final: dest, orphan: orphan})
+			toWrite = append(toWrite, planTarget{pending: pg, out: OutcomeReplaced, final: dest, orphan: orphan, existing: existing})
 		default:
-			toWrite = append(toWrite, planTarget{pending: pg, out: OutcomeInstalled, final: dest, orphan: orphan})
+			toWrite = append(toWrite, planTarget{pending: pg, out: OutcomeInstalled, final: dest, orphan: orphan, existing: existing})
 		}
 	}
 
@@ -236,13 +238,60 @@ func (e *Engine) installOne(
 
 	results := append([]TargetResult(nil), skipped...)
 	for _, pt := range toWrite {
+		preserveActive := len(skill.Preserve) > 0 && pt.existing != nil
+
+		// Pick the source root for preserved content. For scope moves the
+		// previous path is cleaned up below, so we need to snapshot from
+		// there before removal. Otherwise the current final path is the
+		// on-disk version the user has been editing.
+		preserveSrc := ""
+		if preserveActive {
+			if pt.orphan != "" && pt.orphan != pt.final {
+				if _, err := os.Stat(pt.orphan); err == nil {
+					preserveSrc = pt.orphan
+				}
+			}
+			if preserveSrc == "" {
+				if _, err := os.Stat(pt.final); err == nil {
+					preserveSrc = pt.final
+				}
+			}
+		}
+
+		// When preserve is active, copy the shared staging into a
+		// per-target staging dir and merge preserved content into it,
+		// leaving the shared staging untouched for subsequent targets.
+		writeSrc := staging
+		var perTarget string
+		if preserveActive {
+			perTarget = filepath.Join(
+				e.StagingDir,
+				skill.Name+"-"+shortSHA(reg.Source.SHA)+"-"+pt.pending.adapter.Name+"-"+pt.pending.target.Scope,
+			)
+			if err := os.RemoveAll(perTarget); err != nil {
+				return nil, fmt.Errorf("clean per-target staging: %w", err)
+			}
+			if err := copyTree(staging, perTarget); err != nil {
+				return nil, fmt.Errorf("copy per-target staging: %w", err)
+			}
+			if preserveSrc != "" {
+				if err := applyPreserve(preserveSrc, perTarget, skill.Preserve); err != nil {
+					return nil, err
+				}
+			}
+			writeSrc = perTarget
+		}
+
 		if pt.orphan != "" && pt.orphan != pt.final {
 			if err := os.RemoveAll(pt.orphan); err != nil {
 				return nil, fmt.Errorf("clean old install %s: %w", pt.orphan, err)
 			}
 		}
-		if err := replaceDir(staging, pt.final); err != nil {
+		if err := replaceDir(writeSrc, pt.final); err != nil {
 			return nil, fmt.Errorf("place %s: %w", pt.final, err)
+		}
+		if perTarget != "" {
+			_ = os.RemoveAll(perTarget)
 		}
 		m.Upsert(manifest.Installation{
 			Skill:       skill.Name,
@@ -361,4 +410,97 @@ func shortSHA(sha string) string {
 		return sha[:12]
 	}
 	return sha
+}
+
+// applyPreserve merges user-owned content from userRoot into stagingRoot
+// according to the preserve list.
+//
+//   - File entry (no trailing "/"): user wins; user's bytes overwrite whatever
+//     staging shipped.
+//   - Directory entry (trailing "/"): deep merge; staging wins on per-file
+//     conflicts. Files only in user land alongside staging's version.
+//
+// Type mismatches (file entry vs user dir, or dir entry vs user file) and
+// symlinks in the user source are rejected rather than silently resolved.
+func applyPreserve(userRoot, stagingRoot string, entries []string) error {
+	for _, raw := range entries {
+		rel := strings.TrimSpace(raw)
+		rel = strings.TrimPrefix(rel, "./")
+		isDir := strings.HasSuffix(rel, "/")
+		relClean := filepath.FromSlash(strings.TrimSuffix(rel, "/"))
+		if relClean == "" || relClean == "." {
+			continue
+		}
+		srcAbs := filepath.Join(userRoot, relClean)
+		dstAbs := filepath.Join(stagingRoot, relClean)
+
+		fi, err := os.Lstat(srcAbs)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return fmt.Errorf("preserve stat %s: %w", srcAbs, err)
+		}
+		if fi.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("preserve: refusing to follow symlink %s", srcAbs)
+		}
+
+		if isDir {
+			if !fi.IsDir() {
+				return fmt.Errorf("preserve: entry %q declares a directory but %s is a file", raw, srcAbs)
+			}
+			if err := preserveMergeDir(srcAbs, dstAbs); err != nil {
+				return err
+			}
+			continue
+		}
+		if fi.IsDir() {
+			return fmt.Errorf("preserve: entry %q declares a file but %s is a directory", raw, srcAbs)
+		}
+		if err := os.MkdirAll(filepath.Dir(dstAbs), 0o755); err != nil {
+			return fmt.Errorf("preserve mkdir %s: %w", filepath.Dir(dstAbs), err)
+		}
+		if err := copyFile(srcAbs, dstAbs, fi.Mode()&0o777); err != nil {
+			return fmt.Errorf("preserve copy %s: %w", srcAbs, err)
+		}
+	}
+	return nil
+}
+
+// preserveMergeDir walks userDir and copies every regular file into dstDir
+// only when dstDir does not already have that relative path — staging wins on
+// conflicts. Symlinks anywhere in userDir abort the merge.
+func preserveMergeDir(userDir, dstDir string) error {
+	return filepath.Walk(userDir, func(p string, fi os.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		rel, err := filepath.Rel(userDir, p)
+		if err != nil {
+			return err
+		}
+		if rel == "." {
+			return os.MkdirAll(dstDir, fi.Mode()&0o777|0o700)
+		}
+		dst := filepath.Join(dstDir, rel)
+		if fi.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("preserve: refusing to follow symlink %s", p)
+		}
+		if fi.IsDir() {
+			// Only create the dir if it does not already exist — leave
+			// staging-shipped dirs (and their contents) intact.
+			if _, err := os.Stat(dst); err == nil {
+				return nil
+			}
+			return os.MkdirAll(dst, fi.Mode()&0o777|0o700)
+		}
+		if _, err := os.Stat(dst); err == nil {
+			// Staging already ships this file; staging wins.
+			return nil
+		}
+		if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+			return err
+		}
+		return copyFile(p, dst, fi.Mode()&0o777)
+	})
 }

--- a/cli/internal/install/engine.go
+++ b/cli/internal/install/engine.go
@@ -167,11 +167,11 @@ func (e *Engine) installOne(
 	// Pre-compute which targets actually need the extract + copy. If none do,
 	// we skip the tarball fetch entirely so repeated no-op installs are fast.
 	type planTarget struct {
-		pending  pending
-		out      Outcome
-		final    string
-		orphan   string // previous install path to clean up (project-scope move)
-		existing *manifest.Installation
+		pending      pending
+		out          Outcome
+		final        string
+		orphan       string // previous install path to clean up (project-scope move)
+		existingPath string // manifest-recorded previous path, used as preserve source
 	}
 	var toWrite []planTarget
 	var skipped []TargetResult
@@ -196,6 +196,10 @@ func (e *Engine) installOne(
 			upToDate = false
 		}
 
+		existingPath := ""
+		if existing != nil {
+			existingPath = existing.Path
+		}
 		switch {
 		case upToDate && !opts.Force:
 			skipped = append(skipped, TargetResult{
@@ -203,11 +207,11 @@ func (e *Engine) installOne(
 				Path: dest, Outcome: OutcomeSkipped,
 			})
 		case upToDate && opts.Force:
-			toWrite = append(toWrite, planTarget{pending: pg, out: OutcomeForced, final: dest, orphan: orphan, existing: existing})
+			toWrite = append(toWrite, planTarget{pending: pg, out: OutcomeForced, final: dest, orphan: orphan, existingPath: existingPath})
 		case existing != nil:
-			toWrite = append(toWrite, planTarget{pending: pg, out: OutcomeReplaced, final: dest, orphan: orphan, existing: existing})
+			toWrite = append(toWrite, planTarget{pending: pg, out: OutcomeReplaced, final: dest, orphan: orphan, existingPath: existingPath})
 		default:
-			toWrite = append(toWrite, planTarget{pending: pg, out: OutcomeInstalled, final: dest, orphan: orphan, existing: existing})
+			toWrite = append(toWrite, planTarget{pending: pg, out: OutcomeInstalled, final: dest, orphan: orphan, existingPath: existingPath})
 		}
 	}
 
@@ -238,46 +242,25 @@ func (e *Engine) installOne(
 
 	results := append([]TargetResult(nil), skipped...)
 	for _, pt := range toWrite {
-		preserveActive := len(skill.Preserve) > 0 && pt.existing != nil
-
-		// Pick the source root for preserved content. For scope moves the
-		// previous path is cleaned up below, so we need to snapshot from
-		// there before removal. Otherwise the current final path is the
-		// on-disk version the user has been editing.
-		preserveSrc := ""
-		if preserveActive {
-			if pt.orphan != "" && pt.orphan != pt.final {
-				if _, err := os.Stat(pt.orphan); err == nil {
-					preserveSrc = pt.orphan
-				}
-			}
-			if preserveSrc == "" {
-				if _, err := os.Stat(pt.final); err == nil {
-					preserveSrc = pt.final
-				}
-			}
-		}
-
-		// When preserve is active, copy the shared staging into a
-		// per-target staging dir and merge preserved content into it,
-		// leaving the shared staging untouched for subsequent targets.
+		// When preserve is active, build a per-target copy of staging with
+		// user content merged in, leaving the shared staging pristine for
+		// sibling targets. pt.existingPath is the authoritative previous
+		// location whether this is a normal replace or a scope move.
 		writeSrc := staging
-		var perTarget string
-		if preserveActive {
-			perTarget = filepath.Join(
+		if len(skill.Preserve) > 0 && pt.existingPath != "" {
+			perTarget := filepath.Join(
 				e.StagingDir,
 				skill.Name+"-"+shortSHA(reg.Source.SHA)+"-"+pt.pending.adapter.Name+"-"+pt.pending.target.Scope,
 			)
 			if err := os.RemoveAll(perTarget); err != nil {
 				return nil, fmt.Errorf("clean per-target staging: %w", err)
 			}
+			defer os.RemoveAll(perTarget)
 			if err := copyTree(staging, perTarget); err != nil {
 				return nil, fmt.Errorf("copy per-target staging: %w", err)
 			}
-			if preserveSrc != "" {
-				if err := applyPreserve(preserveSrc, perTarget, skill.Preserve); err != nil {
-					return nil, err
-				}
+			if err := applyPreserve(pt.existingPath, perTarget, skill.Preserve); err != nil {
+				return nil, err
 			}
 			writeSrc = perTarget
 		}
@@ -289,9 +272,6 @@ func (e *Engine) installOne(
 		}
 		if err := replaceDir(writeSrc, pt.final); err != nil {
 			return nil, fmt.Errorf("place %s: %w", pt.final, err)
-		}
-		if perTarget != "" {
-			_ = os.RemoveAll(perTarget)
 		}
 		m.Upsert(manifest.Installation{
 			Skill:       skill.Name,
@@ -457,9 +437,6 @@ func applyPreserve(userRoot, stagingRoot string, entries []string) error {
 		if fi.IsDir() {
 			return fmt.Errorf("preserve: entry %q declares a file but %s is a directory", raw, srcAbs)
 		}
-		if err := os.MkdirAll(filepath.Dir(dstAbs), 0o755); err != nil {
-			return fmt.Errorf("preserve mkdir %s: %w", filepath.Dir(dstAbs), err)
-		}
 		if err := copyFile(srcAbs, dstAbs, fi.Mode()&0o777); err != nil {
 			return fmt.Errorf("preserve copy %s: %w", srcAbs, err)
 		}
@@ -487,8 +464,6 @@ func preserveMergeDir(userDir, dstDir string) error {
 			return fmt.Errorf("preserve: refusing to follow symlink %s", p)
 		}
 		if fi.IsDir() {
-			// Only create the dir if it does not already exist — leave
-			// staging-shipped dirs (and their contents) intact.
 			if _, err := os.Stat(dst); err == nil {
 				return nil
 			}
@@ -497,9 +472,6 @@ func preserveMergeDir(userDir, dstDir string) error {
 		if _, err := os.Stat(dst); err == nil {
 			// Staging already ships this file; staging wins.
 			return nil
-		}
-		if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
-			return err
 		}
 		return copyFile(p, dst, fi.Mode()&0o777)
 	})

--- a/cli/internal/install/engine_test.go
+++ b/cli/internal/install/engine_test.go
@@ -268,6 +268,507 @@ func TestEngine_ProjectScopeMovesOldInstall(t *testing.T) {
 	}
 }
 
+func TestInstall_PreserveFreshInstall_SeedsFromStaging(t *testing.T) {
+	root := t.TempDir()
+	cacheDir := filepath.Join(root, "cache")
+	installRoot := filepath.Join(root, "home", ".claude", "skills")
+	manifestPath := filepath.Join(root, "manifest.json")
+
+	skillFiles := map[string]string{
+		"skills/foo/SKILL.md":       "# foo\n",
+		"skills/foo/wiki/seed.md":   "seed-v1\n",
+		"skills/foo/log.md":         "initial\n",
+	}
+	onlyFoo := map[string]string{
+		"SKILL.md":     "# foo\n",
+		"wiki/seed.md": "seed-v1\n",
+		"log.md":       "initial\n",
+	}
+	dirSHA := expectedDirSHA(t, onlyFoo)
+	owner, name, sha := "ex", "r", "sha1fresh000000"
+	seedTarball(t, cacheDir, owner, name, sha, owner+"-"+name+"-abc", skillFiles)
+
+	reg := &registry.Registry{
+		SchemaVersion: registry.SchemaVersion,
+		Source:        registry.Source{Repo: "github.com/ex/r", SHA: sha},
+		Skills: []registry.Skill{{
+			Name: "foo", Version: "0.1.0", Path: "skills/foo",
+			Platforms: []string{"test"}, DirSHA: dirSHA,
+			Preserve: []string{"log.md", "wiki/"},
+		}},
+	}
+	adapter := platform.Adapter{
+		Name:           "test",
+		InstallTargets: map[string]string{"user": installRoot},
+		DefaultScope:   "user",
+	}
+
+	engine := NewEngine(cacheDir, manifestPath)
+	engine.Now = func() time.Time { return time.Unix(1700000000, 0).UTC() }
+	plan, _ := Plan(reg, "foo")
+	if _, err := engine.Execute(reg, plan, ExecuteOpts{
+		Adapters: []platform.Adapter{adapter}, Platforms: []string{"test"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, rel := range []string{"SKILL.md", "wiki/seed.md", "log.md"} {
+		if _, err := os.Stat(filepath.Join(installRoot, "foo", rel)); err != nil {
+			t.Errorf("%s missing after fresh install: %v", rel, err)
+		}
+	}
+}
+
+func TestInstall_PreserveFile_UserWinsOnReplace(t *testing.T) {
+	root := t.TempDir()
+	cacheDir := filepath.Join(root, "cache")
+	installRoot := filepath.Join(root, "home", ".claude", "skills")
+	manifestPath := filepath.Join(root, "manifest.json")
+
+	// v1 ships log.md with "initial".
+	v1Files := map[string]string{
+		"skills/foo/SKILL.md": "# foo\n",
+		"skills/foo/log.md":   "initial\n",
+	}
+	v1Flat := map[string]string{"SKILL.md": "# foo\n", "log.md": "initial\n"}
+	v1SHA := expectedDirSHA(t, v1Flat)
+	owner, name := "ex", "r"
+	src1 := "sha1aaaaaaaaaa"
+	seedTarball(t, cacheDir, owner, name, src1, owner+"-"+name+"-abc", v1Files)
+
+	// v2 ships log.md with "shipped-v2".
+	v2Files := map[string]string{
+		"skills/foo/SKILL.md": "# foo v2\n",
+		"skills/foo/log.md":   "shipped-v2\n",
+	}
+	v2Flat := map[string]string{"SKILL.md": "# foo v2\n", "log.md": "shipped-v2\n"}
+	v2SHA := expectedDirSHA(t, v2Flat)
+	src2 := "sha2bbbbbbbbbb"
+	seedTarball(t, cacheDir, owner, name, src2, owner+"-"+name+"-def", v2Files)
+
+	adapter := platform.Adapter{
+		Name:           "test",
+		InstallTargets: map[string]string{"user": installRoot},
+		DefaultScope:   "user",
+	}
+	engine := NewEngine(cacheDir, manifestPath)
+	engine.Now = func() time.Time { return time.Unix(1700000000, 0).UTC() }
+
+	// Install v1.
+	reg1 := &registry.Registry{
+		SchemaVersion: registry.SchemaVersion,
+		Source:        registry.Source{Repo: "github.com/ex/r", SHA: src1},
+		Skills: []registry.Skill{{
+			Name: "foo", Version: "0.1.0", Path: "skills/foo",
+			Platforms: []string{"test"}, DirSHA: v1SHA,
+			Preserve: []string{"log.md"},
+		}},
+	}
+	plan1, _ := Plan(reg1, "foo")
+	if _, err := engine.Execute(reg1, plan1, ExecuteOpts{
+		Adapters: []platform.Adapter{adapter}, Platforms: []string{"test"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// User edits log.md.
+	logPath := filepath.Join(installRoot, "foo", "log.md")
+	if err := os.WriteFile(logPath, []byte("user-edit\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Install v2.
+	reg2 := &registry.Registry{
+		SchemaVersion: registry.SchemaVersion,
+		Source:        registry.Source{Repo: "github.com/ex/r", SHA: src2},
+		Skills: []registry.Skill{{
+			Name: "foo", Version: "0.2.0", Path: "skills/foo",
+			Platforms: []string{"test"}, DirSHA: v2SHA,
+			Preserve: []string{"log.md"},
+		}},
+	}
+	plan2, _ := Plan(reg2, "foo")
+	if _, err := engine.Execute(reg2, plan2, ExecuteOpts{
+		Adapters: []platform.Adapter{adapter}, Platforms: []string{"test"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// log.md should have user bytes; SKILL.md should be v2 bytes.
+	got, _ := os.ReadFile(logPath)
+	if string(got) != "user-edit\n" {
+		t.Errorf("log.md: want user-edit, got %q", got)
+	}
+	gotSkill, _ := os.ReadFile(filepath.Join(installRoot, "foo", "SKILL.md"))
+	if string(gotSkill) != "# foo v2\n" {
+		t.Errorf("SKILL.md: want v2, got %q", gotSkill)
+	}
+}
+
+func TestInstall_PreserveDir_DeepMerge(t *testing.T) {
+	root := t.TempDir()
+	cacheDir := filepath.Join(root, "cache")
+	installRoot := filepath.Join(root, "home", ".claude", "skills")
+	manifestPath := filepath.Join(root, "manifest.json")
+
+	v1Files := map[string]string{
+		"skills/foo/SKILL.md":     "# foo\n",
+		"skills/foo/wiki/seed.md": "seed-v1\n",
+	}
+	v1Flat := map[string]string{"SKILL.md": "# foo\n", "wiki/seed.md": "seed-v1\n"}
+	v1SHA := expectedDirSHA(t, v1Flat)
+	owner, name := "ex", "r"
+	src1 := "shadir1aaaaaaa"
+	seedTarball(t, cacheDir, owner, name, src1, owner+"-"+name+"-abc", v1Files)
+
+	v2Files := map[string]string{
+		"skills/foo/SKILL.md":     "# foo v2\n",
+		"skills/foo/wiki/seed.md": "seed-v2\n",
+	}
+	v2Flat := map[string]string{"SKILL.md": "# foo v2\n", "wiki/seed.md": "seed-v2\n"}
+	v2SHA := expectedDirSHA(t, v2Flat)
+	src2 := "shadir2bbbbbbb"
+	seedTarball(t, cacheDir, owner, name, src2, owner+"-"+name+"-def", v2Files)
+
+	adapter := platform.Adapter{
+		Name:           "test",
+		InstallTargets: map[string]string{"user": installRoot},
+		DefaultScope:   "user",
+	}
+	engine := NewEngine(cacheDir, manifestPath)
+	engine.Now = func() time.Time { return time.Unix(1700000000, 0).UTC() }
+
+	reg1 := &registry.Registry{
+		SchemaVersion: registry.SchemaVersion,
+		Source:        registry.Source{Repo: "github.com/ex/r", SHA: src1},
+		Skills: []registry.Skill{{
+			Name: "foo", Version: "0.1.0", Path: "skills/foo",
+			Platforms: []string{"test"}, DirSHA: v1SHA,
+			Preserve: []string{"wiki/"},
+		}},
+	}
+	plan1, _ := Plan(reg1, "foo")
+	if _, err := engine.Execute(reg1, plan1, ExecuteOpts{
+		Adapters: []platform.Adapter{adapter}, Platforms: []string{"test"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// User adds a new file and edits the seeded one.
+	wikiDir := filepath.Join(installRoot, "foo", "wiki")
+	if err := os.WriteFile(filepath.Join(wikiDir, "mynote.md"), []byte("my-note\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(wikiDir, "seed.md"), []byte("user-edited\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	reg2 := &registry.Registry{
+		SchemaVersion: registry.SchemaVersion,
+		Source:        registry.Source{Repo: "github.com/ex/r", SHA: src2},
+		Skills: []registry.Skill{{
+			Name: "foo", Version: "0.2.0", Path: "skills/foo",
+			Platforms: []string{"test"}, DirSHA: v2SHA,
+			Preserve: []string{"wiki/"},
+		}},
+	}
+	plan2, _ := Plan(reg2, "foo")
+	if _, err := engine.Execute(reg2, plan2, ExecuteOpts{
+		Adapters: []platform.Adapter{adapter}, Platforms: []string{"test"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// seed.md should now be staging's v2 bytes (staging wins on conflict).
+	got, _ := os.ReadFile(filepath.Join(wikiDir, "seed.md"))
+	if string(got) != "seed-v2\n" {
+		t.Errorf("seed.md: want seed-v2, got %q", got)
+	}
+	// mynote.md should survive.
+	got2, err := os.ReadFile(filepath.Join(wikiDir, "mynote.md"))
+	if err != nil || string(got2) != "my-note\n" {
+		t.Errorf("mynote.md: want my-note, got %q err=%v", got2, err)
+	}
+}
+
+func TestInstall_PreserveWithForce(t *testing.T) {
+	root := t.TempDir()
+	cacheDir := filepath.Join(root, "cache")
+	installRoot := filepath.Join(root, "home", ".claude", "skills")
+	manifestPath := filepath.Join(root, "manifest.json")
+
+	files := map[string]string{
+		"skills/foo/SKILL.md": "# foo\n",
+		"skills/foo/log.md":   "initial\n",
+	}
+	flat := map[string]string{"SKILL.md": "# foo\n", "log.md": "initial\n"}
+	dirSHA := expectedDirSHA(t, flat)
+	owner, name, sha := "ex", "r", "shaforce000000"
+	seedTarball(t, cacheDir, owner, name, sha, owner+"-"+name+"-abc", files)
+
+	reg := &registry.Registry{
+		SchemaVersion: registry.SchemaVersion,
+		Source:        registry.Source{Repo: "github.com/ex/r", SHA: sha},
+		Skills: []registry.Skill{{
+			Name: "foo", Version: "0.1.0", Path: "skills/foo",
+			Platforms: []string{"test"}, DirSHA: dirSHA,
+			Preserve: []string{"log.md"},
+		}},
+	}
+	adapter := platform.Adapter{
+		Name:           "test",
+		InstallTargets: map[string]string{"user": installRoot},
+		DefaultScope:   "user",
+	}
+	engine := NewEngine(cacheDir, manifestPath)
+	engine.Now = func() time.Time { return time.Unix(1700000000, 0).UTC() }
+
+	plan, _ := Plan(reg, "foo")
+	if _, err := engine.Execute(reg, plan, ExecuteOpts{
+		Adapters: []platform.Adapter{adapter}, Platforms: []string{"test"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	logPath := filepath.Join(installRoot, "foo", "log.md")
+	if err := os.WriteFile(logPath, []byte("user-edit\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := engine.Execute(reg, plan, ExecuteOpts{
+		Adapters: []platform.Adapter{adapter}, Platforms: []string{"test"}, Force: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := os.ReadFile(logPath)
+	if string(got) != "user-edit\n" {
+		t.Errorf("forced install wiped preserved file: got %q", got)
+	}
+}
+
+func TestInstall_PreserveScopeMove(t *testing.T) {
+	root := t.TempDir()
+	cacheDir := filepath.Join(root, "cache")
+	oldRoot := filepath.Join(root, "old", ".claude", "skills")
+	newRoot := filepath.Join(root, "new", ".claude", "skills")
+	manifestPath := filepath.Join(root, "manifest.json")
+
+	files := map[string]string{
+		"skills/foo/SKILL.md":     "# foo\n",
+		"skills/foo/wiki/seed.md": "seed\n",
+	}
+	flat := map[string]string{"SKILL.md": "# foo\n", "wiki/seed.md": "seed\n"}
+	dirSHA := expectedDirSHA(t, flat)
+	owner, name, sha := "ex", "r", "shamove000000"
+	seedTarball(t, cacheDir, owner, name, sha, owner+"-"+name+"-abc", files)
+
+	// Pre-seed old install with user content in preserve dir.
+	oldFoo := filepath.Join(oldRoot, "foo")
+	if err := os.MkdirAll(filepath.Join(oldFoo, "wiki"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(oldFoo, "SKILL.md"), []byte("# foo\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(oldFoo, "wiki", "seed.md"), []byte("seed\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(oldFoo, "wiki", "mynote.md"), []byte("my-note\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	m := &manifest.Manifest{SchemaVersion: manifest.SchemaVersion}
+	m.Upsert(manifest.Installation{
+		Skill: "foo", Version: "0.1.0", Platform: "test", Scope: "project",
+		Path: oldFoo, InstalledAt: time.Unix(1700000000, 0).UTC(),
+		SourceSHA: sha, RegistryRef: dirSHA,
+	})
+	if err := manifest.Save(manifestPath, m); err != nil {
+		t.Fatal(err)
+	}
+
+	reg := &registry.Registry{
+		SchemaVersion: registry.SchemaVersion,
+		Source:        registry.Source{Repo: "github.com/ex/r", SHA: sha},
+		Skills: []registry.Skill{{
+			Name: "foo", Version: "0.1.0", Path: "skills/foo",
+			Platforms: []string{"test"}, DirSHA: dirSHA,
+			Preserve: []string{"wiki/"},
+		}},
+	}
+	adapter := platform.Adapter{
+		Name:           "test",
+		InstallTargets: map[string]string{"project": newRoot},
+		DefaultScope:   "project",
+	}
+	engine := NewEngine(cacheDir, manifestPath)
+	engine.Now = func() time.Time { return time.Unix(1700000000, 0).UTC() }
+	plan, _ := Plan(reg, "foo")
+	if _, err := engine.Execute(reg, plan, ExecuteOpts{
+		Adapters: []platform.Adapter{adapter}, Platforms: []string{"test"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := os.Stat(oldFoo); err == nil {
+		t.Error("old path should be gone")
+	}
+	// User content migrated to new location.
+	got, err := os.ReadFile(filepath.Join(newRoot, "foo", "wiki", "mynote.md"))
+	if err != nil || string(got) != "my-note\n" {
+		t.Errorf("migrated user note missing: err=%v got=%q", err, got)
+	}
+}
+
+func TestInstall_PreserveMissingOnDisk_UsesStaging(t *testing.T) {
+	root := t.TempDir()
+	cacheDir := filepath.Join(root, "cache")
+	installRoot := filepath.Join(root, "home", ".claude", "skills")
+	manifestPath := filepath.Join(root, "manifest.json")
+
+	v1Files := map[string]string{
+		"skills/foo/SKILL.md": "# foo\n",
+		"skills/foo/log.md":   "initial\n",
+	}
+	v1Flat := map[string]string{"SKILL.md": "# foo\n", "log.md": "initial\n"}
+	v1SHA := expectedDirSHA(t, v1Flat)
+	owner, name := "ex", "r"
+	src1 := "shamiss1aaaaa"
+	seedTarball(t, cacheDir, owner, name, src1, owner+"-"+name+"-abc", v1Files)
+
+	v2Files := map[string]string{
+		"skills/foo/SKILL.md": "# foo v2\n",
+		"skills/foo/log.md":   "shipped-v2\n",
+	}
+	v2Flat := map[string]string{"SKILL.md": "# foo v2\n", "log.md": "shipped-v2\n"}
+	v2SHA := expectedDirSHA(t, v2Flat)
+	src2 := "shamiss2bbbbb"
+	seedTarball(t, cacheDir, owner, name, src2, owner+"-"+name+"-def", v2Files)
+
+	adapter := platform.Adapter{
+		Name:           "test",
+		InstallTargets: map[string]string{"user": installRoot},
+		DefaultScope:   "user",
+	}
+	engine := NewEngine(cacheDir, manifestPath)
+	engine.Now = func() time.Time { return time.Unix(1700000000, 0).UTC() }
+
+	reg1 := &registry.Registry{
+		SchemaVersion: registry.SchemaVersion,
+		Source:        registry.Source{Repo: "github.com/ex/r", SHA: src1},
+		Skills: []registry.Skill{{
+			Name: "foo", Version: "0.1.0", Path: "skills/foo",
+			Platforms: []string{"test"}, DirSHA: v1SHA,
+			Preserve: []string{"log.md"},
+		}},
+	}
+	plan1, _ := Plan(reg1, "foo")
+	if _, err := engine.Execute(reg1, plan1, ExecuteOpts{
+		Adapters: []platform.Adapter{adapter}, Platforms: []string{"test"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Remove the preserved file from disk.
+	if err := os.Remove(filepath.Join(installRoot, "foo", "log.md")); err != nil {
+		t.Fatal(err)
+	}
+
+	reg2 := &registry.Registry{
+		SchemaVersion: registry.SchemaVersion,
+		Source:        registry.Source{Repo: "github.com/ex/r", SHA: src2},
+		Skills: []registry.Skill{{
+			Name: "foo", Version: "0.2.0", Path: "skills/foo",
+			Platforms: []string{"test"}, DirSHA: v2SHA,
+			Preserve: []string{"log.md"},
+		}},
+	}
+	plan2, _ := Plan(reg2, "foo")
+	if _, err := engine.Execute(reg2, plan2, ExecuteOpts{
+		Adapters: []platform.Adapter{adapter}, Platforms: []string{"test"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := os.ReadFile(filepath.Join(installRoot, "foo", "log.md"))
+	if string(got) != "shipped-v2\n" {
+		t.Errorf("missing preserve should have landed staging seed: got %q", got)
+	}
+}
+
+func TestInstall_PreserveTypeMismatch_Errors(t *testing.T) {
+	root := t.TempDir()
+	cacheDir := filepath.Join(root, "cache")
+	installRoot := filepath.Join(root, "home", ".claude", "skills")
+	manifestPath := filepath.Join(root, "manifest.json")
+
+	// v1 doesn't ship note.md at all; user will create it later as a dir.
+	v1Files := map[string]string{"skills/foo/SKILL.md": "# foo\n"}
+	v1Flat := map[string]string{"SKILL.md": "# foo\n"}
+	v1SHA := expectedDirSHA(t, v1Flat)
+	owner, name := "ex", "r"
+	src1 := "shatyp1aaaaaa"
+	seedTarball(t, cacheDir, owner, name, src1, owner+"-"+name+"-abc", v1Files)
+
+	v2Files := map[string]string{
+		"skills/foo/SKILL.md": "# foo v2\n",
+		"skills/foo/note.md":  "file-v2\n",
+	}
+	v2Flat := map[string]string{"SKILL.md": "# foo v2\n", "note.md": "file-v2\n"}
+	v2SHA := expectedDirSHA(t, v2Flat)
+	src2 := "shatyp2bbbbbb"
+	seedTarball(t, cacheDir, owner, name, src2, owner+"-"+name+"-def", v2Files)
+
+	adapter := platform.Adapter{
+		Name:           "test",
+		InstallTargets: map[string]string{"user": installRoot},
+		DefaultScope:   "user",
+	}
+	engine := NewEngine(cacheDir, manifestPath)
+	engine.Now = func() time.Time { return time.Unix(1700000000, 0).UTC() }
+
+	reg1 := &registry.Registry{
+		SchemaVersion: registry.SchemaVersion,
+		Source:        registry.Source{Repo: "github.com/ex/r", SHA: src1},
+		Skills: []registry.Skill{{
+			Name: "foo", Version: "0.1.0", Path: "skills/foo",
+			Platforms: []string{"test"}, DirSHA: v1SHA,
+			Preserve: []string{"note.md"},
+		}},
+	}
+	plan1, _ := Plan(reg1, "foo")
+	if _, err := engine.Execute(reg1, plan1, ExecuteOpts{
+		Adapters: []platform.Adapter{adapter}, Platforms: []string{"test"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// User creates note.md as a DIRECTORY.
+	if err := os.Mkdir(filepath.Join(installRoot, "foo", "note.md"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	reg2 := &registry.Registry{
+		SchemaVersion: registry.SchemaVersion,
+		Source:        registry.Source{Repo: "github.com/ex/r", SHA: src2},
+		Skills: []registry.Skill{{
+			Name: "foo", Version: "0.2.0", Path: "skills/foo",
+			Platforms: []string{"test"}, DirSHA: v2SHA,
+			Preserve: []string{"note.md"}, // declared as file
+		}},
+	}
+	plan2, _ := Plan(reg2, "foo")
+	_, err := engine.Execute(reg2, plan2, ExecuteOpts{
+		Adapters: []platform.Adapter{adapter}, Platforms: []string{"test"},
+	})
+	if err == nil {
+		t.Fatal("expected type-mismatch error")
+	}
+	// User dir must still exist — no destructive cleanup.
+	if _, serr := os.Stat(filepath.Join(installRoot, "foo", "note.md")); serr != nil {
+		t.Errorf("user dir should survive failed update: %v", serr)
+	}
+}
+
 func TestEngine_DirSHAMismatchFails(t *testing.T) {
 	root := t.TempDir()
 	cacheDir := filepath.Join(root, "cache")

--- a/cli/internal/registry/types.go
+++ b/cli/internal/registry/types.go
@@ -28,6 +28,7 @@ type Skill struct {
 	Tags        []string `json:"tags,omitempty"`
 	Platforms   []string `json:"platforms,omitempty"`
 	Requires    []string `json:"requires,omitempty"`
+	Preserve    []string `json:"preserve,omitempty"`
 	Path        string   `json:"path"`
 	DirSHA      string   `json:"dir_sha"`
 }


### PR DESCRIPTION
## Summary

- Adds a `preserve:` frontmatter field so skills can declare paths that survive a reinstall
- File entries are user-wins; directory entries deep-merge with staging winning on conflicts
- Fresh installs and uninstalls behave unchanged — preserve only kicks in when replacing an existing install

## Why

Smart skills accumulate user-owned content (raw sources, append-only memory, LLM-curated wiki pages). Today every `humblskills install`/`update` wipes the whole skill directory. This makes updates non-destructive for declared paths.

## Test plan

- [x] `go -C cli build ./...`
- [x] `go -C cli test ./...` (new validation + engine tests, 7 engine cases covering fresh install, file/dir semantics, force, scope-move, missing-on-disk, type-mismatch)
- [x] `make registry-check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)