### PR TITLE
fix(cli): size left pane via SizedItem natural width

### DIFF
--- a/cli/cmd/humblskills/browse_skills.go
+++ b/cli/cmd/humblskills/browse_skills.go
@@ -5,6 +5,8 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/charmbracelet/lipgloss"
+
 	"github.com/jjfantini/humblSKILLS/cli/internal/manifest"
 	"github.com/jjfantini/humblSKILLS/cli/internal/registry"
 	"github.com/jjfantini/humblSKILLS/cli/internal/tui"
@@ -36,6 +38,25 @@ func (s skillItem) FilterValue() string {
 	return strings.ToLower(s.s.Name + " " + strings.Join(s.s.Tags, " ") + " " + s.s.Description)
 }
 
+// NaturalWidth reports the row's display width: dot + space + name + 2-gap
+// + version + (optional: 2-gap + badge). Kept in lockstep with Row so the
+// two-pane model can size the left column to actual content.
+func (s skillItem) NaturalWidth(th *ui.Theme) int {
+	versionW := lipgloss.Width("v" + s.s.Version)
+	// 1 (dot) + 1 (space) + name + 2 (gap) + version.
+	w := 1 + 1 + lipgloss.Width(s.s.Name) + 2 + versionW
+	var badge string
+	if s.outdated {
+		badge = tui.Badge(th, tui.BadgeRO, "outdated")
+	} else if s.installed != nil {
+		badge = tui.Badge(th, tui.BadgeDetected, "installed")
+	}
+	if badge != "" {
+		w += 2 + lipgloss.Width(badge)
+	}
+	return w
+}
+
 func (s skillItem) Row(th *ui.Theme, width int, selected bool) string {
 	var dot string
 	if s.installed != nil {
@@ -60,7 +81,14 @@ func (s skillItem) Row(th *ui.Theme, width int, selected bool) string {
 		badge = tui.Badge(th, tui.BadgeDetected, "installed")
 	}
 	if badge == "" {
-		return left
+		// Pad to width so unbadged rows end at the same column as badged
+		// ones — otherwise the divider snaps to the widest row and loses
+		// alignment between the header rule and the body divider.
+		lw := lipgloss.Width(left)
+		if lw >= width {
+			return left
+		}
+		return left + strings.Repeat(" ", width-lw)
 	}
 	return rowWithTrailingBadge(left, badge, width)
 }

--- a/cli/cmd/humblskills/doctor.go
+++ b/cli/cmd/humblskills/doctor.go
@@ -265,6 +265,10 @@ type adapterItem struct{ a adapterReport }
 
 func (a adapterItem) Key() string         { return a.a.Name }
 func (a adapterItem) FilterValue() string { return a.a.Name + " " + a.a.Reason }
+func (a adapterItem) NaturalWidth(th *ui.Theme) int {
+	badge := tui.Badge(th, tui.BadgeMissing, "detected") // both "detected" and "missing" are 8 glyphs; pad puts them at identical width
+	return rowNaturalWidth(a.a.Name, lipgloss.Width(badge))
+}
 func (a adapterItem) Row(th *ui.Theme, width int, selected bool) string {
 	var dot, badge string
 	if a.a.Detected {
@@ -311,6 +315,10 @@ type manifestItem struct {
 
 func (m manifestItem) Key() string         { return "manifest" }
 func (m manifestItem) FilterValue() string { return "manifest " + m.m.Path }
+func (m manifestItem) NaturalWidth(th *ui.Theme) int {
+	badge := tui.Badge(th, tui.BadgeMissing, "error") // "error" is the wider of {"ok","error"}
+	return rowNaturalWidth("manifest", lipgloss.Width(badge))
+}
 func (m manifestItem) Row(th *ui.Theme, width int, selected bool) string {
 	ok := m.issue == ""
 	var dot, badge string
@@ -343,6 +351,18 @@ type registryItem struct{ reg registryReport }
 
 func (r registryItem) Key() string         { return "registry" }
 func (r registryItem) FilterValue() string { return "registry " + r.reg.URL }
+func (r registryItem) NaturalWidth(th *ui.Theme) int {
+	var badge string
+	switch {
+	case r.reg.Error != "":
+		badge = tui.Badge(th, tui.BadgeMissing, "unreachable")
+	case len(r.reg.DepIssues) > 0:
+		badge = tui.Badge(th, tui.BadgeRO, "issues")
+	default:
+		badge = tui.Badge(th, tui.BadgeDetected, fmt.Sprintf("%d skills", r.reg.Skills))
+	}
+	return rowNaturalWidth("registry", lipgloss.Width(badge))
+}
 func (r registryItem) Row(th *ui.Theme, width int, selected bool) string {
 	ok := r.reg.Error == "" && len(r.reg.DepIssues) == 0
 	var dot, badge string
@@ -381,6 +401,15 @@ type updatesItem struct{ u updatesReport }
 
 func (u updatesItem) Key() string         { return "updates" }
 func (u updatesItem) FilterValue() string { return "updates" }
+func (u updatesItem) NaturalWidth(th *ui.Theme) int {
+	var badge string
+	if u.u.Count == 0 {
+		badge = tui.Badge(th, tui.BadgeDetected, "up-to-date")
+	} else {
+		badge = tui.Badge(th, tui.BadgeRO, fmt.Sprintf("%d outdated", u.u.Count))
+	}
+	return rowNaturalWidth("updates", lipgloss.Width(badge))
+}
 func (u updatesItem) Row(th *ui.Theme, width int, selected bool) string {
 	var dot, badge string
 	if u.u.Count == 0 {
@@ -423,6 +452,16 @@ func rowName(th *ui.Theme, name string, selected, enabled bool) string {
 	default:
 		return th.RowUnselected.Render(name)
 	}
+}
+
+// rowNaturalWidth returns the natural display width of a left-pane row whose
+// body reads `● <label>  <badge>`: 1 dot + 1 space + the label's display
+// width + 2 gap + the badge's display width. Items pass this up through
+// SizedItem.NaturalWidth so the two-pane model can size the left column to
+// the actual content instead of clamping to a hard-coded width.
+func rowNaturalWidth(label string, badgeWidth int) int {
+	// 1 (dot) + 1 (space) + label + 2 (gap) + badge.
+	return 1 + 1 + lipgloss.Width(label) + 2 + badgeWidth
 }
 
 // rowWithTrailingBadge lays out a left-anchored label and a right-anchored

--- a/cli/cmd/humblskills/update.go
+++ b/cli/cmd/humblskills/update.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/charmbracelet/lipgloss"
 	"github.com/spf13/cobra"
 
 	"github.com/jjfantini/humblSKILLS/cli/internal/install"
@@ -207,6 +208,12 @@ type updatePlanItem struct{ p install.UpdatePlan }
 func (u updatePlanItem) Key() string { return u.p.Skill }
 func (u updatePlanItem) FilterValue() string {
 	return strings.ToLower(u.p.Skill)
+}
+func (u updatePlanItem) NaturalWidth(th *ui.Theme) int {
+	ver := u.p.FromVersion + " → " + u.p.ToVersion
+	badge := tui.Badge(th, tui.BadgeRO, fmt.Sprintf("%d target%s", len(u.p.Targets), plural(len(u.p.Targets))))
+	// 1 (arrow) + 1 (space) + skill + 2 (gap) + version + 2 (gap) + badge.
+	return 1 + 1 + lipgloss.Width(u.p.Skill) + 2 + lipgloss.Width(ver) + 2 + lipgloss.Width(badge)
 }
 func (u updatePlanItem) Row(th *ui.Theme, width int, selected bool) string {
 	arrow := th.DotWarn.Render("↑")

--- a/cli/internal/tui/listdetail.go
+++ b/cli/internal/tui/listdetail.go
@@ -30,6 +30,21 @@ type Item interface {
 	FilterValue() string
 }
 
+// SizedItem is an optional Item extension that reports the item's *natural*
+// left-pane width (in display cells, NOT including the 2-cell gutter the
+// model prepends). Items that implement it let the pane snug the divider to
+// the content; items that don't fall back to a safe default.
+//
+// Why an interface instead of measuring Row output: Row() renders with ANSI
+// styling (badges with Padding/Background leave trailing `\x1b[0m` rather
+// than literal spaces), so strings.TrimRight can't recover the natural width
+// from a padded render. Letting the item compute its own width directly
+// sidesteps that entirely.
+type SizedItem interface {
+	Item
+	NaturalWidth(theme *ui.Theme) int
+}
+
 // ActionSpec binds a key to a caller-named action. Pressing Key while an item
 // is highlighted exits the model with Result{Action, Item}.
 type ActionSpec struct {
@@ -250,27 +265,35 @@ func (m Model) paneWidths() (left, right int) {
 	return left, right
 }
 
-// measureLeftWidth computes the natural width of the widest row (dot + name
-// + trailing badge), adds 2 cells for the leading gutter, and caps the result
-// at a sensible upper bound. This keeps the divider snug against the content
-// instead of parking it at a fixed 32-col offset regardless of how short the
-// rows actually are.
+// measureLeftWidth computes the natural left-pane width in display cells:
+// the max of (section-title width, widest item's NaturalWidth), plus a
+// 2-cell gutter, clamped to [minW, maxW].
+//
+// Items that don't implement SizedItem contribute the fallback width — we
+// can't infer their natural width from Row() because the rendered string
+// includes ANSI reset sequences that defeat trailing-space trimming. Every
+// Item type in this codebase implements SizedItem; the fallback only matters
+// for third-party embedders.
 func (m Model) measureLeftWidth() int {
 	th := m.cfg.Theme
-	const minW, maxW = 22, 32
+	const (
+		minW     = 22
+		maxW     = 36
+		fallback = 30
+		gutter   = 2 // "  " or "▌ " before the row body
+	)
 	widest := minW
-	// Include the section title so very short rows still leave room for the
-	// "ADAPTERS" / "CHECKS" / "SKILLS" header.
-	if w := lipgloss.Width(th.SectionTitle.Render(spacedUpper(m.cfg.LeftTitle))) + 4; w > widest {
+	if w := lipgloss.Width(th.SectionTitle.Render(spacedUpper(m.cfg.LeftTitle))) + gutter; w > widest {
 		widest = w
 	}
-	// Call each Row with a generous width; the item pads to the requested
-	// width via rowWithTrailingBadge, so the rendered string IS the natural
-	// width when trimmed of trailing spaces.
 	for _, it := range m.cfg.Items {
-		r := it.Row(th, 120, false)
-		r = strings.TrimRight(r, " ")
-		if w := lipgloss.Width(r) + 2; w > widest {
+		var natural int
+		if si, ok := it.(SizedItem); ok {
+			natural = si.NaturalWidth(th)
+		} else {
+			natural = fallback
+		}
+		if w := natural + gutter; w > widest {
 			widest = w
 		}
 	}


### PR DESCRIPTION
## Summary
- The previous auto-size pass measured `Row()` output padded to a large width, then `strings.TrimRight`-ed to recover the natural width. But rendered badges end with an ANSI reset (`\x1b[0m`), not spaces, so TrimRight stripped nothing and every row measured as the padded width. Net: the left pane always clamped to the 32-col `maxW`, pushing the `DETAIL` header off-axis from the header rule.
- Introduce an optional `SizedItem` interface so each item reports its natural width directly. Implement it on every item type: `adapterItem`, `manifestItem`, `registryItem`, `updatesItem`, `skillItem`, `updatePlanItem`.
- Fix `skillItem.Row` to pad unbadged rows to the requested width (otherwise those rows pulled the divider to the widest-row column).

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test ./...` all green.
- [x] `humblskills doctor --json` still prints expected JSON (non-TTY path unchanged).
- [ ] On a real terminal: `humblskills doctor` — DETAIL title sits directly to the right of the body divider, which aligns with the header rule crossing; selected-row ▌ bar and magenta name render without any background fill in both light and dark modes.
- [ ] Same check for `humblskills search`, `humblskills list`, `humblskills update`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)