### PR TITLE
feat(cli): profile command + TUI install platform picker

### DIFF
--- a/cli/cmd/humblskills/browse_skills.go
+++ b/cli/cmd/humblskills/browse_skills.go
@@ -171,6 +171,9 @@ func buildSkillItems(skills []registry.Skill, m *manifest.Manifest) []skillItem 
 // runSkillBrowser opens the shared two-pane picker over skills and routes the
 // user's choice through the right subcommand. Returns (skill, action) where
 // action is one of "install", "update", "uninstall", or "" (user quit).
+//
+// Pressing `p` opens the profile editor inline and re-enters the picker so
+// every surface that uses this browser gets the same footer shortcut.
 func runSkillBrowser(app *App, section string, skills []skillItem, mode skillsBrowseMode, emptyMsg string) (string, string, error) {
 	if len(skills) == 0 {
 		app.UI.Info(emptyMsg)
@@ -186,11 +189,13 @@ func runSkillBrowser(app *App, section string, skills []skillItem, mode skillsBr
 	case modeSearch:
 		actions = []tui.ActionSpec{
 			{Key: "i", Label: "install", Action: "install"},
+			{Key: "p", Label: "profile", Action: "profile"},
 		}
 	case modeInstalledOnly:
 		actions = []tui.ActionSpec{
 			{Key: "u", Label: "update", Action: "update"},
 			{Key: "x", Label: "uninstall", Action: "uninstall"},
+			{Key: "p", Label: "profile", Action: "profile"},
 		}
 	}
 
@@ -219,26 +224,34 @@ func runSkillBrowser(app *App, section string, skills []skillItem, mode skillsBr
 		leftTitle = "INSTALLED"
 	}
 
-	res, err := tui.RunListDetail(tui.Config{
-		Theme:      app.UI.Theme(),
-		Version:    resolveVersion().Version,
-		Section:    section,
-		Meta:       meta,
-		Items:      items,
-		LeftTitle:  leftTitle,
-		RightTitle: "DETAIL",
-		Actions:    actions,
-		EmptyMsg:   emptyMsg,
-	})
-	if err != nil {
-		return "", "", err
+	for {
+		res, err := tui.RunListDetail(tui.Config{
+			Theme:      app.UI.Theme(),
+			Version:    resolveVersion().Version,
+			Section:    section,
+			Meta:       meta,
+			Items:      items,
+			LeftTitle:  leftTitle,
+			RightTitle: "DETAIL",
+			Actions:    actions,
+			EmptyMsg:   emptyMsg,
+		})
+		if err != nil {
+			return "", "", err
+		}
+		if res.Quit || res.Item == nil {
+			return "", "", nil
+		}
+		if res.Action == "profile" {
+			if err := runProfileEditor(app); err != nil {
+				return "", "", err
+			}
+			continue
+		}
+		it, ok := res.Item.(skillItem)
+		if !ok {
+			return "", "", nil
+		}
+		return it.s.Name, res.Action, nil
 	}
-	if res.Quit || res.Item == nil {
-		return "", "", nil
-	}
-	it, ok := res.Item.(skillItem)
-	if !ok {
-		return "", "", nil
-	}
-	return it.s.Name, res.Action, nil
 }

--- a/cli/cmd/humblskills/install.go
+++ b/cli/cmd/humblskills/install.go
@@ -9,14 +9,16 @@ import (
 	"github.com/jjfantini/humblSKILLS/cli/internal/adapters"
 	"github.com/jjfantini/humblSKILLS/cli/internal/install"
 	"github.com/jjfantini/humblSKILLS/cli/internal/manifest"
+	"github.com/jjfantini/humblSKILLS/cli/internal/profile"
 	"github.com/jjfantini/humblSKILLS/cli/internal/registry"
 	"github.com/jjfantini/humblSKILLS/cli/internal/tui"
 )
 
 type installFlags struct {
-	platforms []string
-	scope     string
-	force     bool
+	platforms    []string
+	platformsSet bool
+	scope        string
+	force        bool
 }
 
 func newInstallCmd(app *App) *cobra.Command {
@@ -32,6 +34,7 @@ func newInstallCmd(app *App) *cobra.Command {
 			if len(args) == 1 {
 				skill = args[0]
 			}
+			f.platformsSet = cmd.Flags().Changed("platform")
 			return runInstall(app, skill, f)
 		},
 	}
@@ -59,7 +62,24 @@ func runInstall(app *App, skill string, f installFlags) error {
 		}
 	}
 
-	selected, err := selectPlatforms(adapterList, f.platforms)
+	platforms := f.platforms
+	scope := f.scope
+	useTUIForModal := !f.platformsSet && tui.ShouldUseTUI(app.Config.JSON, app.Config.Quiet, app.Config.Yes)
+	if useTUIForModal {
+		plats, scp, ok, err := promptInstallTargets(app, adapterList, skill)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			return fmt.Errorf("install cancelled")
+		}
+		platforms = plats
+		if scp != "" {
+			scope = scp
+		}
+	}
+
+	selected, err := selectPlatforms(adapterList, platforms)
 	if err != nil {
 		return err
 	}
@@ -91,7 +111,7 @@ func runInstall(app *App, skill string, f installFlags) error {
 		r, err := engine.Execute(reg, plan, install.ExecuteOpts{
 			Adapters:  adapterList,
 			Platforms: selected,
-			Scope:     f.scope,
+			Scope:     scope,
 			Force:     f.force,
 			OnEvent:   sink,
 		})
@@ -176,6 +196,38 @@ func printInstall(app *App, r install.Result) {
 	}
 	if len(installed)+len(replaced)+len(forced) == 0 {
 		app.UI.Info("%d target%s already up-to-date (use --force to reinstall)", len(skipped), plural(len(skipped)))
+	}
+}
+
+// promptInstallTargets opens a huh modal asking the user which platforms to
+// install `skill` into (defaults come from profile), returning the confirmed
+// platforms + scope. If the user picks "edit profile" inside the modal, the
+// profile editor opens and the modal re-prompts with the updated defaults.
+// Returns ok=false if the user cancelled.
+func promptInstallTargets(app *App, adapterList []adapters.Adapter, skill string) ([]string, string, bool, error) {
+	detected := map[string]bool{}
+	for _, r := range adapters.Detect(adapterList) {
+		detected[r.Name] = r.Detected
+	}
+	for {
+		p, err := profile.Load(app.Config.ProfilePath)
+		if err != nil {
+			return nil, "", false, err
+		}
+		res, err := tui.RunInstallPlatformModal(app.UI.Theme(), skill, adapterList, detected, p)
+		if err != nil {
+			return nil, "", false, err
+		}
+		if res.EditProfile {
+			if err := runProfileEditor(app); err != nil {
+				return nil, "", false, err
+			}
+			continue
+		}
+		if !res.Confirmed {
+			return nil, "", false, nil
+		}
+		return res.Platforms, res.Scope, true, nil
 	}
 }
 

--- a/cli/cmd/humblskills/profile.go
+++ b/cli/cmd/humblskills/profile.go
@@ -1,0 +1,236 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/jjfantini/humblSKILLS/cli/internal/adapters"
+	"github.com/jjfantini/humblSKILLS/cli/internal/profile"
+	"github.com/jjfantini/humblSKILLS/cli/internal/tui"
+)
+
+func newProfileCmd(app *App) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "profile",
+		Short: "View or edit your humblskills profile (default platforms + scope)",
+		Long: "profile edits the user profile that drives install defaults. " +
+			"Run bare for an interactive TUI editor, or use subcommands " +
+			"(`show`, `set`, `reset`, `path`) for scripting.",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runProfileDefault(app)
+		},
+	}
+	cmd.AddCommand(
+		newProfileShowCmd(app),
+		newProfileSetCmd(app),
+		newProfileResetCmd(app),
+		newProfilePathCmd(app),
+	)
+	return cmd
+}
+
+func newProfileShowCmd(app *App) *cobra.Command {
+	return &cobra.Command{
+		Use:   "show",
+		Short: "Print the current profile",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runProfileShow(app)
+		},
+	}
+}
+
+func newProfileSetCmd(app *App) *cobra.Command {
+	return &cobra.Command{
+		Use:   "set <key> <value>",
+		Short: "Set a profile value. Keys: platforms, scope.",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runProfileSet(app, args[0], args[1])
+		},
+	}
+}
+
+func newProfileResetCmd(app *App) *cobra.Command {
+	return &cobra.Command{
+		Use:   "reset",
+		Short: "Delete the profile file",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runProfileReset(app)
+		},
+	}
+}
+
+func newProfilePathCmd(app *App) *cobra.Command {
+	return &cobra.Command{
+		Use:   "path",
+		Short: "Print the resolved profile file path",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			fmt.Fprintln(app.UI.Out(), app.Config.ProfilePath)
+			return nil
+		},
+	}
+}
+
+func runProfileDefault(app *App) error {
+	if tui.ShouldUseTUI(app.Config.JSON, app.Config.Quiet, app.Config.Yes) {
+		return runProfileEditor(app)
+	}
+	return runProfileShow(app)
+}
+
+func runProfileEditor(app *App) error {
+	adapterList, err := app.Adapters()
+	if err != nil {
+		return fmt.Errorf("load adapters: %w", err)
+	}
+	p, err := profile.Load(app.Config.ProfilePath)
+	if err != nil {
+		return err
+	}
+	updated, saved, err := tui.RunProfileEditor(app.UI.Theme(), adapterList, p)
+	if err != nil {
+		return err
+	}
+	if !saved {
+		app.UI.Info("profile unchanged")
+		return nil
+	}
+	if err := validateProfileAgainstAdapters(updated, adapterList); err != nil {
+		return err
+	}
+	if err := profile.Save(app.Config.ProfilePath, updated); err != nil {
+		return err
+	}
+	app.UI.Success("saved profile → %s", app.Config.ProfilePath)
+	return nil
+}
+
+func runProfileShow(app *App) error {
+	p, err := profile.Load(app.Config.ProfilePath)
+	if err != nil {
+		return err
+	}
+	if app.Config.JSON {
+		return app.UI.JSON(p)
+	}
+	th := app.UI.Theme()
+	app.UI.Header("profile")
+	app.UI.Section("Defaults")
+	fmt.Fprintln(app.UI.Out(), "  "+th.KVKey.Render("platforms")+"    "+
+		th.KVValue.Render(formatPlatforms(p.DefaultPlatforms)))
+	fmt.Fprintln(app.UI.Out(), "  "+th.KVKey.Render("scope")+"        "+
+		th.KVValue.Render(formatScope(p.DefaultScope)))
+	fmt.Fprintln(app.UI.Out(), "  "+th.KVKey.Render("path")+"         "+
+		th.KVValue.Render(app.Config.ProfilePath))
+	return nil
+}
+
+func runProfileSet(app *App, key, value string) error {
+	adapterList, err := app.Adapters()
+	if err != nil {
+		return fmt.Errorf("load adapters: %w", err)
+	}
+	p, err := profile.Load(app.Config.ProfilePath)
+	if err != nil {
+		return err
+	}
+
+	switch key {
+	case "platforms":
+		names := parseCSV(value)
+		if len(names) == 0 {
+			p.DefaultPlatforms = nil
+		} else {
+			known := adapters.NameSet(adapterList)
+			for _, n := range names {
+				if _, ok := known[n]; !ok {
+					return fmt.Errorf("unknown platform %q — valid: %s", n, strings.Join(adapterNames(adapterList), ", "))
+				}
+			}
+			p.DefaultPlatforms = names
+		}
+	case "scope":
+		if !profile.IsValidScope(value) {
+			return fmt.Errorf("invalid scope %q — valid: user, project, \"\"", value)
+		}
+		p.DefaultScope = value
+	default:
+		return fmt.Errorf("unknown key %q — valid keys: platforms, scope", key)
+	}
+
+	if err := profile.Save(app.Config.ProfilePath, p); err != nil {
+		return err
+	}
+	if app.Config.JSON {
+		return app.UI.JSON(p)
+	}
+	app.UI.Success("set %s → %s", key, value)
+	return nil
+}
+
+func runProfileReset(app *App) error {
+	if err := profile.Delete(app.Config.ProfilePath); err != nil {
+		return err
+	}
+	if app.Config.JSON {
+		return app.UI.JSON(map[string]string{"path": app.Config.ProfilePath, "status": "deleted"})
+	}
+	app.UI.Success("removed %s", app.Config.ProfilePath)
+	return nil
+}
+
+// validateProfileAgainstAdapters drops any platform names that aren't in the
+// current adapter set; warns but doesn't fail.
+func validateProfileAgainstAdapters(p *profile.Profile, adapterList []adapters.Adapter) error {
+	if len(p.DefaultPlatforms) == 0 {
+		return nil
+	}
+	kept, dropped := profile.FilterKnownPlatforms(p.DefaultPlatforms, adapters.NameSet(adapterList))
+	if len(dropped) > 0 {
+		return fmt.Errorf("unknown platform(s): %s", strings.Join(dropped, ", "))
+	}
+	p.DefaultPlatforms = kept
+	return nil
+}
+
+func parseCSV(s string) []string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil
+	}
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+func adapterNames(as []adapters.Adapter) []string {
+	out := make([]string, 0, len(as))
+	for _, a := range as {
+		out = append(out, a.Name)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func formatPlatforms(p []string) string {
+	if len(p) == 0 {
+		return "(all detected)"
+	}
+	return strings.Join(p, ", ")
+}
+
+func formatScope(s string) string {
+	if s == "" {
+		return "(adapter default)"
+	}
+	return s
+}

--- a/cli/cmd/humblskills/root.go
+++ b/cli/cmd/humblskills/root.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/jjfantini/humblSKILLS/cli/internal/adapters"
 	"github.com/jjfantini/humblSKILLS/cli/internal/manifest"
+	"github.com/jjfantini/humblSKILLS/cli/internal/profile"
 	"github.com/jjfantini/humblSKILLS/cli/internal/registry"
 	"github.com/jjfantini/humblSKILLS/cli/internal/ui"
 )
@@ -27,6 +28,7 @@ type Config struct {
 	RegistryURL  string
 	CacheDir     string
 	ManifestPath string
+	ProfilePath  string
 	JSON         bool
 	NoColor      bool
 	Verbose      bool
@@ -38,6 +40,7 @@ type globalFlags struct {
 	registry string
 	cacheDir string
 	manifest string
+	profile  string
 	json     bool
 	noColor  bool
 	verbose  bool
@@ -64,6 +67,7 @@ func newRootCmd() *cobra.Command {
 	f.StringVar(&g.registry, "registry", "", "registry URL (or file:// path). Defaults to the hosted registry; env: HUMBLSKILLS_REGISTRY")
 	f.StringVar(&g.cacheDir, "cache-dir", "", "cache directory (env: HUMBLSKILLS_CACHE_DIR; default: XDG_CACHE_HOME/humblskills)")
 	f.StringVar(&g.manifest, "manifest", "", "install manifest path (env: HUMBLSKILLS_MANIFEST; default: XDG_STATE_HOME/humblskills/manifest.json)")
+	f.StringVar(&g.profile, "profile", "", "profile config path (env: HUMBLSKILLS_PROFILE; default: XDG_CONFIG_HOME/humblskills/config.json)")
 	f.BoolVar(&g.json, "json", false, "emit machine-readable JSON")
 	f.BoolVar(&g.noColor, "no-color", false, "disable ANSI colour output")
 	f.BoolVarP(&g.verbose, "verbose", "v", false, "print extra detail")
@@ -79,6 +83,7 @@ func newRootCmd() *cobra.Command {
 		newUpdateCmd(app),
 		newListCmd(app),
 		newSearchCmd(app),
+		newProfileCmd(app),
 	)
 
 	return cmd
@@ -126,6 +131,12 @@ func configureApp(_ *cobra.Command, app *App, g globalFlags) error {
 	}
 	cfg.ManifestPath = manifestPath
 
+	profilePath, err := resolveProfilePath(firstNonEmpty(g.profile, os.Getenv("HUMBLSKILLS_PROFILE")))
+	if err != nil {
+		return err
+	}
+	cfg.ProfilePath = profilePath
+
 	app.Config = cfg
 	app.Adapters = adapters.Load
 
@@ -151,6 +162,13 @@ func resolveManifestPath(override string) (string, error) {
 		return override, nil
 	}
 	return manifest.DefaultPath()
+}
+
+func resolveProfilePath(override string) (string, error) {
+	if override != "" {
+		return override, nil
+	}
+	return profile.DefaultPath()
 }
 
 func firstNonEmpty(vs ...string) string {

--- a/cli/internal/profile/profile.go
+++ b/cli/internal/profile/profile.go
@@ -1,0 +1,114 @@
+// Package profile persists the user's humblskills preferences: default
+// install platforms and default scope. The profile is plain JSON on disk
+// and mirrors the manifest package's Load/Save shape.
+package profile
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	"github.com/adrg/xdg"
+)
+
+const SchemaVersion = 1
+
+// Profile is the full on-disk document.
+type Profile struct {
+	SchemaVersion    int      `json:"schema_version"`
+	DefaultPlatforms []string `json:"default_platforms,omitempty"`
+	DefaultScope     string   `json:"default_scope,omitempty"`
+}
+
+// DefaultPath resolves the profile path using XDG_CONFIG_HOME (falling back
+// to ~/.humblskills/config.json if XDG resolution fails).
+func DefaultPath() (string, error) {
+	if p, err := xdg.ConfigFile("humblskills/config.json"); err == nil {
+		return p, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve profile path: %w", err)
+	}
+	return filepath.Join(home, ".humblskills", "config.json"), nil
+}
+
+// Load reads the profile at path. If the file doesn't exist, returns an
+// empty Profile with the current schema version (not an error).
+func Load(path string) (*Profile, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return &Profile{SchemaVersion: SchemaVersion}, nil
+		}
+		return nil, fmt.Errorf("read profile: %w", err)
+	}
+	var p Profile
+	if err := json.Unmarshal(data, &p); err != nil {
+		return nil, fmt.Errorf("parse profile: %w", err)
+	}
+	if p.SchemaVersion == 0 {
+		p.SchemaVersion = SchemaVersion
+	}
+	if p.SchemaVersion != SchemaVersion {
+		return nil, fmt.Errorf("unsupported profile schema_version %d (expected %d)", p.SchemaVersion, SchemaVersion)
+	}
+	return &p, nil
+}
+
+// Save writes the profile to path atomically (write tmp, rename).
+func Save(path string, p *Profile) error {
+	if p == nil {
+		return errors.New("nil profile")
+	}
+	if p.SchemaVersion == 0 {
+		p.SchemaVersion = SchemaVersion
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create profile dir: %w", err)
+	}
+	data, err := json.MarshalIndent(p, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		return fmt.Errorf("write tmp: %w", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("rename tmp: %w", err)
+	}
+	return nil
+}
+
+// Delete removes the profile file. Missing files are not an error.
+func Delete(path string) error {
+	if err := os.Remove(path); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("delete profile: %w", err)
+	}
+	return nil
+}
+
+// FilterKnownPlatforms drops platform names that aren't in `known`. Returns
+// the cleaned list and the names that were dropped (for caller warnings).
+func FilterKnownPlatforms(platforms []string, known map[string]struct{}) (kept, dropped []string) {
+	for _, p := range platforms {
+		if _, ok := known[p]; ok {
+			kept = append(kept, p)
+		} else {
+			dropped = append(dropped, p)
+		}
+	}
+	return kept, dropped
+}
+
+// IsValidScope reports whether s is one of the accepted scope values.
+func IsValidScope(s string) bool {
+	return s == "" || s == "user" || s == "project"
+}

--- a/cli/internal/tui/profile.go
+++ b/cli/internal/tui/profile.go
@@ -1,0 +1,164 @@
+package tui
+
+import (
+	"errors"
+
+	"github.com/charmbracelet/huh"
+
+	"github.com/jjfantini/humblSKILLS/cli/internal/adapters"
+	"github.com/jjfantini/humblSKILLS/cli/internal/profile"
+	"github.com/jjfantini/humblSKILLS/cli/internal/ui"
+)
+
+// RunProfileEditor opens a huh form to edit the user's profile (default
+// platforms + default scope). Returns (updated profile, saved, err). `saved`
+// is false if the user cancelled.
+func RunProfileEditor(theme *ui.Theme, adapterList []adapters.Adapter, p *profile.Profile) (*profile.Profile, bool, error) {
+	if p == nil {
+		p = &profile.Profile{}
+	}
+
+	platforms := make([]string, len(p.DefaultPlatforms))
+	copy(platforms, p.DefaultPlatforms)
+	scope := p.DefaultScope
+
+	opts := make([]huh.Option[string], 0, len(adapterList))
+	for _, a := range adapterList {
+		opts = append(opts, huh.NewOption(a.Name, a.Name))
+	}
+
+	scopeOpts := []huh.Option[string]{
+		huh.NewOption("adapter default", ""),
+		huh.NewOption("user", "user"),
+		huh.NewOption("project", "project"),
+	}
+
+	form := huh.NewForm(
+		huh.NewGroup(
+			huh.NewMultiSelect[string]().
+				Title("Default platforms").
+				Description("Leave empty to use every detected platform.").
+				Options(opts...).
+				Value(&platforms),
+			huh.NewSelect[string]().
+				Title("Default scope").
+				Options(scopeOpts...).
+				Value(&scope),
+		),
+	).WithTheme(ui.HuhTheme(theme))
+
+	if err := form.Run(); err != nil {
+		if errors.Is(err, huh.ErrUserAborted) {
+			return p, false, nil
+		}
+		return p, false, err
+	}
+
+	out := &profile.Profile{
+		SchemaVersion:    profile.SchemaVersion,
+		DefaultPlatforms: platforms,
+		DefaultScope:     scope,
+	}
+	return out, true, nil
+}
+
+// InstallModalResult is what the install platform picker returns.
+type InstallModalResult struct {
+	Platforms []string
+	Scope     string
+	Confirmed bool
+	EditProfile bool
+}
+
+// RunInstallPlatformModal opens a huh form asking the user which detected
+// platforms to install `skill` into, and at which scope. Default selections
+// come from the profile. Returns Confirmed=false if the user cancelled, and
+// EditProfile=true if they chose the "edit profile" action.
+func RunInstallPlatformModal(
+	theme *ui.Theme,
+	skill string,
+	adapterList []adapters.Adapter,
+	detected map[string]bool,
+	p *profile.Profile,
+) (InstallModalResult, error) {
+	if p == nil {
+		p = &profile.Profile{}
+	}
+
+	platforms := make([]string, 0)
+	if len(p.DefaultPlatforms) > 0 {
+		for _, name := range p.DefaultPlatforms {
+			if detected[name] {
+				platforms = append(platforms, name)
+			}
+		}
+	} else {
+		for _, a := range adapterList {
+			if detected[a.Name] {
+				platforms = append(platforms, a.Name)
+			}
+		}
+	}
+
+	opts := make([]huh.Option[string], 0, len(adapterList))
+	for _, a := range adapterList {
+		label := a.Name
+		if detected[a.Name] {
+			label += "  (detected)"
+		} else {
+			label += "  (not detected)"
+		}
+		opts = append(opts, huh.NewOption(label, a.Name))
+	}
+
+	scope := p.DefaultScope
+	scopeOpts := []huh.Option[string]{
+		huh.NewOption("adapter default", ""),
+		huh.NewOption("user", "user"),
+		huh.NewOption("project", "project"),
+	}
+
+	action := "install"
+	actionOpts := []huh.Option[string]{
+		huh.NewOption("install", "install"),
+		huh.NewOption("edit profile defaults", "profile"),
+		huh.NewOption("cancel", "cancel"),
+	}
+
+	form := huh.NewForm(
+		huh.NewGroup(
+			huh.NewMultiSelect[string]().
+				Title("Install "+skill+" to:").
+				Options(opts...).
+				Value(&platforms),
+			huh.NewSelect[string]().
+				Title("Scope").
+				Options(scopeOpts...).
+				Value(&scope),
+			huh.NewSelect[string]().
+				Title("Action").
+				Options(actionOpts...).
+				Value(&action),
+		),
+	).WithTheme(ui.HuhTheme(theme))
+
+	if err := form.Run(); err != nil {
+		if errors.Is(err, huh.ErrUserAborted) {
+			return InstallModalResult{}, nil
+		}
+		return InstallModalResult{}, err
+	}
+
+	switch action {
+	case "profile":
+		return InstallModalResult{EditProfile: true}, nil
+	case "cancel":
+		return InstallModalResult{}, nil
+	}
+
+	return InstallModalResult{
+		Platforms: platforms,
+		Scope:     scope,
+		Confirmed: true,
+	}, nil
+}


### PR DESCRIPTION
## Summary
- TUI install no longer forces every detected platform — a new modal after skill selection lets the user pick platforms + scope per install, with defaults from a persisted user profile.
- New `humblskills profile` command with `show`, `set`, `reset`, `path` subcommands (scriptable) plus a bare interactive TUI editor.
- New `p profile` footer shortcut in every skill picker jumps straight to the profile editor and returns to the picker.
- Profile stored as JSON at `XDG_CONFIG_HOME/humblskills/config.json` (fallback `~/.humblskills/config.json`); `--profile` / `HUMBLSKILLS_PROFILE` override.
- `--platform` bypasses the modal, preserving the scripted install path unchanged.

## Test plan
- [x] `go build ./...` and `go vet ./...` clean
- [x] `go test ./...` passes
- [x] `profile show` on fresh machine prints empty profile
- [x] `profile set platforms claude-code` round-trips via `profile show --json`
- [x] `profile set platforms bogus` errors with the adapter list
- [x] `profile set scope bad` errors; `profile set scope user` succeeds
- [x] `profile reset` deletes the file
- [x] `profile path` prints the resolved path
- [ ] Manual: TTY install flow opens modal with profile defaults pre-checked, `p` re-opens profile editor
- [ ] Manual: `humblskills install <skill> --platform cursor` skips the modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)