### PR TITLE
fix(cli): align two-pane divider and fill selected row

### DIFF
--- a/cli/cmd/humblskills/doctor.go
+++ b/cli/cmd/humblskills/doctor.go
@@ -426,17 +426,18 @@ func rowName(th *ui.Theme, name string, selected, enabled bool) string {
 }
 
 // rowWithTrailingBadge lays out a left-anchored label and a right-anchored
-// badge within `width` cells. If the row can't fit, the badge is omitted.
+// badge within `width` cells. When the badge can't fit it's dropped, but the
+// label is still padded so every row ends at the same column — otherwise the
+// divider snaps to the widest row and loses alignment.
 func rowWithTrailingBadge(label, badge string, width int) string {
-	if width < 10 {
-		return label
-	}
 	lw := lipgloss.Width(label)
-	bw := lipgloss.Width(badge)
-	gap := width - lw - bw
-	if gap < 1 {
-		return label
+	if width < 10 || width-lw < lipgloss.Width(badge)+1 {
+		if lw >= width {
+			return label
+		}
+		return label + strings.Repeat(" ", width-lw)
 	}
+	gap := width - lw - lipgloss.Width(badge)
 	return label + strings.Repeat(" ", gap) + badge
 }
 

--- a/cli/internal/tui/chrome.go
+++ b/cli/internal/tui/chrome.go
@@ -64,11 +64,9 @@ func Footer(theme *ui.Theme, hints []KeyHint, right string, width int) string {
 		parts = append(parts, theme.KbdKey.Render(h.Keys)+" "+theme.KbdLabel.Render(h.Label))
 	}
 	left := strings.Join(parts, "  ")
-	rightR := ""
-	if right != "" {
-		rightR = theme.Meta.Render(right)
-	}
-	line := padBetween(left, rightR, width-2)
+	// `right` is passed through unchanged so callers can compose mixed
+	// styles (e.g. muted label + magenta value for `focused: <name>`).
+	line := padBetween(left, right, width-2)
 	rule := DashedRule(theme, width-2)
 	return "  " + rule + "\n  " + line
 }

--- a/cli/internal/tui/listdetail.go
+++ b/cli/internal/tui/listdetail.go
@@ -299,7 +299,9 @@ func (m Model) View() string {
 	if m.cfg.FocusedLabel != nil {
 		focused = m.cfg.FocusedLabel(m.items, m.cursor)
 	} else if len(m.items) > 0 {
-		focused = "focused: " + m.items[m.cursor].Key()
+		// "focused:" stays muted; the value (item key) renders in the
+		// magenta brand colour to match the design.
+		focused = th.Meta.Render("focused: ") + th.Brand.Render(m.items[m.cursor].Key())
 	}
 	footer := Footer(th, m.hints(), focused, m.width)
 
@@ -315,37 +317,58 @@ func (m Model) renderBody(leftW, rightW int) string {
 	divider := m.renderDivider()
 	right := m.renderRight(rightW)
 
-	return lipgloss.JoinHorizontal(lipgloss.Top, "  "+left, " "+divider+" ", right)
+	return lipgloss.JoinHorizontal(lipgloss.Top, left, " "+divider+" ", right)
 }
 
 func (m Model) renderLeft(width int) string {
 	th := m.cfg.Theme
 
+	// Every line in the left block is padded to exactly `width` cells so
+	// lipgloss.JoinHorizontal lines the divider up at a fixed x regardless of
+	// which row has the longest content.
+	pad := func(s string) string {
+		w := lipgloss.Width(s)
+		if w >= width {
+			return s
+		}
+		return s + strings.Repeat(" ", width-w)
+	}
+
 	var title string
 	if m.filtOn {
 		m.filter.Width = width - 2
-		title = m.filter.View()
+		title = "  " + m.filter.View()
 	} else {
-		title = th.SectionTitle.Render(spacedUpper(m.cfg.LeftTitle))
+		title = "  " + th.SectionTitle.Render(spacedUpper(m.cfg.LeftTitle))
 	}
 
 	if len(m.items) == 0 {
-		empty := th.Detail.Render(firstNonEmpty(m.cfg.EmptyMsg, "— no items —"))
-		return title + "\n\n" + padLeft(empty, width)
+		empty := "  " + th.Detail.Render(firstNonEmpty(m.cfg.EmptyMsg, "— no items —"))
+		return pad(title) + "\n\n" + pad(empty)
 	}
 
 	var sb strings.Builder
-	sb.WriteString(title)
+	sb.WriteString(pad(title))
 	sb.WriteString("\n\n")
 	for i, it := range m.items {
 		selected := i == m.cursor
 		row := it.Row(th, width-2, selected)
+		// Pad the row body (minus the leading bar/gutter) to width-2.
+		rowW := lipgloss.Width(row)
+		if rowW < width-2 {
+			row += strings.Repeat(" ", width-2-rowW)
+		}
+		var line string
 		if selected {
 			bar := th.Bullet.Render("▌")
-			sb.WriteString(bar + " " + row)
+			// Wrap the content + padding in RowBg so the highlight fills
+			// every cell from just after the bar to the divider. The bar
+			// itself sits outside the highlight band, matching the design.
+			line = bar + th.RowBg.Render(" "+row)
 		} else {
-			sb.WriteString("  " + row)
+			line = "  " + row
 		}
+		sb.WriteString(line)
 		if i < len(m.items)-1 {
 			sb.WriteString("\n")
 		}

--- a/cli/internal/ui/theme.go
+++ b/cli/internal/ui/theme.go
@@ -104,9 +104,10 @@ type Theme struct {
 	SectionTitle lipgloss.Style // uppercase comment header in each pane
 
 	// Row rendering.
-	RowSelected   lipgloss.Style // bg-hl bg, magenta fg, bold
+	RowSelected   lipgloss.Style // magenta fg, bold (inherits parent bg)
 	RowUnselected lipgloss.Style
 	RowDim        lipgloss.Style // comment-colour (missing/unavailable)
+	RowBg         lipgloss.Style // bg-hl full-row background for the cursor row
 	Bullet        lipgloss.Style // magenta ▌ bar
 	DotOK         lipgloss.Style // green ●
 	DotNo         lipgloss.Style // red ●
@@ -182,10 +183,12 @@ func buildTheme(p Palette, r *lipgloss.Renderer) *Theme {
 	t.Divider = r.NewStyle().Foreground(p.Border)
 	t.SectionTitle = r.NewStyle().Foreground(p.Comment).Bold(true)
 
-	// Rows.
-	t.RowSelected = r.NewStyle().Background(p.BGHL).Foreground(p.Magenta).Bold(true)
+	// Rows. RowSelected is applied to the name text only; RowBg wraps the
+	// full row so the highlight fills edge-to-edge through any padding gaps.
+	t.RowSelected = r.NewStyle().Foreground(p.Magenta).Bold(true)
 	t.RowUnselected = r.NewStyle().Foreground(p.FG)
 	t.RowDim = r.NewStyle().Foreground(p.Comment)
+	t.RowBg = r.NewStyle().Background(p.BGHL)
 	t.Bullet = r.NewStyle().Foreground(p.Magenta).Bold(true)
 	t.DotOK = r.NewStyle().Foreground(p.Green)
 	t.DotNo = r.NewStyle().Foreground(p.Red)


### PR DESCRIPTION
## Summary
Three follow-up fixes on top of #18 to match the design screenshot:
- Divider + DETAIL title were snapping inward toward the widest row because the left pane didn't pad to a fixed width. Every left-pane line is now padded to `leftW` before `lipgloss.JoinHorizontal`, so the divider sits at a predictable column.
- The cursor row's highlight now fills edge-to-edge. `RowSelected` dropped its background — the new `RowBg` style wraps the full row and `RowSelected` stays a magenta-bold-fg name style rendered inside it.
- The footer's \`focused:\` context now renders \`focused: \` in muted comment colour and the value in the magenta brand colour, matching the design mock.

Also: `rowWithTrailingBadge` in doctor now always pads to the requested width — even when the badge gets dropped — so narrow rows can't regress divider alignment.

## Test plan
- [x] \`go build ./...\`
- [x] \`go vet ./...\`
- [x] \`go test ./...\`
- [ ] Visual: doctor / install / list pickers on TTY — selected row fills to divider, DETAIL title aligned right next to divider, \`focused: <magenta value>\` in the footer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)