### PR TITLE
feat(cli): polish search UI and add interactive install picker

### DIFF
--- a/cli/cmd/humblskills/install.go
+++ b/cli/cmd/humblskills/install.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"sort"
 
@@ -9,6 +10,7 @@ import (
 	"github.com/jjfantini/humblSKILLS/cli/internal/install"
 	"github.com/jjfantini/humblSKILLS/cli/internal/platform"
 	"github.com/jjfantini/humblSKILLS/cli/internal/registry"
+	"github.com/jjfantini/humblSKILLS/cli/internal/ui"
 )
 
 type installFlags struct {
@@ -20,11 +22,17 @@ type installFlags struct {
 func newInstallCmd(app *App) *cobra.Command {
 	var f installFlags
 	cmd := &cobra.Command{
-		Use:   "install <skill>",
+		Use:   "install [skill]",
 		Short: "Install a skill (and its deps) onto every detected platform",
-		Args:  cobra.ExactArgs(1),
+		Long: "install <skill> installs a named skill. With no arg, it opens " +
+			"an interactive, filterable picker listing every skill in the registry.",
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runInstall(app, args[0], f)
+			skill := ""
+			if len(args) == 1 {
+				skill = args[0]
+			}
+			return runInstall(app, skill, f)
 		},
 	}
 	cmd.Flags().StringSliceVar(&f.platforms, "platform", nil, "restrict install to these adapters (default: all detected)")
@@ -42,6 +50,13 @@ func runInstall(app *App, skill string, f installFlags) error {
 	reg, _, err := registry.NewFetcher(app.Config.RegistryURL, app.Config.CacheDir).Load()
 	if err != nil {
 		return fmt.Errorf("load registry: %w", err)
+	}
+
+	if skill == "" {
+		skill, err = pickSkill(app, reg)
+		if err != nil {
+			return err
+		}
 	}
 
 	selected, err := selectPlatforms(adapters, f.platforms)
@@ -145,4 +160,40 @@ func printInstall(app *App, r install.Result) {
 	if len(installed)+len(replaced)+len(forced) == 0 {
 		app.UI.Info("%d target%s already up-to-date (use --force to reinstall)", len(skipped), plural(len(skipped)))
 	}
+}
+
+// pickSkill opens an interactive, filterable picker listing every skill in
+// the registry. Each option shows "name  vX.Y.Z  —  description" so the user
+// can judge skills at a glance. Returns a usage-style error when the caller
+// isn't on an interactive TTY (or passed --yes/--json) so the missing arg is
+// surfaced clearly rather than hanging on a prompt.
+func pickSkill(app *App, reg *registry.Registry) (string, error) {
+	if len(reg.Skills) == 0 {
+		return "", fmt.Errorf("registry is empty")
+	}
+
+	skills := append([]registry.Skill(nil), reg.Skills...)
+	sort.Slice(skills, func(i, j int) bool { return skills[i].Name < skills[j].Name })
+
+	opts := make([]ui.SelectOption, 0, len(skills))
+	for _, s := range skills {
+		label := fmt.Sprintf("%s  v%s  —  %s", s.Name, s.Version, s.Description)
+		opts = append(opts, ui.SelectOption{Label: label, Value: s.Name})
+	}
+
+	picked, err := app.Prompt.Select(
+		"Pick a skill to install",
+		"type to filter · ↑↓ to navigate · enter to install",
+		opts,
+	)
+	if err != nil {
+		if errors.Is(err, ui.ErrNonInteractive) {
+			return "", fmt.Errorf("skill name required — usage: humblskills install <skill>")
+		}
+		return "", err
+	}
+	if picked == "" {
+		return "", fmt.Errorf("no skill selected")
+	}
+	return picked, nil
 }

--- a/cli/cmd/humblskills/search.go
+++ b/cli/cmd/humblskills/search.go
@@ -1,10 +1,15 @@
 package main
 
 import (
+	"fmt"
+	"os"
 	"sort"
 	"strings"
 
+	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 
 	"github.com/jjfantini/humblSKILLS/cli/internal/registry"
 )
@@ -42,15 +47,7 @@ func newSearchCmd(app *App) *cobra.Command {
 				app.UI.Warn("no skills matched %q", query)
 				return nil
 			}
-			for _, s := range hits {
-				app.UI.Info("%s@%s — %s", s.Name, s.Version, s.Description)
-				if len(s.Tags) > 0 {
-					app.UI.Detail("  tags: %s", strings.Join(s.Tags, ", "))
-				}
-				if len(s.Platforms) > 0 {
-					app.UI.Detail("  platforms: %s", strings.Join(s.Platforms, ", "))
-				}
-			}
+			app.UI.Println(renderSearchResults(hits, query, app.Config.NoColor))
 			return nil
 		},
 	}
@@ -69,4 +66,159 @@ func matches(s registry.Skill, q string) bool {
 		}
 	}
 	return false
+}
+
+// renderSearchResults returns a multi-line, styled string listing every
+// skill. Layout is terminal-width-aware and degrades to plain ASCII when
+// noColor is set.
+func renderSearchResults(hits []registry.Skill, query string, noColor bool) string {
+	r := lipgloss.DefaultRenderer()
+	if noColor {
+		r = lipgloss.NewRenderer(os.Stdout)
+		r.SetColorProfile(termenv.Ascii)
+	}
+
+	width := termWidth()
+	if width > 96 {
+		width = 96
+	}
+	if width < 48 {
+		width = 48
+	}
+	inner := width - 4 // gutter on each side
+
+	var (
+		brand     = r.NewStyle().Bold(true).Foreground(lipgloss.Color("#A78BFA"))
+		crumb     = r.NewStyle().Foreground(lipgloss.Color("244"))
+		count     = r.NewStyle().Foreground(lipgloss.Color("244")).Italic(true)
+		rule      = r.NewStyle().Foreground(lipgloss.Color("238"))
+		bullet    = r.NewStyle().Foreground(lipgloss.Color("#A78BFA"))
+		nameStyle = r.NewStyle().Bold(true).Foreground(lipgloss.Color("#5EEAD4"))
+		version   = r.NewStyle().Foreground(lipgloss.Color("244"))
+		descStyle = r.NewStyle().Foreground(lipgloss.Color("252"))
+		tag       = r.NewStyle().Foreground(lipgloss.Color("#93C5FD"))
+		platform  = r.NewStyle().Foreground(lipgloss.Color("#F0ABFC"))
+		hit       = r.NewStyle().Bold(true).Foreground(lipgloss.Color("#FDE68A"))
+		label     = r.NewStyle().Foreground(lipgloss.Color("244"))
+	)
+
+	var sb strings.Builder
+
+	// Header: "  humblskills › search  "foo""
+	header := "  " + brand.Render("humblskills") + crumb.Render("  ›  search")
+	if query != "" {
+		header += crumb.Render("  ›  ") + hit.Render(fmt.Sprintf("%q", query))
+	}
+	sb.WriteString("\n")
+	sb.WriteString(header)
+	sb.WriteString("\n  ")
+	sb.WriteString(rule.Render(strings.Repeat("─", inner)))
+	sb.WriteString("\n")
+
+	// Count line
+	noun := "skill"
+	if len(hits) != 1 {
+		noun = "skills"
+	}
+	var summary string
+	if query != "" {
+		summary = fmt.Sprintf("%d %s matching your query", len(hits), noun)
+	} else {
+		summary = fmt.Sprintf("%d %s in registry", len(hits), noun)
+	}
+	sb.WriteString("  ")
+	sb.WriteString(count.Render(summary))
+	sb.WriteString("\n\n")
+
+	for i, s := range hits {
+		// Title line: ▸ name-with-highlight                              v0.1.0
+		left := bullet.Render("▸ ") + highlightName(s.Name, query, nameStyle, hit)
+		right := version.Render("v" + s.Version)
+		pad := inner - lipgloss.Width(left) - lipgloss.Width(right)
+		if pad < 1 {
+			pad = 1
+		}
+		sb.WriteString("  " + left + strings.Repeat(" ", pad) + right + "\n")
+
+		// Description, soft-wrapped to inner-2 and indented.
+		if s.Description != "" {
+			wrapped := descStyle.Width(inner - 2).Render(s.Description)
+			for _, line := range strings.Split(wrapped, "\n") {
+				sb.WriteString("    " + line + "\n")
+			}
+		}
+
+		// Metadata: tags + platforms on one or two lines.
+		if len(s.Tags) > 0 {
+			chips := make([]string, 0, len(s.Tags))
+			for _, t := range s.Tags {
+				chips = append(chips, tag.Render("#"+t))
+			}
+			sb.WriteString("    " + label.Render("tags    ") + strings.Join(chips, "  ") + "\n")
+		}
+		if len(s.Platforms) > 0 {
+			plats := make([]string, 0, len(s.Platforms))
+			for _, pl := range s.Platforms {
+				plats = append(plats, platform.Render(pl))
+			}
+			sb.WriteString("    " + label.Render("target  ") + strings.Join(plats, "  ") + "\n")
+		}
+
+		if i < len(hits)-1 {
+			sb.WriteString("\n")
+		}
+	}
+
+	// Hint footer.
+	sb.WriteString("\n  ")
+	sb.WriteString(rule.Render(strings.Repeat("─", inner)))
+	sb.WriteString("\n  ")
+	sb.WriteString(crumb.Render("install with  "))
+	sb.WriteString(nameStyle.Render("humblskills install <name>"))
+	sb.WriteString("\n")
+
+	return sb.String()
+}
+
+// highlightName returns the skill name with case-insensitive query matches
+// wrapped in the hit style. The non-matching parts are rendered with base.
+// If query is empty, the name is returned under base untouched.
+func highlightName(name, query string, base, hit lipgloss.Style) string {
+	if query == "" {
+		return base.Render(name)
+	}
+	lower := strings.ToLower(name)
+	idx := strings.Index(lower, query)
+	if idx < 0 {
+		return base.Render(name)
+	}
+	var sb strings.Builder
+	cursor := 0
+	for idx >= 0 {
+		if idx > cursor {
+			sb.WriteString(base.Render(name[cursor:idx]))
+		}
+		end := idx + len(query)
+		sb.WriteString(hit.Render(name[idx:end]))
+		cursor = end
+		rest := lower[cursor:]
+		next := strings.Index(rest, query)
+		if next < 0 {
+			break
+		}
+		idx = cursor + next
+	}
+	if cursor < len(name) {
+		sb.WriteString(base.Render(name[cursor:]))
+	}
+	return sb.String()
+}
+
+// termWidth returns a sensible content width, falling back to 80 when stdout
+// isn't a TTY (piped output, CI, tests).
+func termWidth() int {
+	if w, _, err := term.GetSize(int(os.Stdout.Fd())); err == nil && w > 0 {
+		return w
+	}
+	return 80
 }

--- a/cli/internal/ui/prompt.go
+++ b/cli/internal/ui/prompt.go
@@ -38,6 +38,11 @@ func NewPrompter(yes bool) *Prompter {
 	return p
 }
 
+// theme is the shared huh theme for every interactive prompt. Catppuccin
+// gives the CLI a consistent, modern look and respects NO_COLOR via huh's
+// internal colour handling.
+func theme() *huh.Theme { return huh.ThemeCatppuccin() }
+
 // Confirm asks a yes/no question. When non-interactive, returns dflt.
 func (p *Prompter) Confirm(title string, dflt bool) (bool, error) {
 	if p.Yes {
@@ -52,6 +57,7 @@ func (p *Prompter) Confirm(title string, dflt bool) (bool, error) {
 		Affirmative("Yes").
 		Negative("No").
 		Value(&v).
+		WithTheme(theme()).
 		Run()
 	if err != nil {
 		return dflt, err
@@ -98,9 +104,58 @@ func (p *Prompter) MultiSelect(title string, options []MultiSelectOption) ([]str
 		Title(title).
 		Options(opts...).
 		Value(&selected).
+		WithTheme(theme()).
 		Run()
 	if err != nil {
 		return nil, fmt.Errorf("prompt: %w", err)
 	}
 	return selected, nil
+}
+
+// SelectOption is one entry shown in a Select.
+type SelectOption struct {
+	// Label is the visible text. Falls back to Value when empty.
+	Label string
+	// Value is returned from Select when this entry is picked.
+	Value string
+}
+
+// Select shows a single-select picker with type-to-filter. It returns the
+// chosen option's Value. Requires an interactive TTY: returns
+// ErrNonInteractive (or a usage-style error via --yes) when a selection can't
+// be made for the user.
+func (p *Prompter) Select(title, description string, options []SelectOption) (string, error) {
+	if len(options) == 0 {
+		return "", nil
+	}
+	if p.Yes {
+		// --yes can't pick for the user — a single-select has no safe default.
+		return "", ErrNonInteractive
+	}
+	if !p.Interactive {
+		return "", ErrNonInteractive
+	}
+
+	opts := make([]huh.Option[string], 0, len(options))
+	for _, o := range options {
+		label := o.Label
+		if label == "" {
+			label = o.Value
+		}
+		opts = append(opts, huh.NewOption(label, o.Value))
+	}
+	var picked string
+	sel := huh.NewSelect[string]().
+		Title(title).
+		Options(opts...).
+		Filtering(true).
+		Height(12).
+		Value(&picked)
+	if description != "" {
+		sel = sel.Description(description)
+	}
+	if err := sel.WithTheme(theme()).Run(); err != nil {
+		return "", fmt.Errorf("prompt: %w", err)
+	}
+	return picked, nil
 }

--- a/cli/internal/ui/ui.go
+++ b/cli/internal/ui/ui.go
@@ -91,6 +91,16 @@ func New(opts Options) *Printer {
 	}
 }
 
+// Println writes a pre-rendered string to stdout with a trailing newline.
+// Use when the caller has already composed styled output (e.g. via lipgloss)
+// and just needs it emitted. Suppressed in JSON / quiet mode.
+func (p *Printer) Println(s string) {
+	if p.jsonMode || p.level < LevelNormal {
+		return
+	}
+	fmt.Fprintln(p.out, s)
+}
+
 // Info prints at LevelNormal+. Suppressed in JSON mode.
 func (p *Printer) Info(format string, args ...any) {
 	if p.jsonMode || p.level < LevelNormal {


### PR DESCRIPTION
## Summary
- **`humblskills search`** renders a modern card layout: breadcrumb header, rule, result count, bulleted cards with right-aligned version, soft-wrapped description, `#tag` chips, and highlighted query matches. Width-aware (48–96 cols). `--json` / `--no-color` / `--quiet` still honored.
- **`humblskills install`** accepts an optional skill arg. With no arg on a TTY, opens a filterable [huh](https://github.com/charmbracelet/huh) picker (Catppuccin theme) listing the whole registry as \`name  vX.Y.Z  —  description\`. Non-interactive (pipe/CI/\`--yes\`/\`--json\`) returns a clear usage error instead of hanging.
- Supporting: new \`ui.Printer.Println\` for pre-rendered output, new \`ui.Prompter.Select\` wrapper around \`huh.Select\`, Catppuccin theme applied to Confirm/MultiSelect/Select for a consistent look.

## Test plan
- [x] \`go build ./...\` succeeds
- [x] \`go test ./...\` passes (existing UI tests still green)
- [x] \`humblskills search\` renders the new layout
- [x] \`humblskills search smart\` highlights the match in the name
- [x] \`humblskills search nothingmatches\` shows the styled warning
- [x] \`humblskills --json search smart\` emits JSON only
- [x] \`humblskills --no-color search smart\` strips ANSI but keeps structure
- [x] \`humblskills install\` (non-interactive) returns a usage error
- [ ] Manually verify the huh picker opens and filters as expected in a real TTY

🤖 Generated with [Claude Code](https://claude.com/claude-code)