### PR TITLE
feat(cli): unified TUI chrome with browse, wizards, and progress

### DIFF
--- a/cli/cmd/humblskills/doctor.go
+++ b/cli/cmd/humblskills/doctor.go
@@ -6,12 +6,15 @@ import (
 	"os"
 	"time"
 
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/lipgloss/table"
 	"github.com/spf13/cobra"
 
 	"github.com/jjfantini/humblSKILLS/cli/internal/install"
 	"github.com/jjfantini/humblSKILLS/cli/internal/manifest"
 	"github.com/jjfantini/humblSKILLS/cli/internal/platform"
 	"github.com/jjfantini/humblSKILLS/cli/internal/registry"
+	"github.com/jjfantini/humblSKILLS/cli/internal/tui"
 )
 
 type doctorReport struct {
@@ -102,7 +105,17 @@ func runDoctor(app *App) error {
 	}
 
 	f := registry.NewFetcher(app.Config.RegistryURL, app.Config.CacheDir)
-	reg, origin, rErr := f.Load()
+	var (
+		reg    *registry.Registry
+		origin registry.Origin
+		rErr   error
+	)
+	_ = tui.RunWithSpinner(app.UI.Theme(), "loading registry…", func() error {
+		reg, origin, rErr = f.Load()
+		// Return nil so the spinner never treats a registry miss as a hard
+		// failure — rErr is surfaced below via the Registry section.
+		return nil
+	})
 	rr := registryReport{URL: app.Config.RegistryURL, Source: string(origin)}
 	if rErr != nil {
 		rr.Error = rErr.Error()
@@ -157,38 +170,71 @@ func hasFailures(r doctorReport) bool {
 }
 
 func printDoctor(app *App, r doctorReport) {
-	app.UI.Info("Adapters:")
+	th := app.UI.Theme()
+	app.UI.Header("doctor")
+
+	app.UI.Section("Adapters")
 	anyDetected := false
+	rows := make([][]string, 0, len(r.Adapters))
 	for _, a := range r.Adapters {
 		if a.Detected {
 			anyDetected = true
-			app.UI.Success("%s — %s", a.Name, a.Reason)
-		} else {
-			app.UI.Detail("  %s (not detected): %s", a.Name, a.Reason)
 		}
-		for _, t := range a.Targets {
-			mark := "rw"
-			if !t.Writable {
-				mark = "ro"
+		status := th.Success.Render("● detected")
+		if !a.Detected {
+			status = th.Detail.Render("○ missing")
+		}
+		targets := "—"
+		if len(a.Targets) > 0 {
+			parts := make([]string, 0, len(a.Targets))
+			for _, t := range a.Targets {
+				mark := "rw"
+				if !t.Writable {
+					mark = "ro"
+				}
+				parts = append(parts,
+					th.Platform.Render(t.Scope)+th.Detail.Render(" ["+mark+"] "+t.Path),
+				)
 			}
-			app.UI.Detail("    %s [%s] %s", t.Scope, mark, t.Path)
+			targets = joinLines(parts)
 		}
+		rows = append(rows, []string{
+			th.Name.Render(a.Name),
+			status,
+			th.Detail.Render(a.Reason),
+			targets,
+		})
+	}
+	if len(rows) > 0 {
+		tbl := table.New().
+			Border(lipgloss.RoundedBorder()).
+			BorderStyle(th.RuleLine).
+			Headers("Adapter", "Status", "Reason", "Targets").
+			Rows(rows...).
+			StyleFunc(func(row, _ int) lipgloss.Style {
+				if row == table.HeaderRow {
+					return th.Label.Padding(0, 1).Bold(true)
+				}
+				return lipgloss.NewStyle().Padding(0, 1)
+			})
+		fmt.Fprintln(app.UI.Out(), tbl.Render())
 	}
 	if !anyDetected {
 		app.UI.Warn("no agent platform detected — run inside a project that uses Claude Code, Cursor, etc.")
 	}
 
-	app.UI.Info("")
-	app.UI.Info("Manifest:")
+	app.UI.Section("Manifest")
 	if _, err := os.Stat(r.Manifest.Path); err == nil {
-		app.UI.Info("  %s (%d install%s)", r.Manifest.Path, r.Manifest.Installs, plural(r.Manifest.Installs))
+		app.UI.Info("  %s %s",
+			th.Name.Render(r.Manifest.Path),
+			th.Detail.Render(fmt.Sprintf("(%d install%s)", r.Manifest.Installs, plural(r.Manifest.Installs))),
+		)
 	} else {
 		app.UI.Detail("  %s (not yet created)", r.Manifest.Path)
 	}
 
-	app.UI.Info("")
-	app.UI.Info("Registry:")
-	app.UI.Info("  URL: %s", r.Registry.URL)
+	app.UI.Section("Registry")
+	app.UI.Info("  %s %s", th.Label.Render("url"), th.Name.Render(r.Registry.URL))
 	if r.Registry.Error != "" {
 		app.UI.Error("registry unreachable: %s", r.Registry.Error)
 	} else {
@@ -202,16 +248,30 @@ func printDoctor(app *App, r doctorReport) {
 	}
 
 	if r.Updates.Count > 0 {
-		app.UI.Info("")
+		app.UI.Section("Updates")
 		app.UI.Warn("%d skill%s can be updated — run 'humblskills update'", r.Updates.Count, plural(r.Updates.Count))
 		for _, name := range r.Updates.Skills {
-			app.UI.Detail("  %s", name)
+			app.UI.Detail("  • %s", name)
 		}
 	}
 
 	for _, i := range r.Issues {
 		app.UI.Warn(i)
 	}
+}
+
+// joinLines concatenates target strings using literal newlines — lipgloss
+// tables soft-wrap cells on newlines, so each target ends up on its own line
+// without manual row duplication.
+func joinLines(lines []string) string {
+	s := ""
+	for i, l := range lines {
+		if i > 0 {
+			s += "\n"
+		}
+		s += l
+	}
+	return s
 }
 
 func plural(n int) string {

--- a/cli/cmd/humblskills/install.go
+++ b/cli/cmd/humblskills/install.go
@@ -10,6 +10,7 @@ import (
 	"github.com/jjfantini/humblSKILLS/cli/internal/install"
 	"github.com/jjfantini/humblSKILLS/cli/internal/platform"
 	"github.com/jjfantini/humblSKILLS/cli/internal/registry"
+	"github.com/jjfantini/humblSKILLS/cli/internal/tui"
 	"github.com/jjfantini/humblSKILLS/cli/internal/ui"
 )
 
@@ -72,24 +73,41 @@ func runInstall(app *App, skill string, f installFlags) error {
 		return err
 	}
 
-	app.UI.Detail("plan:")
-	for _, s := range plan {
-		tag := "root"
-		if s.IsDep {
-			tag = "dep"
+	engine := install.NewEngine(app.Config.CacheDir, app.Config.ManifestPath)
+	useTUI := tui.ShouldUseTUI(app.Config.JSON, app.Config.Quiet, app.Config.Yes)
+
+	if !useTUI {
+		app.UI.Detail("plan:")
+		for _, s := range plan {
+			tag := "root"
+			if s.IsDep {
+				tag = "dep"
+			}
+			app.UI.Detail("  %s %s@%s", tag, s.Skill.Name, s.Skill.Version)
 		}
-		app.UI.Detail("  %s %s@%s", tag, s.Skill.Name, s.Skill.Version)
 	}
 
-	engine := install.NewEngine(app.Config.CacheDir, app.Config.ManifestPath)
-	res, err := engine.Execute(reg, plan, install.ExecuteOpts{
-		Adapters:  adapters,
-		Platforms: selected,
-		Scope:     f.scope,
-		Force:     f.force,
-	})
-	if err != nil {
+	var res install.Result
+	run := func(sink install.EventSink) error {
+		r, err := engine.Execute(reg, plan, install.ExecuteOpts{
+			Adapters:  adapters,
+			Platforms: selected,
+			Scope:     f.scope,
+			Force:     f.force,
+			OnEvent:   sink,
+		})
+		res = r
 		return err
+	}
+
+	if useTUI {
+		if err := tui.ExecuteWithProgress(app.UI.Theme(), "install", run); err != nil {
+			return err
+		}
+	} else {
+		if err := run(nil); err != nil {
+			return err
+		}
 	}
 
 	if app.Config.JSON {

--- a/cli/cmd/humblskills/list.go
+++ b/cli/cmd/humblskills/list.go
@@ -1,11 +1,17 @@
 package main
 
 import (
+	"fmt"
 	"sort"
+	"strings"
 
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/lipgloss/table"
 	"github.com/spf13/cobra"
 
 	"github.com/jjfantini/humblSKILLS/cli/internal/manifest"
+	"github.com/jjfantini/humblSKILLS/cli/internal/tui"
+	"github.com/jjfantini/humblSKILLS/cli/internal/ui"
 )
 
 func newListCmd(app *App) *cobra.Command {
@@ -34,10 +40,108 @@ func newListCmd(app *App) *cobra.Command {
 				}
 				return installs[i].Scope < installs[j].Scope
 			})
-			for _, inst := range installs {
-				app.UI.Info("%s@%s  [%s/%s]  %s", inst.Skill, inst.Version, inst.Platform, inst.Scope, inst.Path)
+
+			if tui.ShouldUseTUI(app.Config.JSON, app.Config.Quiet, app.Config.Yes) {
+				return runListTUI(app, installs)
 			}
+			renderListTable(app, installs)
 			return nil
 		},
 	}
+}
+
+// renderListTable prints installs as a bordered table using the shared theme.
+// Used in non-TTY / piped / --json-less paths.
+func renderListTable(app *App, installs []manifest.Installation) {
+	th := app.UI.Theme()
+	app.UI.Header("list")
+
+	rows := make([][]string, 0, len(installs))
+	for _, inst := range installs {
+		rows = append(rows, []string{
+			th.Name.Render(inst.Skill),
+			th.Version.Render("v" + inst.Version),
+			th.Platform.Render(inst.Platform),
+			th.Label.Render(inst.Scope),
+			th.Detail.Render(inst.Path),
+		})
+	}
+	tbl := table.New().
+		Border(lipgloss.RoundedBorder()).
+		BorderStyle(th.RuleLine).
+		Headers("Skill", "Version", "Platform", "Scope", "Path").
+		Rows(rows...).
+		StyleFunc(func(row, _ int) lipgloss.Style {
+			if row == table.HeaderRow {
+				return th.Label.Padding(0, 1).Bold(true)
+			}
+			return lipgloss.NewStyle().Padding(0, 1)
+		})
+	fmt.Fprintln(app.UI.Out(), tbl.Render())
+	fmt.Fprintln(app.UI.Out(), "  "+th.Crumb.Render(fmt.Sprintf(
+		"%d install%s total", len(installs), plural(len(installs)))))
+}
+
+// runListTUI launches the shared browser in "installed" mode. Actions: update,
+// uninstall, or quit. After the browser exits, the appropriate command is
+// routed back through runUpdate / Uninstall so the user stays in one flow.
+func runListTUI(app *App, installs []manifest.Installation) error {
+	items := make([]tui.BrowseItem, 0, len(installs))
+	for _, inst := range installs {
+		items = append(items, installedBrowseItem{Installation: inst})
+	}
+	m, err := tui.Run(tui.NewBrowser(tui.BrowserConfig{
+		Command:  "installed",
+		Theme:    app.UI.Theme(),
+		Items:    items,
+		Actions:  []tui.BrowseAction{tui.ActionUpdate, tui.ActionUninstall},
+		EmptyMsg: "no skills installed",
+	}))
+	if err != nil {
+		return err
+	}
+	browser, ok := m.(tui.Browser)
+	if !ok {
+		return nil
+	}
+	res := browser.Selected()
+	it, ok := res.Item.(installedBrowseItem)
+	if !ok {
+		return nil
+	}
+	switch res.Action {
+	case tui.ActionUpdate:
+		return runUpdate(app, []string{it.Skill}, updateFlags{})
+	case tui.ActionUninstall:
+		return runUninstall(app, it.Skill)
+	}
+	return nil
+}
+
+// installedBrowseItem adapts manifest.Installation to the BrowseItem contract.
+type installedBrowseItem struct {
+	manifest.Installation
+}
+
+func (i installedBrowseItem) FilterValue() string {
+	return i.Skill + " " + i.Platform + " " + i.Scope
+}
+func (i installedBrowseItem) Title() string { return i.Skill + "  v" + i.Version }
+func (i installedBrowseItem) Description() string {
+	return i.Platform + "/" + i.Scope
+}
+func (i installedBrowseItem) Preview(theme *ui.Theme, width int) string {
+	var sb strings.Builder
+	sb.WriteString(theme.Name.Render(i.Skill))
+	sb.WriteString("  ")
+	sb.WriteString(theme.Version.Render("v" + i.Version))
+	sb.WriteString("\n\n")
+	sb.WriteString(theme.Label.Render("platform  ") + theme.Platform.Render(i.Platform) + "\n")
+	sb.WriteString(theme.Label.Render("scope     ") + theme.Platform.Render(i.Scope) + "\n")
+	sb.WriteString(theme.Label.Render("path      ") + theme.Detail.Render(i.Path) + "\n")
+	if !i.InstalledAt.IsZero() {
+		sb.WriteString(theme.Label.Render("installed ") +
+			theme.Detail.Render(i.InstalledAt.Format("2006-01-02 15:04")) + "\n")
+	}
+	return sb.String()
 }

--- a/cli/cmd/humblskills/registry.go
+++ b/cli/cmd/humblskills/registry.go
@@ -6,6 +6,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/jjfantini/humblSKILLS/cli/internal/registry"
+	"github.com/jjfantini/humblSKILLS/cli/internal/tui"
 )
 
 type refreshResult struct {
@@ -31,7 +32,15 @@ func newRegistryRefreshCmd(app *App) *cobra.Command {
 		Short: "Force a refresh of the cached registry",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			f := registry.NewFetcher(app.Config.RegistryURL, app.Config.CacheDir)
-			reg, origin, err := f.Refresh()
+			var (
+				reg    *registry.Registry
+				origin registry.Origin
+			)
+			err := tui.RunWithSpinner(app.UI.Theme(), "refreshing registry…", func() error {
+				r, o, e := f.Refresh()
+				reg, origin = r, o
+				return e
+			})
 			if err != nil {
 				return err
 			}

--- a/cli/cmd/humblskills/search.go
+++ b/cli/cmd/humblskills/search.go
@@ -7,11 +7,12 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
-	"github.com/muesli/termenv"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 
 	"github.com/jjfantini/humblSKILLS/cli/internal/registry"
+	"github.com/jjfantini/humblSKILLS/cli/internal/tui"
+	"github.com/jjfantini/humblSKILLS/cli/internal/ui"
 )
 
 func newSearchCmd(app *App) *cobra.Command {
@@ -47,7 +48,16 @@ func newSearchCmd(app *App) *cobra.Command {
 				app.UI.Warn("no skills matched %q", query)
 				return nil
 			}
-			app.UI.Println(renderSearchResults(hits, query, app.Config.NoColor))
+
+			// With no query and an interactive terminal, drop into the TUI
+			// browser so the user can filter + preview + install without
+			// leaving the CLI.
+			useTUI := query == "" && tui.ShouldUseTUI(app.Config.JSON, app.Config.Quiet, app.Config.Yes)
+			if useTUI {
+				return runSearchTUI(app, hits)
+			}
+
+			app.UI.Println(renderSearchResults(app.UI.Theme(), hits, query))
 			return nil
 		},
 	}
@@ -68,16 +78,87 @@ func matches(s registry.Skill, q string) bool {
 	return false
 }
 
-// renderSearchResults returns a multi-line, styled string listing every
-// skill. Layout is terminal-width-aware and degrades to plain ASCII when
-// noColor is set.
-func renderSearchResults(hits []registry.Skill, query string, noColor bool) string {
-	r := lipgloss.DefaultRenderer()
-	if noColor {
-		r = lipgloss.NewRenderer(os.Stdout)
-		r.SetColorProfile(termenv.Ascii)
+// runSearchTUI launches the bubbletea browser over hits. When the user exits
+// with the install action, the selected skill is handed straight to
+// runInstall so one TUI flows into the next.
+func runSearchTUI(app *App, hits []registry.Skill) error {
+	items := make([]tui.BrowseItem, 0, len(hits))
+	for _, s := range hits {
+		items = append(items, skillBrowseItem{Skill: s})
 	}
+	m, err := tui.Run(tui.NewBrowser(tui.BrowserConfig{
+		Command:  "search",
+		Theme:    app.UI.Theme(),
+		Items:    items,
+		Actions:  []tui.BrowseAction{tui.ActionInstall},
+		EmptyMsg: "no skills in registry",
+	}))
+	if err != nil {
+		return err
+	}
+	browser, ok := m.(tui.Browser)
+	if !ok {
+		return nil
+	}
+	res := browser.Selected()
+	if res.Action != tui.ActionInstall {
+		return nil
+	}
+	it, ok := res.Item.(skillBrowseItem)
+	if !ok {
+		return nil
+	}
+	app.UI.Info("installing %s…", app.UI.Theme().Name.Render(it.Name))
+	return runInstall(app, it.Name, installFlags{})
+}
 
+// skillBrowseItem adapts registry.Skill to the tui.BrowseItem contract.
+type skillBrowseItem struct {
+	registry.Skill
+}
+
+func (s skillBrowseItem) FilterValue() string {
+	return s.Name + " " + strings.Join(s.Tags, " ") + " " + s.Skill.Description
+}
+func (s skillBrowseItem) Title() string { return s.Name + "  v" + s.Version }
+func (s skillBrowseItem) Description() string {
+	return s.Skill.Description
+}
+func (s skillBrowseItem) Preview(theme *ui.Theme, width int) string {
+	var sb strings.Builder
+	sb.WriteString(theme.Name.Render(s.Name))
+	sb.WriteString("  ")
+	sb.WriteString(theme.Version.Render("v" + s.Version))
+	sb.WriteString("\n\n")
+	if s.Skill.Description != "" {
+		sb.WriteString(theme.Desc.Width(width).Render(s.Skill.Description))
+		sb.WriteString("\n\n")
+	}
+	if len(s.Tags) > 0 {
+		chips := make([]string, 0, len(s.Tags))
+		for _, t := range s.Tags {
+			chips = append(chips, theme.Tag.Render("#"+t))
+		}
+		sb.WriteString(theme.Label.Render("tags    ") + strings.Join(chips, "  ") + "\n")
+	}
+	if len(s.Platforms) > 0 {
+		plats := make([]string, 0, len(s.Platforms))
+		for _, p := range s.Platforms {
+			plats = append(plats, theme.Platform.Render(p))
+		}
+		sb.WriteString(theme.Label.Render("target  ") + strings.Join(plats, "  ") + "\n")
+	}
+	if len(s.Requires) > 0 {
+		sb.WriteString(theme.Label.Render("deps    ") +
+			theme.Detail.Render(strings.Join(s.Requires, ", ")) + "\n")
+	}
+	return sb.String()
+}
+
+// renderSearchResults returns a multi-line, themed string listing every hit.
+// Layout is terminal-width-aware; every colour token is sourced from the
+// shared Theme so styling stays in sync with every other surface.
+func renderSearchResults(theme *ui.Theme, hits []registry.Skill, query string) string {
 	width := termWidth()
 	if width > 96 {
 		width = 96
@@ -85,37 +166,19 @@ func renderSearchResults(hits []registry.Skill, query string, noColor bool) stri
 	if width < 48 {
 		width = 48
 	}
-	inner := width - 4 // gutter on each side
-
-	var (
-		brand     = r.NewStyle().Bold(true).Foreground(lipgloss.Color("#A78BFA"))
-		crumb     = r.NewStyle().Foreground(lipgloss.Color("244"))
-		count     = r.NewStyle().Foreground(lipgloss.Color("244")).Italic(true)
-		rule      = r.NewStyle().Foreground(lipgloss.Color("238"))
-		bullet    = r.NewStyle().Foreground(lipgloss.Color("#A78BFA"))
-		nameStyle = r.NewStyle().Bold(true).Foreground(lipgloss.Color("#5EEAD4"))
-		version   = r.NewStyle().Foreground(lipgloss.Color("244"))
-		descStyle = r.NewStyle().Foreground(lipgloss.Color("252"))
-		tag       = r.NewStyle().Foreground(lipgloss.Color("#93C5FD"))
-		platform  = r.NewStyle().Foreground(lipgloss.Color("#F0ABFC"))
-		hit       = r.NewStyle().Bold(true).Foreground(lipgloss.Color("#FDE68A"))
-		label     = r.NewStyle().Foreground(lipgloss.Color("244"))
-	)
+	inner := width - 4
 
 	var sb strings.Builder
-
-	// Header: "  humblskills › search  "foo""
-	header := "  " + brand.Render("humblskills") + crumb.Render("  ›  search")
+	header := "  " + theme.Brand.Render("humblskills") + theme.Crumb.Render("  ›  search")
 	if query != "" {
-		header += crumb.Render("  ›  ") + hit.Render(fmt.Sprintf("%q", query))
+		header += theme.Crumb.Render("  ›  ") + theme.Hit.Render(fmt.Sprintf("%q", query))
 	}
 	sb.WriteString("\n")
 	sb.WriteString(header)
 	sb.WriteString("\n  ")
-	sb.WriteString(rule.Render(strings.Repeat("─", inner)))
+	sb.WriteString(theme.RuleLine.Render(strings.Repeat("─", inner)))
 	sb.WriteString("\n")
 
-	// Count line
 	noun := "skill"
 	if len(hits) != 1 {
 		noun = "skills"
@@ -127,41 +190,37 @@ func renderSearchResults(hits []registry.Skill, query string, noColor bool) stri
 		summary = fmt.Sprintf("%d %s in registry", len(hits), noun)
 	}
 	sb.WriteString("  ")
-	sb.WriteString(count.Render(summary))
+	sb.WriteString(theme.Count.Render(summary))
 	sb.WriteString("\n\n")
 
 	for i, s := range hits {
-		// Title line: ▸ name-with-highlight                              v0.1.0
-		left := bullet.Render("▸ ") + highlightName(s.Name, query, nameStyle, hit)
-		right := version.Render("v" + s.Version)
+		left := theme.Bullet.Render("▸ ") + highlightName(s.Name, query, theme.Name, theme.Hit)
+		right := theme.Version.Render("v" + s.Version)
 		pad := inner - lipgloss.Width(left) - lipgloss.Width(right)
 		if pad < 1 {
 			pad = 1
 		}
 		sb.WriteString("  " + left + strings.Repeat(" ", pad) + right + "\n")
 
-		// Description, soft-wrapped to inner-2 and indented.
 		if s.Description != "" {
-			wrapped := descStyle.Width(inner - 2).Render(s.Description)
+			wrapped := theme.Desc.Width(inner - 2).Render(s.Description)
 			for _, line := range strings.Split(wrapped, "\n") {
 				sb.WriteString("    " + line + "\n")
 			}
 		}
-
-		// Metadata: tags + platforms on one or two lines.
 		if len(s.Tags) > 0 {
 			chips := make([]string, 0, len(s.Tags))
 			for _, t := range s.Tags {
-				chips = append(chips, tag.Render("#"+t))
+				chips = append(chips, theme.Tag.Render("#"+t))
 			}
-			sb.WriteString("    " + label.Render("tags    ") + strings.Join(chips, "  ") + "\n")
+			sb.WriteString("    " + theme.Label.Render("tags    ") + strings.Join(chips, "  ") + "\n")
 		}
 		if len(s.Platforms) > 0 {
 			plats := make([]string, 0, len(s.Platforms))
 			for _, pl := range s.Platforms {
-				plats = append(plats, platform.Render(pl))
+				plats = append(plats, theme.Platform.Render(pl))
 			}
-			sb.WriteString("    " + label.Render("target  ") + strings.Join(plats, "  ") + "\n")
+			sb.WriteString("    " + theme.Label.Render("target  ") + strings.Join(plats, "  ") + "\n")
 		}
 
 		if i < len(hits)-1 {
@@ -169,20 +228,18 @@ func renderSearchResults(hits []registry.Skill, query string, noColor bool) stri
 		}
 	}
 
-	// Hint footer.
 	sb.WriteString("\n  ")
-	sb.WriteString(rule.Render(strings.Repeat("─", inner)))
+	sb.WriteString(theme.RuleLine.Render(strings.Repeat("─", inner)))
 	sb.WriteString("\n  ")
-	sb.WriteString(crumb.Render("install with  "))
-	sb.WriteString(nameStyle.Render("humblskills install <name>"))
+	sb.WriteString(theme.Crumb.Render("install with  "))
+	sb.WriteString(theme.Name.Render("humblskills install <name>"))
 	sb.WriteString("\n")
 
 	return sb.String()
 }
 
-// highlightName returns the skill name with case-insensitive query matches
-// wrapped in the hit style. The non-matching parts are rendered with base.
-// If query is empty, the name is returned under base untouched.
+// highlightName wraps every case-insensitive query match inside hit style,
+// leaving non-matching segments in base. Empty query → untouched name.
 func highlightName(name, query string, base, hit lipgloss.Style) string {
 	if query == "" {
 		return base.Render(name)
@@ -214,8 +271,6 @@ func highlightName(name, query string, base, hit lipgloss.Style) string {
 	return sb.String()
 }
 
-// termWidth returns a sensible content width, falling back to 80 when stdout
-// isn't a TTY (piped output, CI, tests).
 func termWidth() int {
 	if w, _, err := term.GetSize(int(os.Stdout.Fd())); err == nil && w > 0 {
 		return w

--- a/cli/cmd/humblskills/uninstall.go
+++ b/cli/cmd/humblskills/uninstall.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/jjfantini/humblSKILLS/cli/internal/install"
 	"github.com/jjfantini/humblSKILLS/cli/internal/manifest"
+	"github.com/jjfantini/humblSKILLS/cli/internal/tui"
 )
 
 func newUninstallCmd(app *App) *cobra.Command {
@@ -15,44 +16,68 @@ func newUninstallCmd(app *App) *cobra.Command {
 		Short: "Remove an installed skill from every target",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			skill := args[0]
-
-			m, err := manifest.Load(app.Config.ManifestPath)
-			if err != nil {
-				return fmt.Errorf("load manifest: %w", err)
-			}
-			entries := m.FindAll(skill)
-			if len(entries) == 0 {
-				app.UI.Warn("%s is not installed", skill)
-				return nil
-			}
-
-			ok, err := app.Prompt.Confirm(
-				fmt.Sprintf("Remove %s from %d target%s?", skill, len(entries), plural(len(entries))),
-				true,
-			)
-			if err != nil {
-				return err
-			}
-			if !ok {
-				app.UI.Info("cancelled")
-				return nil
-			}
-
-			engine := install.NewEngine(app.Config.CacheDir, app.Config.ManifestPath)
-			res, err := engine.Uninstall(skill)
-			if err != nil {
-				return err
-			}
-			if app.Config.JSON {
-				return app.UI.JSON(struct {
-					Results []install.TargetResult `json:"results"`
-				}{res})
-			}
-			for _, t := range res {
-				app.UI.Success("removed %s [%s/%s]", t.Skill, t.Platform, t.Scope)
-			}
-			return nil
+			return runUninstall(app, args[0])
 		},
 	}
+}
+
+// runUninstall performs the interactive uninstall flow. Extracted from the
+// cobra RunE so the list TUI can route an 'x' action back through exactly the
+// same confirm + engine + print path.
+func runUninstall(app *App, skill string) error {
+	m, err := manifest.Load(app.Config.ManifestPath)
+	if err != nil {
+		return fmt.Errorf("load manifest: %w", err)
+	}
+	entries := m.FindAll(skill)
+	if len(entries) == 0 {
+		app.UI.Warn("%s is not installed", skill)
+		return nil
+	}
+
+	// Show exactly what's about to be removed before asking.
+	theme := app.UI.Theme()
+	lines := make([]string, 0, len(entries))
+	for _, e := range entries {
+		lines = append(lines, fmt.Sprintf(
+			"%s  %s  %s",
+			theme.Name.Render(e.Skill+"@"+e.Version),
+			theme.Platform.Render("["+e.Platform+"/"+e.Scope+"]"),
+			theme.Detail.Render(e.Path),
+		))
+	}
+	ok := true
+	if !app.Config.Yes && !app.Config.JSON {
+		got, err := tui.ConfirmWithSummary(
+			theme,
+			fmt.Sprintf("Uninstall %s", skill),
+			fmt.Sprintf("Remove %d target%s?", len(entries), plural(len(entries))),
+			lines,
+			true,
+			app.Prompt.Interactive,
+		)
+		if err != nil {
+			return err
+		}
+		ok = got
+	}
+	if !ok {
+		app.UI.Info("cancelled")
+		return nil
+	}
+
+	engine := install.NewEngine(app.Config.CacheDir, app.Config.ManifestPath)
+	res, err := engine.Uninstall(skill)
+	if err != nil {
+		return err
+	}
+	if app.Config.JSON {
+		return app.UI.JSON(struct {
+			Results []install.TargetResult `json:"results"`
+		}{res})
+	}
+	for _, t := range res {
+		app.UI.Success("removed %s [%s/%s]", t.Skill, t.Platform, t.Scope)
+	}
+	return nil
 }

--- a/cli/cmd/humblskills/update.go
+++ b/cli/cmd/humblskills/update.go
@@ -9,6 +9,7 @@ import (
 	"github.com/jjfantini/humblSKILLS/cli/internal/install"
 	"github.com/jjfantini/humblSKILLS/cli/internal/manifest"
 	"github.com/jjfantini/humblSKILLS/cli/internal/registry"
+	"github.com/jjfantini/humblSKILLS/cli/internal/tui"
 	"github.com/jjfantini/humblSKILLS/cli/internal/ui"
 )
 
@@ -85,44 +86,60 @@ func runUpdate(app *App, only []string, f updateFlags) error {
 	}
 
 	engine := install.NewEngine(app.Config.CacheDir, app.Config.ManifestPath)
+	useTUI := tui.ShouldUseTUI(app.Config.JSON, app.Config.Quiet, app.Config.Yes)
 	var aggregate install.Result
-	for _, plan := range selected {
-		stepPlan, err := install.Plan(reg, plan.Skill)
-		if err != nil {
+
+	run := func(sink install.EventSink) error {
+		for _, plan := range selected {
+			stepPlan, err := install.Plan(reg, plan.Skill)
+			if err != nil {
+				return err
+			}
+
+			// Group existing targets by scope; within each scope, the set of
+			// platforms is exactly the adapters this skill is currently installed
+			// onto. Skip platforms the binary no longer knows about (warn once).
+			byScope := map[string][]string{}
+			for _, t := range plan.Targets {
+				if _, ok := adapterKnown[t.Platform]; !ok {
+					app.UI.Warn("skipping unknown platform %q in manifest for %s", t.Platform, plan.Skill)
+					continue
+				}
+				byScope[t.Scope] = append(byScope[t.Scope], t.Platform)
+			}
+
+			scopes := make([]string, 0, len(byScope))
+			for s := range byScope {
+				scopes = append(scopes, s)
+			}
+			sort.Strings(scopes)
+
+			for _, scope := range scopes {
+				plats := byScope[scope]
+				sort.Strings(plats)
+				res, err := engine.Execute(reg, stepPlan, install.ExecuteOpts{
+					Adapters:  adapters,
+					Platforms: plats,
+					Scope:     scope,
+					Force:     true,
+					OnEvent:   sink,
+				})
+				if err != nil {
+					return fmt.Errorf("%s: %w", plan.Skill, err)
+				}
+				aggregate.Results = append(aggregate.Results, res.Results...)
+			}
+		}
+		return nil
+	}
+
+	if useTUI {
+		if err := tui.ExecuteWithProgress(app.UI.Theme(), "update", run); err != nil {
 			return err
 		}
-
-		// Group existing targets by scope; within each scope, the set of
-		// platforms is exactly the adapters this skill is currently installed
-		// onto. Skip platforms the binary no longer knows about (warn once).
-		byScope := map[string][]string{}
-		for _, t := range plan.Targets {
-			if _, ok := adapterKnown[t.Platform]; !ok {
-				app.UI.Warn("skipping unknown platform %q in manifest for %s", t.Platform, plan.Skill)
-				continue
-			}
-			byScope[t.Scope] = append(byScope[t.Scope], t.Platform)
-		}
-
-		scopes := make([]string, 0, len(byScope))
-		for s := range byScope {
-			scopes = append(scopes, s)
-		}
-		sort.Strings(scopes)
-
-		for _, scope := range scopes {
-			plats := byScope[scope]
-			sort.Strings(plats)
-			res, err := engine.Execute(reg, stepPlan, install.ExecuteOpts{
-				Adapters:  adapters,
-				Platforms: plats,
-				Scope:     scope,
-				Force:     true,
-			})
-			if err != nil {
-				return fmt.Errorf("%s: %w", plan.Skill, err)
-			}
-			aggregate.Results = append(aggregate.Results, res.Results...)
+	} else {
+		if err := run(nil); err != nil {
+			return err
 		}
 	}
 

--- a/cli/cmd/humblskills/version.go
+++ b/cli/cmd/humblskills/version.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"runtime/debug"
 
 	"github.com/spf13/cobra"
@@ -27,11 +28,18 @@ func newVersionCmd(app *App) *cobra.Command {
 			if app.Config.JSON {
 				return app.UI.JSON(info)
 			}
+			th := app.UI.Theme()
 			suffix := ""
 			if info.Dirty {
-				suffix = " (dirty)"
+				suffix = th.Warn.Render(" (dirty)")
 			}
-			app.UI.Info("humblskills %s  commit %s%s", info.Version, info.Commit, suffix)
+			wordmark := th.Brand.Bold(true).Render("humblskills")
+			ver := th.Name.Render(info.Version)
+			sha := th.Detail.Render("commit " + info.Commit)
+			fmt.Fprintln(app.UI.Out(), "")
+			fmt.Fprintln(app.UI.Out(), "  "+wordmark+"  "+ver+suffix)
+			fmt.Fprintln(app.UI.Out(), "  "+sha)
+			fmt.Fprintln(app.UI.Out(), "")
 			return nil
 		},
 	}

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -4,6 +4,8 @@ go 1.23.0
 
 require (
 	github.com/adrg/xdg v0.5.3
+	github.com/charmbracelet/bubbles v0.21.0
+	github.com/charmbracelet/bubbletea v1.3.4
 	github.com/charmbracelet/huh v0.6.0
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/muesli/termenv v0.16.0
@@ -17,9 +19,8 @@ require (
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/catppuccin/go v0.3.0 // indirect
-	github.com/charmbracelet/bubbles v0.21.0 // indirect
-	github.com/charmbracelet/bubbletea v1.3.4 // indirect
 	github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc // indirect
+	github.com/charmbracelet/harmonica v0.2.0 // indirect
 	github.com/charmbracelet/x/ansi v0.9.3 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.13 // indirect
 	github.com/charmbracelet/x/exp/strings v0.0.0-20240722160745-212f7b056ed0 // indirect
@@ -35,6 +36,7 @@ require (
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
+	github.com/sahilm/fuzzy v0.1.1 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	golang.org/x/sync v0.15.0 // indirect

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -16,6 +16,8 @@ github.com/charmbracelet/bubbletea v1.3.4 h1:kCg7B+jSCFPLYRA52SDZjr51kG/fMUEoPoZ
 github.com/charmbracelet/bubbletea v1.3.4/go.mod h1:dtcUCyCGEX3g9tosuYiut3MXgY/Jsv9nKVdibKKRRXo=
 github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc h1:4pZI35227imm7yK2bGPcfpFEmuY1gc2YSTShr4iJBfs=
 github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc/go.mod h1:X4/0JoqgTIPSFcRA/P6INZzIuyqdFY5rm8tb41s9okk=
+github.com/charmbracelet/harmonica v0.2.0 h1:8NxJWRWg/bzKqqEaaeFNipOu77YR5t8aSwG4pgaUBiQ=
+github.com/charmbracelet/harmonica v0.2.0/go.mod h1:KSri/1RMQOZLbw7AHqgcBycp8pgJnQMYYT8QZRqZ1Ao=
 github.com/charmbracelet/huh v0.6.0 h1:mZM8VvZGuE0hoDXq6XLxRtgfWyTI3b2jZNKh0xWmax8=
 github.com/charmbracelet/huh v0.6.0/go.mod h1:GGNKeWCeNzKpEOh/OJD8WBwTQjV3prFAtQPpLv+AVwU=
 github.com/charmbracelet/lipgloss v1.1.0 h1:vYXsiLHVkK7fp74RkV7b2kq9+zDLoEU4MZoFqR/noCY=
@@ -39,6 +41,8 @@ github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97MGsxSvLiUE2X8qFplwetxpGLQrlU1Q9AUEIzCaM=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
+github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=
 github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
@@ -61,6 +65,8 @@ github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJ
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/sahilm/fuzzy v0.1.1 h1:ceu5RHF8DGgoi+/dR5PsECjCDH1BE3Fnmpo7aVXOdRA=
+github.com/sahilm/fuzzy v0.1.1/go.mod h1:VFvziUEIMCrT6A6tw2RFIXPXXmzXbOsSHF0DOI8ZK9Y=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
 github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
 github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=

--- a/cli/internal/install/engine.go
+++ b/cli/internal/install/engine.go
@@ -75,6 +75,10 @@ type ExecuteOpts struct {
 	// Force causes existing targets to be replaced even when the manifest
 	// shows they're up-to-date.
 	Force bool
+	// OnEvent, when set, receives progress notifications as the run proceeds.
+	// Callers that don't need progress (tests, --json, scripts) can leave it
+	// nil. See events.go for Phase semantics.
+	OnEvent EventSink
 }
 
 // Execute runs the plan: fetch each skill, verify its content hash, and place
@@ -103,18 +107,58 @@ func (e *Engine) Execute(reg *registry.Registry, plan []Step, opts ExecuteOpts) 
 		return res, fmt.Errorf("load manifest: %w", err)
 	}
 
+	total := countTargets(plan, opts.Platforms)
+	opts.OnEvent.emit(Event{Phase: PhaseRunStart, Total: total})
+
 	for _, step := range plan {
+		opts.OnEvent.emit(Event{
+			Phase: PhaseStepStart,
+			Skill: step.Skill.Name,
+			IsDep: step.IsDep,
+		})
 		stepRes, err := e.installOne(reg, step, opts, adapterIndex, m)
 		if err != nil {
+			opts.OnEvent.emit(Event{
+				Phase: PhaseError,
+				Skill: step.Skill.Name,
+				Err:   err,
+			})
 			return res, fmt.Errorf("%s: %w", step.Skill.Name, err)
 		}
 		res.Results = append(res.Results, stepRes...)
 	}
 
 	if err := manifest.Save(e.ManifestPath, m); err != nil {
+		opts.OnEvent.emit(Event{Phase: PhaseError, Err: err})
 		return res, fmt.Errorf("save manifest: %w", err)
 	}
+	opts.OnEvent.emit(Event{Phase: PhaseRunDone, Total: total})
 	return res, nil
+}
+
+// countTargets walks plan and totals the (skill, platform, scope) triples the
+// run will visit, honouring each skill's platforms[] allow-list. Cheap, keeps
+// progress denominators honest without guesswork.
+func countTargets(plan []Step, platforms []string) int {
+	total := 0
+	for _, step := range plan {
+		allow := map[string]struct{}{}
+		if len(step.Skill.Platforms) == 0 {
+			for _, p := range platforms {
+				allow[p] = struct{}{}
+			}
+		} else {
+			for _, p := range step.Skill.Platforms {
+				allow[p] = struct{}{}
+			}
+		}
+		for _, p := range platforms {
+			if _, ok := allow[p]; ok {
+				total++
+			}
+		}
+	}
+	return total
 }
 
 func (e *Engine) installOne(
@@ -202,9 +246,17 @@ func (e *Engine) installOne(
 		}
 		switch {
 		case upToDate && !opts.Force:
+			opts.OnEvent.emit(Event{
+				Phase: PhaseTargetStart, Skill: skill.Name, IsDep: step.IsDep,
+				Platform: pg.adapter.Name, Scope: pg.target.Scope,
+			})
 			skipped = append(skipped, TargetResult{
 				Skill: skill.Name, Platform: pg.adapter.Name, Scope: pg.target.Scope,
 				Path: dest, Outcome: OutcomeSkipped,
+			})
+			opts.OnEvent.emit(Event{
+				Phase: PhaseTargetDone, Skill: skill.Name, IsDep: step.IsDep,
+				Platform: pg.adapter.Name, Scope: pg.target.Scope, Outcome: OutcomeSkipped,
 			})
 		case upToDate && opts.Force:
 			toWrite = append(toWrite, planTarget{pending: pg, out: OutcomeForced, final: dest, orphan: orphan, existingPath: existingPath})
@@ -242,6 +294,10 @@ func (e *Engine) installOne(
 
 	results := append([]TargetResult(nil), skipped...)
 	for _, pt := range toWrite {
+		opts.OnEvent.emit(Event{
+			Phase: PhaseTargetStart, Skill: skill.Name, IsDep: step.IsDep,
+			Platform: pt.pending.adapter.Name, Scope: pt.pending.target.Scope,
+		})
 		// When preserve is active, build a per-target copy of staging with
 		// user content merged in, leaving the shared staging pristine for
 		// sibling targets. pt.existingPath is the authoritative previous
@@ -289,6 +345,11 @@ func (e *Engine) installOne(
 			Scope:    pt.pending.target.Scope,
 			Path:     pt.final,
 			Outcome:  pt.out,
+		})
+		opts.OnEvent.emit(Event{
+			Phase: PhaseTargetDone, Skill: skill.Name, IsDep: step.IsDep,
+			Platform: pt.pending.adapter.Name, Scope: pt.pending.target.Scope,
+			Outcome: pt.out,
 		})
 	}
 	return results, nil

--- a/cli/internal/install/events.go
+++ b/cli/internal/install/events.go
@@ -1,0 +1,49 @@
+package install
+
+// Phase names one moment in an install run that the UI layer might want to
+// reflect (progress bar ticks, spinner labels, log lines).
+type Phase string
+
+const (
+	// PhaseRunStart fires once, before any step, with Total set to the number
+	// of (skill, platform, scope) triples that will be visited.
+	PhaseRunStart Phase = "run_start"
+	// PhaseStepStart fires once per planned skill, before its targets are
+	// processed. IsDep distinguishes transitive deps from the root skill.
+	PhaseStepStart Phase = "step_start"
+	// PhaseTargetStart fires when work begins on one (skill, platform, scope)
+	// triple. The skill may still be shared across targets via staging.
+	PhaseTargetStart Phase = "target_start"
+	// PhaseTargetDone fires when a single target finishes. Outcome names the
+	// terminal state (installed / replaced / skipped / forced).
+	PhaseTargetDone Phase = "target_done"
+	// PhaseRunDone fires once, after every step has been processed.
+	PhaseRunDone Phase = "run_done"
+	// PhaseError fires when a target fails; the caller can show Err and abort.
+	PhaseError Phase = "error"
+)
+
+// Event is a single progress notification emitted by the engine. Not every
+// field is populated for every Phase — Total is only meaningful on RunStart,
+// Outcome only on TargetDone, Err only on Error.
+type Event struct {
+	Phase    Phase
+	Skill    string
+	Platform string
+	Scope    string
+	IsDep    bool
+	Total    int
+	Outcome  Outcome
+	Err      error
+}
+
+// EventSink receives engine progress events. Callers that don't care about
+// progress (tests, scripts, --json consumers) can pass nil.
+type EventSink func(Event)
+
+// emit is a nil-safe helper so call-sites don't have to guard.
+func (s EventSink) emit(ev Event) {
+	if s != nil {
+		s(ev)
+	}
+}

--- a/cli/internal/tui/app.go
+++ b/cli/internal/tui/app.go
@@ -1,0 +1,35 @@
+// Package tui hosts every bubbletea model + shared TUI chrome used by the
+// humblskills CLI. Each command's "interactive" mode (browse, wizard, confirm)
+// lives here so the visual frame — header, keybar, palette — stays consistent
+// across commands.
+//
+// Callers are expected to check ShouldUseTUI before invoking anything here;
+// when that returns false the command should fall back to its static
+// (pipe-friendly, --json-safe) path.
+package tui
+
+import (
+	"os"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"golang.org/x/term"
+)
+
+// ShouldUseTUI reports whether the caller can safely take over the screen with
+// an alt-screen bubbletea model. It's false whenever the user opted out
+// explicitly (--json, --quiet, --yes) or the process isn't attached to a TTY
+// on both stdin and stdout.
+func ShouldUseTUI(jsonMode, quiet, yes bool) bool {
+	if jsonMode || quiet || yes {
+		return false
+	}
+	return term.IsTerminal(int(os.Stdin.Fd())) && term.IsTerminal(int(os.Stdout.Fd()))
+}
+
+// Run starts a bubbletea program using the shared set of program options
+// (alt-screen + mouse cell motion). It blocks until the model finishes and
+// returns the last rendered model so callers can extract results.
+func Run(m tea.Model) (tea.Model, error) {
+	p := tea.NewProgram(m, tea.WithAltScreen(), tea.WithMouseCellMotion())
+	return p.Run()
+}

--- a/cli/internal/tui/browse.go
+++ b/cli/internal/tui/browse.go
@@ -1,0 +1,305 @@
+package tui
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/key"
+	"github.com/charmbracelet/bubbles/list"
+	"github.com/charmbracelet/bubbles/viewport"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/jjfantini/humblSKILLS/cli/internal/ui"
+)
+
+// BrowseItem is the contract for a row shown in the browser. Commands
+// implement it over their domain type (registry.Skill for search, a manifest
+// entry for list) so a single model drives both surfaces.
+type BrowseItem interface {
+	list.Item
+	Title() string
+	Description() string
+	// Preview returns the right-pane content. width is the viewport's usable
+	// width — implementations should wrap to honour it.
+	Preview(theme *ui.Theme, width int) string
+}
+
+// BrowseAction names the shortcut the user pressed to exit the browser.
+type BrowseAction string
+
+const (
+	ActionNone      BrowseAction = ""
+	ActionInstall   BrowseAction = "install"
+	ActionUpdate    BrowseAction = "update"
+	ActionUninstall BrowseAction = "uninstall"
+	ActionQuit      BrowseAction = "quit"
+)
+
+// BrowserConfig parametrises NewBrowser.
+type BrowserConfig struct {
+	// Command is the breadcrumb label, e.g. "search" or "installed".
+	Command string
+	// Detail optionally appears after the breadcrumb, e.g. a query.
+	Detail string
+	// Theme drives every rendered colour.
+	Theme *ui.Theme
+	// Items populate the left-side list.
+	Items []BrowseItem
+	// Actions is the set of action shortcuts that should exit the browser.
+	// Include ActionInstall in search mode; ActionUpdate + ActionUninstall in
+	// installed-list mode.
+	Actions []BrowseAction
+	// EmptyMsg is shown when Items is empty.
+	EmptyMsg string
+}
+
+// BrowseResult is what Browser.Selected returns after Run exits.
+type BrowseResult struct {
+	Action BrowseAction
+	Item   BrowseItem
+}
+
+// Browser is a bubbletea model: left-side filterable list, right-side preview
+// pane, shared header/footer chrome. All rendering honours cfg.Theme so it
+// looks identical to every other humblskills TUI surface.
+type Browser struct {
+	cfg      BrowserConfig
+	list     list.Model
+	preview  viewport.Model
+	width    int
+	height   int
+	result   BrowseResult
+	keys     Keys
+	actionOn map[BrowseAction]bool
+}
+
+// NewBrowser builds a Browser ready to hand to Run. Callers typically do:
+//
+//	res, err := tui.Run(tui.NewBrowser(cfg))
+//	m := res.(tui.Browser)
+//	switch m.Selected().Action { ... }
+func NewBrowser(cfg BrowserConfig) Browser {
+	items := make([]list.Item, len(cfg.Items))
+	for i, it := range cfg.Items {
+		items[i] = it
+	}
+
+	delegate := newBrowseDelegate(cfg.Theme)
+	l := list.New(items, delegate, 0, 0)
+	l.Title = cfg.EmptyMsg // reused as header message slot when empty
+	l.SetShowTitle(false)
+	l.SetShowStatusBar(false)
+	l.SetShowHelp(false)
+	l.SetFilteringEnabled(true)
+	l.SetShowFilter(true)
+	l.SetShowPagination(true)
+	l.DisableQuitKeybindings()
+
+	actionOn := map[BrowseAction]bool{}
+	for _, a := range cfg.Actions {
+		actionOn[a] = true
+	}
+
+	vp := viewport.New(0, 0)
+	return Browser{
+		cfg:      cfg,
+		list:     l,
+		preview:  vp,
+		keys:     DefaultKeys(),
+		actionOn: actionOn,
+	}
+}
+
+// Selected returns the chosen item + action once the browser has exited.
+func (b Browser) Selected() BrowseResult { return b.result }
+
+func (b Browser) Init() tea.Cmd { return nil }
+
+func (b Browser) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		b.width, b.height = msg.Width, msg.Height
+		b.resize()
+		b.refreshPreview()
+		return b, nil
+
+	case tea.KeyMsg:
+		// Never steal keys while the user is typing in the filter input.
+		if b.list.FilterState() == list.Filtering {
+			break
+		}
+		switch {
+		case key.Matches(msg, b.keys.Quit):
+			b.result = BrowseResult{Action: ActionQuit}
+			return b, tea.Quit
+		case key.Matches(msg, b.keys.Enter):
+			if b.actionOn[ActionInstall] {
+				return b.exitWith(ActionInstall)
+			}
+			if b.actionOn[ActionUpdate] {
+				return b.exitWith(ActionUpdate)
+			}
+		}
+		switch msg.String() {
+		case "i":
+			if b.actionOn[ActionInstall] {
+				return b.exitWith(ActionInstall)
+			}
+		case "u":
+			if b.actionOn[ActionUpdate] {
+				return b.exitWith(ActionUpdate)
+			}
+		case "x":
+			if b.actionOn[ActionUninstall] {
+				return b.exitWith(ActionUninstall)
+			}
+		}
+	}
+
+	var cmd tea.Cmd
+	prevIdx := b.list.Index()
+	b.list, cmd = b.list.Update(msg)
+	if b.list.Index() != prevIdx {
+		b.refreshPreview()
+	}
+	return b, cmd
+}
+
+func (b Browser) View() string {
+	th := b.cfg.Theme
+	header := Header(th, b.cfg.Command, b.cfg.Detail, b.width)
+
+	body := b.renderBody()
+	footer := Footer(th, b.hints())
+	bodyHeight := b.height - lipgloss.Height(header) - lipgloss.Height(footer) - 3
+	if bodyHeight < 5 {
+		bodyHeight = 5
+	}
+	return Frame(header, body, footer, bodyHeight)
+}
+
+func (b Browser) renderBody() string {
+	if len(b.cfg.Items) == 0 {
+		return "  " + b.cfg.Theme.Detail.Render(b.cfg.EmptyMsg)
+	}
+	left := b.list.View()
+	right := b.preview.View()
+	row := lipgloss.JoinHorizontal(lipgloss.Top, left, "  ", right)
+	return row
+}
+
+func (b Browser) hints() []KeyHint {
+	hints := []KeyHint{
+		{Keys: "↑/↓", Label: "navigate"},
+		{Keys: "/", Label: "filter"},
+	}
+	if b.actionOn[ActionInstall] {
+		hints = append(hints, KeyHint{Keys: "enter/i", Label: "install"})
+	}
+	if b.actionOn[ActionUpdate] {
+		hints = append(hints, KeyHint{Keys: "u", Label: "update"})
+	}
+	if b.actionOn[ActionUninstall] {
+		hints = append(hints, KeyHint{Keys: "x", Label: "uninstall"})
+	}
+	hints = append(hints, KeyHint{Keys: "q", Label: "quit"})
+	return hints
+}
+
+func (b *Browser) exitWith(a BrowseAction) (tea.Model, tea.Cmd) {
+	selected, ok := b.list.SelectedItem().(BrowseItem)
+	if !ok {
+		return *b, nil
+	}
+	b.result = BrowseResult{Action: a, Item: selected}
+	return *b, tea.Quit
+}
+
+func (b *Browser) resize() {
+	if b.width == 0 || b.height == 0 {
+		return
+	}
+	// Header (2 lines) + blank + footer (1 line) + blank = 5 rows of chrome.
+	bodyHeight := b.height - 6
+	if bodyHeight < 5 {
+		bodyHeight = 5
+	}
+	leftW := b.width / 3
+	if leftW < 24 {
+		leftW = 24
+	}
+	if leftW > 44 {
+		leftW = 44
+	}
+	rightW := b.width - leftW - 4
+	if rightW < 20 {
+		rightW = 20
+	}
+	b.list.SetSize(leftW, bodyHeight)
+	b.preview.Width = rightW
+	b.preview.Height = bodyHeight
+}
+
+func (b *Browser) refreshPreview() {
+	it, ok := b.list.SelectedItem().(BrowseItem)
+	if !ok {
+		b.preview.SetContent("")
+		return
+	}
+	b.preview.SetContent(it.Preview(b.cfg.Theme, b.preview.Width))
+	b.preview.GotoTop()
+}
+
+// browseDelegate renders each row with our palette. Two lines per row: bold
+// title + muted description. On selection the bullet + title pick up brand
+// colour so the active row is unambiguous.
+type browseDelegate struct {
+	theme *ui.Theme
+}
+
+func newBrowseDelegate(t *ui.Theme) browseDelegate { return browseDelegate{theme: t} }
+
+func (d browseDelegate) Height() int  { return 2 }
+func (d browseDelegate) Spacing() int { return 1 }
+
+func (d browseDelegate) Update(_ tea.Msg, _ *list.Model) tea.Cmd { return nil }
+
+func (d browseDelegate) Render(w io.Writer, m list.Model, index int, item list.Item) {
+	it, ok := item.(BrowseItem)
+	if !ok {
+		return
+	}
+	selected := index == m.Index()
+
+	title := it.Title()
+	desc := it.Description()
+
+	var titleStyle, descStyle lipgloss.Style
+	var bullet string
+	if selected {
+		bullet = d.theme.Bullet.Render("▸ ")
+		titleStyle = d.theme.Name
+		descStyle = d.theme.Detail
+	} else {
+		bullet = "  "
+		titleStyle = d.theme.Info.Bold(false)
+		descStyle = d.theme.Detail
+	}
+
+	fmt.Fprintln(w, bullet+titleStyle.Render(title))
+	if desc != "" {
+		fmt.Fprintln(w, "  "+descStyle.Render(trimOne(desc)))
+	} else {
+		fmt.Fprintln(w, "")
+	}
+}
+
+// trimOne clips to one line so the two-line delegate height stays consistent.
+func trimOne(s string) string {
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		return s[:i]
+	}
+	return s
+}

--- a/cli/internal/tui/chrome.go
+++ b/cli/internal/tui/chrome.go
@@ -1,0 +1,72 @@
+package tui
+
+import (
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/jjfantini/humblSKILLS/cli/internal/ui"
+)
+
+// Header renders the standard breadcrumb that sits atop every TUI model:
+//
+//	  humblskills › <command> › <detail>
+//	  ──────────────────────────────────
+//
+// detail may be empty. width bounds the rule line so the frame keeps its shape
+// on narrow terminals.
+func Header(theme *ui.Theme, command, detail string, width int) string {
+	if width < 20 {
+		width = 20
+	}
+	line := "  " + theme.Brand.Render("humblskills") +
+		theme.Crumb.Render("  ›  "+command)
+	if detail != "" {
+		line += theme.Crumb.Render("  ›  ") + theme.Hit.Render(detail)
+	}
+	rule := theme.RuleLine.Render(strings.Repeat("─", max(width-4, 4)))
+	return line + "\n  " + rule
+}
+
+// KeyHint is one "label → keys" pair shown in the footer keybar.
+type KeyHint struct {
+	Keys  string
+	Label string
+}
+
+// Footer renders the shared keybar. Example:
+//
+//	  ↑/↓ navigate · / filter · enter select · q quit
+func Footer(theme *ui.Theme, hints []KeyHint) string {
+	var parts []string
+	for _, h := range hints {
+		parts = append(parts, theme.Name.Render(h.Keys)+" "+theme.Crumb.Render(h.Label))
+	}
+	return "  " + strings.Join(parts, theme.Crumb.Render(" · "))
+}
+
+// Frame composes header + body + footer into a single renderable string,
+// padding the body to bodyHeight rows so the footer sits at a predictable
+// place regardless of content length.
+func Frame(header, body, footer string, bodyHeight int) string {
+	body = padToHeight(body, bodyHeight)
+	return header + "\n\n" + body + "\n\n" + footer
+}
+
+func padToHeight(s string, h int) string {
+	if h <= 0 {
+		return s
+	}
+	lines := lipgloss.Height(s)
+	if lines >= h {
+		return s
+	}
+	return s + strings.Repeat("\n", h-lines)
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/cli/internal/tui/confirm.go
+++ b/cli/internal/tui/confirm.go
@@ -1,0 +1,51 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/huh"
+
+	"github.com/jjfantini/humblSKILLS/cli/internal/ui"
+)
+
+// ConfirmWithSummary renders a framed summary panel listing the items being
+// acted on, then asks the user to confirm via the shared huh theme. Use it for
+// destructive actions (uninstall, force-reinstall) where the user should see
+// exactly what's about to change before they press enter.
+//
+// Returns (answer, error). When the process isn't interactive, the panel is
+// still printed (so CI logs show intent) but the confirm falls back to dflt.
+func ConfirmWithSummary(
+	theme *ui.Theme,
+	title, prompt string,
+	lines []string,
+	dflt bool,
+	interactive bool,
+) (bool, error) {
+	fmt.Println()
+	fmt.Println("  " + theme.Brand.Render(title))
+	fmt.Println()
+	if len(lines) > 0 {
+		body := strings.Join(lines, "\n")
+		fmt.Println(theme.Panel.Render(body))
+		fmt.Println()
+	}
+
+	if !interactive {
+		return dflt, nil
+	}
+
+	v := dflt
+	err := huh.NewConfirm().
+		Title(prompt).
+		Affirmative("Yes").
+		Negative("No").
+		Value(&v).
+		WithTheme(ui.HuhTheme(theme)).
+		Run()
+	if err != nil {
+		return dflt, err
+	}
+	return v, nil
+}

--- a/cli/internal/tui/keymap.go
+++ b/cli/internal/tui/keymap.go
@@ -1,0 +1,61 @@
+package tui
+
+import "github.com/charmbracelet/bubbles/key"
+
+// Keys is the canonical set of key.Bindings reused across every TUI model in
+// humblskills. Models extend it rather than defining their own so users learn
+// one keymap and every command honours it.
+type Keys struct {
+	Up     key.Binding
+	Down   key.Binding
+	Left   key.Binding
+	Right  key.Binding
+	Filter key.Binding
+	Enter  key.Binding
+	Back   key.Binding
+	Help   key.Binding
+	Quit   key.Binding
+}
+
+// DefaultKeys returns the shared bindings. Arrow keys + vim-style hjkl so both
+// camps feel at home.
+func DefaultKeys() Keys {
+	return Keys{
+		Up: key.NewBinding(
+			key.WithKeys("up", "k"),
+			key.WithHelp("↑/k", "up"),
+		),
+		Down: key.NewBinding(
+			key.WithKeys("down", "j"),
+			key.WithHelp("↓/j", "down"),
+		),
+		Left: key.NewBinding(
+			key.WithKeys("left", "h"),
+			key.WithHelp("←/h", "left"),
+		),
+		Right: key.NewBinding(
+			key.WithKeys("right", "l"),
+			key.WithHelp("→/l", "right"),
+		),
+		Filter: key.NewBinding(
+			key.WithKeys("/"),
+			key.WithHelp("/", "filter"),
+		),
+		Enter: key.NewBinding(
+			key.WithKeys("enter"),
+			key.WithHelp("enter", "select"),
+		),
+		Back: key.NewBinding(
+			key.WithKeys("esc"),
+			key.WithHelp("esc", "back"),
+		),
+		Help: key.NewBinding(
+			key.WithKeys("?"),
+			key.WithHelp("?", "help"),
+		),
+		Quit: key.NewBinding(
+			key.WithKeys("q", "ctrl+c"),
+			key.WithHelp("q", "quit"),
+		),
+	}
+}

--- a/cli/internal/tui/progress.go
+++ b/cli/internal/tui/progress.go
@@ -1,0 +1,284 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/progress"
+	"github.com/charmbracelet/bubbles/spinner"
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/jjfantini/humblSKILLS/cli/internal/install"
+	"github.com/jjfantini/humblSKILLS/cli/internal/ui"
+)
+
+// ProgressEventMsg wraps an install.Event for the bubbletea runtime so the
+// ProgressModel can react to engine progress without the caller exposing
+// internal types.
+type ProgressEventMsg struct{ Event install.Event }
+
+// ProgressDoneMsg signals that the engine goroutine has finished. Err is nil
+// on success; on failure it's the error the engine returned.
+type ProgressDoneMsg struct{ Err error }
+
+// Subscribe returns a tea.Cmd that reads the next engine event from ch. When
+// the channel is closed, it emits ProgressDoneMsg{Err: doneErr} where doneErr
+// is whatever the caller placed on the doneErr channel — typically the error
+// returned by engine.Execute.
+//
+// Compose with bubbletea by re-issuing Subscribe from every ProgressEventMsg
+// handler so the model keeps draining ch until it closes.
+func Subscribe(ch <-chan install.Event, doneErr <-chan error) tea.Cmd {
+	return func() tea.Msg {
+		ev, ok := <-ch
+		if !ok {
+			var err error
+			select {
+			case err = <-doneErr:
+			default:
+			}
+			return ProgressDoneMsg{Err: err}
+		}
+		return ProgressEventMsg{Event: ev}
+	}
+}
+
+// ProgressModel renders a framed progress bar + per-target status list driven
+// by install engine events. Use alongside a goroutine that wraps
+// engine.Execute and forwards events onto a channel.
+type ProgressModel struct {
+	theme   *ui.Theme
+	command string // breadcrumb detail, e.g. "install" or "update"
+	bar     progress.Model
+	spin    spinner.Model
+	items   []*progressEntry
+	keyed   map[string]*progressEntry
+	total   int
+	done    int
+	width   int
+	current *progressEntry
+	err     error
+	running bool
+	events  <-chan install.Event
+	doneErr <-chan error
+}
+
+type progressEntry struct {
+	skill    string
+	platform string
+	scope    string
+	outcome  install.Outcome
+	done     bool
+	errored  bool
+}
+
+func (p *progressEntry) key() string {
+	return p.skill + "\x00" + p.platform + "\x00" + p.scope
+}
+
+// NewProgressModel builds a model subscribed to events/doneErr. command is the
+// header breadcrumb ("install" or "update").
+func NewProgressModel(theme *ui.Theme, command string, events <-chan install.Event, doneErr <-chan error) ProgressModel {
+	p := progress.New(
+		progress.WithGradient(string(theme.Palette.Brand), string(theme.Palette.Accent)),
+		progress.WithoutPercentage(),
+	)
+	p.Width = 40
+
+	sp := spinner.New()
+	sp.Spinner = spinner.Dot
+	sp.Style = theme.Brand
+
+	return ProgressModel{
+		theme:   theme,
+		command: command,
+		bar:     p,
+		spin:    sp,
+		keyed:   map[string]*progressEntry{},
+		events:  events,
+		doneErr: doneErr,
+		running: true,
+	}
+}
+
+// Err returns the engine's terminal error, if any. Meaningful only after the
+// model has exited.
+func (m ProgressModel) Err() error { return m.err }
+
+func (m ProgressModel) Init() tea.Cmd {
+	return tea.Batch(m.spin.Tick, Subscribe(m.events, m.doneErr))
+}
+
+func (m ProgressModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		barW := m.width - 12
+		if barW < 20 {
+			barW = 20
+		}
+		if barW > 60 {
+			barW = 60
+		}
+		m.bar.Width = barW
+		return m, nil
+
+	case ProgressEventMsg:
+		m.applyEvent(msg.Event)
+		cmds := []tea.Cmd{Subscribe(m.events, m.doneErr)}
+		if m.total > 0 {
+			cmds = append(cmds, m.bar.SetPercent(float64(m.done)/float64(m.total)))
+		}
+		return m, tea.Batch(cmds...)
+
+	case ProgressDoneMsg:
+		m.err = msg.Err
+		m.running = false
+		return m, tea.Quit
+
+	case spinner.TickMsg:
+		var cmd tea.Cmd
+		m.spin, cmd = m.spin.Update(msg)
+		return m, cmd
+
+	case progress.FrameMsg:
+		newBar, cmd := m.bar.Update(msg)
+		if nb, ok := newBar.(progress.Model); ok {
+			m.bar = nb
+		}
+		return m, cmd
+
+	case tea.KeyMsg:
+		if !m.running && (msg.String() == "q" || msg.String() == "enter" || msg.String() == "esc") {
+			return m, tea.Quit
+		}
+	}
+	return m, nil
+}
+
+func (m ProgressModel) View() string {
+	th := m.theme
+	header := Header(th, m.command, "", m.width)
+
+	var sb strings.Builder
+	if m.running {
+		sb.WriteString("  " + m.spin.View() + " " +
+			th.Name.Render(fmt.Sprintf("%d / %d", m.done, m.total)) + "\n")
+	} else if m.err != nil {
+		sb.WriteString("  " + th.Error.Render("✗ ") +
+			th.Name.Render(fmt.Sprintf("%d / %d", m.done, m.total)) + "\n")
+	} else {
+		sb.WriteString("  " + th.Success.Render("✓ ") +
+			th.Name.Render(fmt.Sprintf("%d / %d complete", m.done, m.total)) + "\n")
+	}
+	sb.WriteString("  " + m.bar.View() + "\n\n")
+
+	for _, it := range m.items {
+		line := m.renderEntry(it)
+		sb.WriteString("  " + line + "\n")
+	}
+
+	if m.err != nil {
+		sb.WriteString("\n  " + th.Error.Render("error: ") + th.Detail.Render(m.err.Error()) + "\n")
+	}
+
+	var footer string
+	if m.running {
+		footer = Footer(th, []KeyHint{{Keys: "ctrl+c", Label: "abort"}})
+	} else {
+		footer = Footer(th, []KeyHint{{Keys: "enter/q", Label: "close"}})
+	}
+	return header + "\n\n" + sb.String() + "\n" + footer
+}
+
+func (m *ProgressModel) applyEvent(ev install.Event) {
+	switch ev.Phase {
+	case install.PhaseRunStart:
+		m.total = ev.Total
+	case install.PhaseTargetStart:
+		it := m.upsert(ev)
+		m.current = it
+	case install.PhaseTargetDone:
+		it := m.upsert(ev)
+		it.done = true
+		it.outcome = ev.Outcome
+		m.done++
+	case install.PhaseError:
+		if ev.Skill != "" {
+			it := m.upsert(ev)
+			it.errored = true
+		}
+		if ev.Err != nil && m.err == nil {
+			m.err = ev.Err
+		}
+	}
+}
+
+func (m *ProgressModel) upsert(ev install.Event) *progressEntry {
+	it := &progressEntry{
+		skill:    ev.Skill,
+		platform: ev.Platform,
+		scope:    ev.Scope,
+	}
+	k := it.key()
+	if existing, ok := m.keyed[k]; ok {
+		return existing
+	}
+	m.keyed[k] = it
+	m.items = append(m.items, it)
+	return it
+}
+
+func (m ProgressModel) renderEntry(it *progressEntry) string {
+	th := m.theme
+	var icon, label string
+	switch {
+	case it.errored:
+		icon = th.Error.Render("✗")
+		label = th.Error.Render("error")
+	case it.done:
+		icon = th.Success.Render("✓")
+		label = th.Detail.Render(string(it.outcome))
+	default:
+		icon = th.Brand.Render("…")
+		label = th.Detail.Render("running")
+	}
+	where := ""
+	if it.platform != "" {
+		where = th.Platform.Render("[" + it.platform + "/" + it.scope + "]")
+	}
+	return fmt.Sprintf("%s %s %s %s",
+		icon,
+		th.Name.Render(it.skill),
+		where,
+		label,
+	)
+}
+
+// ExecuteWithProgress runs fn in a goroutine while a ProgressModel UI shows
+// live engine progress. fn is expected to call engine.Execute (or equivalent)
+// with an EventSink that forwards onto events. fn's error becomes
+// ProgressDoneMsg.Err.
+//
+// Returns the final engine error when the model exits.
+func ExecuteWithProgress(theme *ui.Theme, command string, fn func(sink install.EventSink) error) error {
+	events := make(chan install.Event, 32)
+	doneErr := make(chan error, 1)
+
+	sink := install.EventSink(func(ev install.Event) { events <- ev })
+
+	go func() {
+		defer close(events)
+		doneErr <- fn(sink)
+	}()
+
+	m, err := Run(NewProgressModel(theme, command, events, doneErr))
+	if err != nil {
+		return err
+	}
+	if pm, ok := m.(ProgressModel); ok {
+		return pm.Err()
+	}
+	return nil
+}
+

--- a/cli/internal/tui/spinner.go
+++ b/cli/internal/tui/spinner.go
@@ -1,0 +1,69 @@
+package tui
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"sync"
+	"time"
+
+	"golang.org/x/term"
+
+	"github.com/jjfantini/humblSKILLS/cli/internal/ui"
+)
+
+// spinnerFrames is the classic braille dot pattern used by charmbracelet's
+// spinner.Dot. Copied verbatim so we don't pull bubbletea into commands that
+// only need an inline spinner next to a blocking call.
+var spinnerFrames = []string{
+	"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏",
+}
+
+// RunWithSpinner shows an animated spinner on stderr while fn runs, then
+// clears the line before returning fn's error. When stderr is not a TTY
+// (pipes, CI) fn is called straight through with no output, so scripts and
+// logs stay clean.
+//
+// Use this for short-lived blocking calls: registry fetches, manifest loads,
+// anything under a few seconds. For multi-step progress, drive a bubbletea
+// model with install.EventSink instead.
+func RunWithSpinner(theme *ui.Theme, label string, fn func() error) error {
+	errW := os.Stderr
+	if !term.IsTerminal(int(errW.Fd())) {
+		return fn()
+	}
+
+	stop := startSpinner(errW, theme, label)
+	err := fn()
+	stop()
+	return err
+}
+
+func startSpinner(w io.Writer, theme *ui.Theme, label string) func() {
+	done := make(chan struct{})
+	var once sync.Once
+	stop := func() {
+		once.Do(func() {
+			close(done)
+			// Clear the spinner line before the caller prints anything else.
+			fmt.Fprint(w, "\r\x1b[K")
+		})
+	}
+
+	go func() {
+		ticker := time.NewTicker(90 * time.Millisecond)
+		defer ticker.Stop()
+		i := 0
+		for {
+			select {
+			case <-done:
+				return
+			case <-ticker.C:
+				frame := theme.Brand.Render(spinnerFrames[i%len(spinnerFrames)])
+				fmt.Fprintf(w, "\r%s %s", frame, theme.Crumb.Render(label))
+				i++
+			}
+		}
+	}()
+	return stop
+}

--- a/cli/internal/ui/huhtheme.go
+++ b/cli/internal/ui/huhtheme.go
@@ -1,0 +1,34 @@
+package ui
+
+import "github.com/charmbracelet/huh"
+
+// HuhTheme returns a *huh.Theme aligned with the humblskills palette. The base
+// is huh's Catppuccin theme (which the CLI was already using) with a handful of
+// Focused-state overrides so prompts share the same brand purple, muted crumb
+// colour, and accent as the rest of the CLI.
+func HuhTheme(t *Theme) *huh.Theme {
+	if t == nil {
+		t = DefaultTheme()
+	}
+	h := huh.ThemeCatppuccin()
+	p := t.Palette
+
+	// Titles + selection cues pick up the brand accent.
+	h.Focused.Title = h.Focused.Title.Foreground(p.Brand).Bold(true)
+	h.Focused.SelectSelector = h.Focused.SelectSelector.Foreground(p.Brand)
+	h.Focused.MultiSelectSelector = h.Focused.MultiSelectSelector.Foreground(p.Brand)
+	h.Focused.SelectedPrefix = h.Focused.SelectedPrefix.Foreground(p.Name)
+	h.Focused.SelectedOption = h.Focused.SelectedOption.Foreground(p.Name)
+	h.Focused.NextIndicator = h.Focused.NextIndicator.Foreground(p.Brand)
+	h.Focused.PrevIndicator = h.Focused.PrevIndicator.Foreground(p.Brand)
+
+	// Descriptions / blurred text use our muted crumb colour.
+	h.Focused.Description = h.Focused.Description.Foreground(p.Muted)
+	h.Blurred.Description = h.Blurred.Description.Foreground(p.Muted)
+
+	// Error indicator uses our error red so prompts agree with Printer.
+	h.Focused.ErrorIndicator = h.Focused.ErrorIndicator.Foreground(p.Error)
+	h.Focused.ErrorMessage = h.Focused.ErrorMessage.Foreground(p.Error)
+
+	return h
+}

--- a/cli/internal/ui/prompt.go
+++ b/cli/internal/ui/prompt.go
@@ -38,10 +38,11 @@ func NewPrompter(yes bool) *Prompter {
 	return p
 }
 
-// theme is the shared huh theme for every interactive prompt. Catppuccin
-// gives the CLI a consistent, modern look and respects NO_COLOR via huh's
-// internal colour handling.
-func theme() *huh.Theme { return huh.ThemeCatppuccin() }
+// theme is the shared huh theme for every interactive prompt. It's derived
+// from the CLI's Palette so prompts share colours with every other surface
+// (Printer messages, search listings, TUI chrome). huh handles NO_COLOR
+// internally.
+func theme() *huh.Theme { return HuhTheme(DefaultTheme()) }
 
 // Confirm asks a yes/no question. When non-interactive, returns dflt.
 func (p *Prompter) Confirm(title string, dflt bool) (bool, error) {

--- a/cli/internal/ui/theme.go
+++ b/cli/internal/ui/theme.go
@@ -1,0 +1,127 @@
+package ui
+
+import (
+	"io"
+	"os"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
+)
+
+// Palette is the set of semantic colour tokens used across humblskills. One
+// palette drives both the Printer's message styles and every lipgloss/bubbletea
+// surface so the CLI looks like a single cohesive application.
+type Palette struct {
+	Brand    lipgloss.Color // primary accent — wordmark, bullets, progress fill
+	Accent   lipgloss.Color // secondary accent — platform chips
+	Name     lipgloss.Color // skill names, headings
+	Tag      lipgloss.Color // #tags
+	Platform lipgloss.Color // platform chips
+	Hit      lipgloss.Color // filter / query match highlight
+	Muted    lipgloss.Color // secondary text, crumbs, versions
+	Rule     lipgloss.Color // divider lines
+	Desc     lipgloss.Color // long-form description text
+	Success  lipgloss.Color
+	Warn     lipgloss.Color
+	Error    lipgloss.Color
+}
+
+// DefaultPalette mirrors the Catppuccin-aligned tokens previously scattered
+// across search.go and ui.go. Truecolour hexes degrade gracefully on 256-colour
+// terminals via lipgloss.
+func DefaultPalette() Palette {
+	return Palette{
+		Brand:    lipgloss.Color("#A78BFA"),
+		Accent:   lipgloss.Color("#F0ABFC"),
+		Name:     lipgloss.Color("#5EEAD4"),
+		Tag:      lipgloss.Color("#93C5FD"),
+		Platform: lipgloss.Color("#F0ABFC"),
+		Hit:      lipgloss.Color("#FDE68A"),
+		Muted:    lipgloss.Color("244"),
+		Rule:     lipgloss.Color("238"),
+		Desc:     lipgloss.Color("252"),
+		Success:  lipgloss.Color("10"),
+		Warn:     lipgloss.Color("11"),
+		Error:    lipgloss.Color("9"),
+	}
+}
+
+// Theme pairs a palette with pre-built lipgloss styles, all tied to a single
+// renderer so that --no-color / NO_COLOR degrade in exactly one place.
+type Theme struct {
+	Palette  Palette
+	Renderer *lipgloss.Renderer
+
+	// Printer-facing styles.
+	Info    lipgloss.Style
+	Success lipgloss.Style
+	Warn    lipgloss.Style
+	Error   lipgloss.Style
+	Detail  lipgloss.Style
+
+	// Layout / content styles consumed by search, doctor, and the tui package.
+	Brand    lipgloss.Style
+	Crumb    lipgloss.Style
+	RuleLine lipgloss.Style
+	Bullet   lipgloss.Style
+	Name     lipgloss.Style
+	Version  lipgloss.Style
+	Desc     lipgloss.Style
+	Tag      lipgloss.Style
+	Platform lipgloss.Style
+	Hit      lipgloss.Style
+	Label    lipgloss.Style
+	Count    lipgloss.Style
+	Panel    lipgloss.Style
+}
+
+// NewTheme builds a Theme using a renderer attached to out. When noColor is
+// true the renderer is coerced to ASCII so every style becomes a no-op.
+func NewTheme(palette Palette, out io.Writer, noColor bool) *Theme {
+	if out == nil {
+		out = os.Stdout
+	}
+	var r *lipgloss.Renderer
+	if noColor {
+		r = lipgloss.NewRenderer(out)
+		r.SetColorProfile(termenv.Ascii)
+	} else {
+		r = lipgloss.DefaultRenderer()
+	}
+	return buildTheme(palette, r)
+}
+
+// DefaultTheme returns the standard palette wrapping the default lipgloss
+// renderer. Suitable for commands that don't need to override colour handling.
+func DefaultTheme() *Theme {
+	return buildTheme(DefaultPalette(), lipgloss.DefaultRenderer())
+}
+
+func buildTheme(p Palette, r *lipgloss.Renderer) *Theme {
+	t := &Theme{Palette: p, Renderer: r}
+
+	t.Info = r.NewStyle()
+	t.Success = r.NewStyle().Foreground(p.Success).Bold(true)
+	t.Warn = r.NewStyle().Foreground(p.Warn).Bold(true)
+	t.Error = r.NewStyle().Foreground(p.Error).Bold(true)
+	t.Detail = r.NewStyle().Foreground(p.Muted)
+
+	t.Brand = r.NewStyle().Bold(true).Foreground(p.Brand)
+	t.Crumb = r.NewStyle().Foreground(p.Muted)
+	t.RuleLine = r.NewStyle().Foreground(p.Rule)
+	t.Bullet = r.NewStyle().Foreground(p.Brand)
+	t.Name = r.NewStyle().Bold(true).Foreground(p.Name)
+	t.Version = r.NewStyle().Foreground(p.Muted)
+	t.Desc = r.NewStyle().Foreground(p.Desc)
+	t.Tag = r.NewStyle().Foreground(p.Tag)
+	t.Platform = r.NewStyle().Foreground(p.Platform)
+	t.Hit = r.NewStyle().Bold(true).Foreground(p.Hit)
+	t.Label = r.NewStyle().Foreground(p.Muted)
+	t.Count = r.NewStyle().Foreground(p.Muted).Italic(true)
+	t.Panel = r.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(p.Rule).
+		Padding(0, 1)
+
+	return t
+}

--- a/cli/internal/ui/ui.go
+++ b/cli/internal/ui/ui.go
@@ -8,9 +8,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-
-	"github.com/charmbracelet/lipgloss"
-	"github.com/muesli/termenv"
 )
 
 // Level controls how much Printer prints.
@@ -43,15 +40,7 @@ type Printer struct {
 	out, err io.Writer
 	level    Level
 	jsonMode bool
-	styles   styles
-}
-
-type styles struct {
-	info    lipgloss.Style
-	success lipgloss.Style
-	warn    lipgloss.Style
-	errS    lipgloss.Style
-	detail  lipgloss.Style
+	theme    *Theme
 }
 
 // New returns a Printer configured by opts. It honours the NO_COLOR env var in
@@ -68,28 +57,19 @@ func New(opts Options) *Printer {
 
 	noColor := opts.NoColor || os.Getenv("NO_COLOR") != ""
 
-	r := lipgloss.DefaultRenderer()
-	if noColor {
-		r = lipgloss.NewRenderer(out)
-		r.SetColorProfile(termenv.Ascii)
-	}
-
-	s := styles{
-		info:    r.NewStyle(),
-		success: r.NewStyle().Foreground(lipgloss.Color("10")).Bold(true),
-		warn:    r.NewStyle().Foreground(lipgloss.Color("11")).Bold(true),
-		errS:    r.NewStyle().Foreground(lipgloss.Color("9")).Bold(true),
-		detail:  r.NewStyle().Foreground(lipgloss.Color("8")),
-	}
-
 	return &Printer{
 		out:      out,
 		err:      errW,
 		level:    opts.Level,
 		jsonMode: opts.JSON,
-		styles:   s,
+		theme:    NewTheme(DefaultPalette(), out, noColor),
 	}
 }
+
+// Theme returns the Printer's underlying theme, so commands rendering ad-hoc
+// lipgloss layouts (search, doctor, TUIs) share the same palette + renderer
+// and honour --no-color without reaching for their own state.
+func (p *Printer) Theme() *Theme { return p.theme }
 
 // Println writes a pre-rendered string to stdout with a trailing newline.
 // Use when the caller has already composed styled output (e.g. via lipgloss)
@@ -106,7 +86,7 @@ func (p *Printer) Info(format string, args ...any) {
 	if p.jsonMode || p.level < LevelNormal {
 		return
 	}
-	fmt.Fprintln(p.out, p.styles.info.Render(fmt.Sprintf(format, args...)))
+	fmt.Fprintln(p.out, p.theme.Info.Render(fmt.Sprintf(format, args...)))
 }
 
 // Success prints a styled success line. Suppressed in JSON / quiet mode.
@@ -114,7 +94,7 @@ func (p *Printer) Success(format string, args ...any) {
 	if p.jsonMode || p.level < LevelNormal {
 		return
 	}
-	fmt.Fprintln(p.out, p.styles.success.Render("✓ ")+fmt.Sprintf(format, args...))
+	fmt.Fprintln(p.out, p.theme.Success.Render("✓ ")+fmt.Sprintf(format, args...))
 }
 
 // Warn prints a styled warning. Suppressed in JSON / quiet mode.
@@ -122,13 +102,13 @@ func (p *Printer) Warn(format string, args ...any) {
 	if p.jsonMode || p.level < LevelNormal {
 		return
 	}
-	fmt.Fprintln(p.err, p.styles.warn.Render("! ")+fmt.Sprintf(format, args...))
+	fmt.Fprintln(p.err, p.theme.Warn.Render("! ")+fmt.Sprintf(format, args...))
 }
 
 // Error prints a styled error. Always emitted (even in quiet / JSON mode) so
 // failures aren't silent.
 func (p *Printer) Error(format string, args ...any) {
-	fmt.Fprintln(p.err, p.styles.errS.Render("✗ ")+fmt.Sprintf(format, args...))
+	fmt.Fprintln(p.err, p.theme.Error.Render("✗ ")+fmt.Sprintf(format, args...))
 }
 
 // Detail prints at LevelVerbose. Suppressed otherwise.
@@ -136,7 +116,7 @@ func (p *Printer) Detail(format string, args ...any) {
 	if p.jsonMode || p.level < LevelVerbose {
 		return
 	}
-	fmt.Fprintln(p.out, p.styles.detail.Render(fmt.Sprintf(format, args...)))
+	fmt.Fprintln(p.out, p.theme.Detail.Render(fmt.Sprintf(format, args...)))
 }
 
 // JSON marshals v and prints it to Out. Intended for --json output.
@@ -149,3 +129,35 @@ func (p *Printer) JSON(v any) error {
 
 // IsJSON reports whether the printer is in JSON mode.
 func (p *Printer) IsJSON() bool { return p.jsonMode }
+
+// Out / Err expose the configured writers so commands that compose their own
+// lipgloss layouts can emit directly while the Printer still governs colour +
+// level semantics.
+func (p *Printer) Out() io.Writer { return p.out }
+func (p *Printer) Err() io.Writer { return p.err }
+
+// Header prints the shared breadcrumb used above command output:
+//
+//	  humblskills › <command>
+//	  ────────────────────────
+//
+// Suppressed in JSON / quiet mode.
+func (p *Printer) Header(command string) {
+	if p.jsonMode || p.level < LevelNormal {
+		return
+	}
+	line := "  " + p.theme.Brand.Render("humblskills") +
+		p.theme.Crumb.Render("  ›  "+command)
+	fmt.Fprintln(p.out)
+	fmt.Fprintln(p.out, line)
+}
+
+// Section prints a muted label used to group related lines in static output
+// (e.g. "Adapters:", "Registry:"). Suppressed in JSON / quiet mode.
+func (p *Printer) Section(label string) {
+	if p.jsonMode || p.level < LevelNormal {
+		return
+	}
+	fmt.Fprintln(p.out)
+	fmt.Fprintln(p.out, p.theme.Label.Render(label))
+}


### PR DESCRIPTION
## Summary
- Centralise palette in `cli/internal/ui/theme.go`; derive huh theme from the same tokens so every prompt and surface matches
- New `cli/internal/tui/` package: shared chrome (Header/Footer/Frame), browser (used by `search` + `list`), progress model driven by engine events, framed confirm, spinner, keymap
- Install engine emits phased events via an optional `EventSink`; install/update route through `tui.ExecuteWithProgress` on TTY for a live progress bar, keeping the non-TTY / `--json` / `--yes` paths byte-identical
- Polish pass on `doctor` (framed table, spinner during registry load), `registry refresh` (spinner), `uninstall` (framed summary), `version` (wordmark banner)

## Test plan
- [x] `go build ./...`
- [x] `go test ./...`
- [ ] `./humblskills search` drops into browse TUI, `i` installs
- [ ] `./humblskills install` shows live progress bar per target
- [ ] `./humblskills update` shows live progress bar across skills
- [ ] `./humblskills list` routes `u`/`x` to update/uninstall
- [ ] `./humblskills --json list` emits pure JSON, no ANSI
- [ ] `NO_COLOR=1 ./humblskills doctor` stays legible

🤖 Generated with [Claude Code](https://claude.com/claude-code)