### PR TITLE
feat(cli)!: local-owned preserve list on update

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,22 +75,22 @@ skip confirmation prompts.
 
 ## Preserving user content across updates
 
-Smart skills often accumulate user-owned content over time — raw sources,
+Smart skills often accumulate user-owned content over time - raw sources,
 append-only memory (`log.md`, `decisions.md`, `patterns.md`), LLM-curated
 wiki pages. By default `humblskills update` and `humblskills install`
 overwrite the skill directory with whatever the registry ships. Skills that
-need to keep user content around on update can declare a `preserve:` list in
+need to keep user content around on update declare a `preserve:` list in
 their SKILL.md frontmatter.
 
 Entries are relative paths inside the skill directory. A trailing `/` makes
 the entry a directory; anything else is a file. Globs are not supported.
 
-| Entry form      | Example              | Meaning on update                                    |
-| --------------- | -------------------- | ---------------------------------------------------- |
-| **File**        | `references/log.md`  | User wins. User's bytes survive the update.          |
+| Entry form      | Example              | Meaning on update                                        |
+| --------------- | -------------------- | -------------------------------------------------------- |
+| **File**        | `references/log.md`  | User wins. User's bytes survive the update.              |
 | **Directory**   | `references/wiki/`   | Deep merge. Staging wins per-file; user-only files kept. |
 
-Fresh installs always seed everything from the registry — preserve only kicks
+Fresh installs always seed everything from the registry - preserve only kicks
 in when replacing an existing install. Running `humblskills uninstall` wipes
 everything, including preserved content.
 
@@ -110,7 +110,61 @@ preserve:
 
 Skill authors who declare a preserve *directory* should note in their skill
 docs that any files shipped inside that directory may be overwritten on
-update — that's the deep-merge contract.
+update - that's the deep-merge contract.
+
+### You own the preserve list after install
+
+The `preserve:` list in the registry is the **seed** - what ships on first
+install. After that, the list belongs to you. `humblskills update` reads
+`preserve:` from the **installed** `SKILL.md` on disk (per target, so each
+platform + scope is independent), not from the upstream registry entry.
+
+That means:
+
+- Add an entry locally -> that path survives your next `humblskills update`,
+  even if upstream never listed it.
+- Remove an entry locally -> that path gets overwritten by upstream bytes on
+  the next update.
+- Empty your `preserve:` list -> the update is a clean overwrite for every
+  path.
+
+Use this to pin author-shipped files in place, protect notes you stash
+inside the skill directory, or stop preserving a directory the author
+reorganized.
+
+Only the `preserve:` key is treated as user-owned. Every other frontmatter
+field (`name`, `description`, `version`, `requires`, `platforms`, `tags`)
+and the full markdown body flow through from upstream on every update. So
+when the author ships a new description, version bump, or prose rewrite,
+you get it; your `preserve:` list rides along untouched. This also means
+your preserve edits survive indefinitely - you don't need to re-edit after
+each update, because the rewritten `SKILL.md` carries your list forward.
+
+A few nuances:
+
+- If you'd rather freeze the entire `SKILL.md` (maybe you've made prose
+  edits you don't want overwritten), add `SKILL.md` itself to your
+  `preserve:` list. That makes user-wins on the file, so upstream changes
+  to the description/version/body stop flowing - opt-in only.
+- If the installed `SKILL.md` is missing, unparseable, or carries an
+  invalid preserve list (e.g. a `..` traversal), the engine falls back to
+  the registry's list and prints a warning. It won't wipe your data over
+  broken YAML.
+- The YAML round-trip on update normalizes whitespace and drops comments
+  inside the frontmatter block. Keys and their values stay intact; only
+  formatting inside the YAML mapping is rewritten.
+
+### Getting clean upstream: `--force` or reinstall
+
+```sh
+humblskills update --force <skill>          # bypass local preserve, reinstall cleanly
+humblskills install --force <skill>         # same effect outside update flow
+humblskills uninstall <skill> && humblskills install <skill>   # equivalent
+```
+
+`--force` ignores your local preserve edits and replaces the on-disk skill
+with exactly what the registry ships. This is the escape hatch for "throw
+away my customizations and give me the author's version."
 
 ## Developing the CLI
 

--- a/cli/cmd/humblskills/install.go
+++ b/cli/cmd/humblskills/install.go
@@ -145,8 +145,19 @@ func selectPlatforms(adapterList []adapters.Adapter, requested []string) ([]stri
 }
 
 func printInstall(app *App, r install.Result) {
+	for _, w := range r.Warnings {
+		where := ""
+		if w.Skill != "" {
+			where = w.Skill
+			if w.Platform != "" {
+				where += " [" + w.Platform + "/" + w.Scope + "]"
+			}
+			where += ": "
+		}
+		app.UI.Warn("%s%s", where, w.Msg)
+	}
 	if len(r.Results) == 0 {
-		app.UI.Warn("nothing to do — skill(s) declared no matching platforms")
+		app.UI.Warn("nothing to do - skill(s) declared no matching platforms")
 		return
 	}
 	var installed, replaced, skipped, forced []install.TargetResult

--- a/cli/cmd/humblskills/update.go
+++ b/cli/cmd/humblskills/update.go
@@ -18,6 +18,7 @@ import (
 type updateFlags struct {
 	all   bool
 	check bool
+	force bool
 }
 
 func newUpdateCmd(app *App) *cobra.Command {
@@ -28,13 +29,17 @@ func newUpdateCmd(app *App) *cobra.Command {
 		Long: "update with no args opens an interactive picker of every skill that " +
 			"has drifted from the registry. Names can be passed to narrow the set. " +
 			"--all (or --yes) skips the picker and upgrades every drifted skill. " +
-			"--check prints the diff and exits without changing anything.",
+			"--check prints the diff and exits without changing anything. " +
+			"By default, the preserve list on each installed SKILL.md is honored so " +
+			"your local customizations survive. --force ignores local preserve edits " +
+			"and reinstalls cleanly from the registry (equivalent to uninstall + install).",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runUpdate(app, args, f)
 		},
 	}
 	cmd.Flags().BoolVar(&f.all, "all", false, "update every drifted skill without prompting")
 	cmd.Flags().BoolVar(&f.check, "check", false, "print what would change and exit")
+	cmd.Flags().BoolVar(&f.force, "force", false, "bypass local preserve edits; reinstall cleanly from registry")
 	return cmd
 }
 
@@ -120,13 +125,14 @@ func runUpdate(app *App, only []string, f updateFlags) error {
 					Adapters:  adapters,
 					Platforms: plats,
 					Scope:     scope,
-					Force:     true,
+					Force:     f.force,
 					OnEvent:   sink,
 				})
 				if err != nil {
 					return fmt.Errorf("%s: %w", plan.Skill, err)
 				}
 				aggregate.Results = append(aggregate.Results, res.Results...)
+				aggregate.Warnings = append(aggregate.Warnings, res.Warnings...)
 			}
 		}
 		return nil

--- a/cli/internal/frontmatter/validate.go
+++ b/cli/internal/frontmatter/validate.go
@@ -192,6 +192,14 @@ func normalizePreserve(raw string) string {
 	return cleaned
 }
 
+// ValidatePreserve is the exported entry point for preserve-list validation.
+// Returns a list of human-readable error strings (empty on success). Used by
+// the install engine to decide whether an installed skill's locally-edited
+// preserve list is safe to apply.
+func ValidatePreserve(entries []string) []string {
+	return validatePreserve(entries)
+}
+
 // validatePreserve checks every entry in fm.Preserve for shape violations and
 // returns a list of error strings (empty on success).
 func validatePreserve(entries []string) []string {

--- a/cli/internal/install/engine.go
+++ b/cli/internal/install/engine.go
@@ -40,6 +40,19 @@ type TargetResult struct {
 // Result aggregates every target outcome produced by one install run.
 type Result struct {
 	Results []TargetResult `json:"results"`
+	// Warnings are non-fatal notices collected during the run (e.g. local
+	// preserve list unreadable, fell back to registry). Every warning is also
+	// emitted as a PhaseWarn event; this slice is a convenience for callers
+	// that don't install an EventSink.
+	Warnings []Warning `json:"warnings,omitempty"`
+}
+
+// Warning is a structured non-fatal notice from one Execute call.
+type Warning struct {
+	Skill    string `json:"skill,omitempty"`
+	Platform string `json:"platform,omitempty"`
+	Scope    string `json:"scope,omitempty"`
+	Msg      string `json:"msg"`
 }
 
 // Engine installs skills by fetching tarballs, verifying dir_sha, and copying
@@ -105,6 +118,18 @@ func (e *Engine) Execute(reg *registry.Registry, plan []Step, opts ExecuteOpts) 
 	m, err := manifest.Load(e.ManifestPath)
 	if err != nil {
 		return res, fmt.Errorf("load manifest: %w", err)
+	}
+
+	// Wrap the caller's sink so every PhaseWarn also lands in Result.Warnings.
+	// Callers without an EventSink (scripts, --json) still see warnings.
+	userSink := opts.OnEvent
+	opts.OnEvent = func(ev Event) {
+		if ev.Phase == PhaseWarn {
+			res.Warnings = append(res.Warnings, Warning{
+				Skill: ev.Skill, Platform: ev.Platform, Scope: ev.Scope, Msg: ev.Msg,
+			})
+		}
+		userSink.emit(ev)
 	}
 
 	total := countTargets(plan, opts.Platforms)
@@ -298,12 +323,45 @@ func (e *Engine) installOne(
 			Phase: PhaseTargetStart, Skill: skill.Name, IsDep: step.IsDep,
 			Platform: pt.pending.adapter.Name, Scope: pt.pending.target.Scope,
 		})
-		// When preserve is active, build a per-target copy of staging with
-		// user content merged in, leaving the shared staging pristine for
-		// sibling targets. pt.existingPath is the authoritative previous
-		// location whether this is a normal replace or a scope move.
+		// Decide which preserve list to honour for this target:
+		//
+		//   - --force: none. Caller explicitly asked for a clean upstream
+		//     overwrite, matching 'uninstall + install'.
+		//   - fresh install (no existingPath): none. Staging already ships
+		//     the registry's view; there's nothing on disk to merge back.
+		//   - normal replace: read the USER's list from the installed
+		//     SKILL.md. User owns the list post-install; removing an entry
+		//     locally means they want that path overwritten next update.
+		//   - fallback: if the local SKILL.md is missing, unparseable, or
+		//     holds an invalid preserve list, use the registry's list and
+		//     warn. Safer than silently wiping user data over broken YAML.
+		var preserveList []string
+		userOwnsPreserve := false
+		if pt.existingPath != "" && !opts.Force {
+			if local, ok, reason := loadLocalPreserve(pt.existingPath); ok {
+				preserveList = local
+				userOwnsPreserve = true
+			} else {
+				preserveList = skill.Preserve
+				opts.OnEvent.emit(Event{
+					Phase: PhaseWarn, Skill: skill.Name,
+					Platform: pt.pending.adapter.Name, Scope: pt.pending.target.Scope,
+					Msg: fmt.Sprintf("local preserve unreadable (%s); falling back to registry list", reason),
+				})
+			}
+		}
+
+		// We need a per-target staging copy when either:
+		//   - preserveList has entries to merge user content from existingPath
+		//   - user owns the preserve list (even if empty) - we need to
+		//     rewrite staging's SKILL.md with the user's preserve key so
+		//     their edit persists past this update. Everything else in the
+		//     SKILL.md (description, version, body) still flows from the
+		//     registry.
+		// Otherwise, staging is used as-is so sibling targets share it.
 		writeSrc := staging
-		if len(skill.Preserve) > 0 && pt.existingPath != "" {
+		needsPerTarget := pt.existingPath != "" && (len(preserveList) > 0 || userOwnsPreserve)
+		if needsPerTarget {
 			perTarget := filepath.Join(
 				e.StagingDir,
 				skill.Name+"-"+shortSHA(reg.Source.SHA)+"-"+pt.pending.adapter.Name+"-"+pt.pending.target.Scope,
@@ -315,8 +373,16 @@ func (e *Engine) installOne(
 			if err := copyTree(staging, perTarget); err != nil {
 				return nil, fmt.Errorf("copy per-target staging: %w", err)
 			}
-			if err := applyPreserve(pt.existingPath, perTarget, skill.Preserve); err != nil {
-				return nil, err
+			if len(preserveList) > 0 {
+				if err := applyPreserve(pt.existingPath, perTarget, preserveList); err != nil {
+					return nil, err
+				}
+			}
+			if userOwnsPreserve {
+				skillMDPath := filepath.Join(perTarget, "SKILL.md")
+				if err := mergePreserveIntoSkillMD(skillMDPath, preserveList); err != nil {
+					return nil, fmt.Errorf("merge preserve into SKILL.md: %w", err)
+				}
 			}
 			writeSrc = perTarget
 		}

--- a/cli/internal/install/engine_test.go
+++ b/cli/internal/install/engine_test.go
@@ -6,6 +6,7 @@ import (
 	"compress/gzip"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -491,7 +492,11 @@ func TestInstall_PreserveDir_DeepMerge(t *testing.T) {
 	}
 }
 
-func TestInstall_PreserveWithForce(t *testing.T) {
+// TestInstall_ForceBypassesPreserve pins the new semantics: --force gives the
+// caller a clean upstream install. Preserve is NOT applied, so any user edits
+// in preserved paths are overwritten. This is the documented escape hatch for
+// users who want to drop their local customizations without running uninstall.
+func TestInstall_ForceBypassesPreserve(t *testing.T) {
 	root := t.TempDir()
 	cacheDir := filepath.Join(root, "cache")
 	installRoot := filepath.Join(root, "home", ".claude", "skills")
@@ -541,8 +546,593 @@ func TestInstall_PreserveWithForce(t *testing.T) {
 		t.Fatal(err)
 	}
 	got, _ := os.ReadFile(logPath)
-	if string(got) != "user-edit\n" {
-		t.Errorf("forced install wiped preserved file: got %q", got)
+	if string(got) != "initial\n" {
+		t.Errorf("force should have restored upstream bytes; got %q", got)
+	}
+}
+
+// skillMD is a tiny helper for writing test SKILL.md bodies with valid
+// frontmatter. The tests exercise the locally-edited preserve behavior, so
+// the files they ship/install need real YAML up top for Parse to succeed.
+func skillMD(name, version string, preserve []string) string {
+	sb := strings.Builder{}
+	sb.WriteString("---\n")
+	sb.WriteString("name: " + name + "\n")
+	sb.WriteString("description: test skill\n")
+	sb.WriteString("version: " + version + "\n")
+	if len(preserve) > 0 {
+		sb.WriteString("preserve:\n")
+		for _, p := range preserve {
+			sb.WriteString("  - " + p + "\n")
+		}
+	} else {
+		sb.WriteString("preserve: []\n")
+	}
+	sb.WriteString("---\n\n# " + name + "\n")
+	return sb.String()
+}
+
+// TestUpdate_UsesLocalPreserveList: the user added a new entry to their
+// installed SKILL.md's preserve list. On update that user-only entry must
+// survive even though the registry doesn't list it.
+func TestUpdate_UsesLocalPreserveList(t *testing.T) {
+	root := t.TempDir()
+	cacheDir := filepath.Join(root, "cache")
+	installRoot := filepath.Join(root, "home", ".claude", "skills")
+	manifestPath := filepath.Join(root, "manifest.json")
+
+	v1Body := skillMD("foo", "0.1.0", []string{"log.md"})
+	v1Files := map[string]string{
+		"skills/foo/SKILL.md": v1Body,
+		"skills/foo/log.md":   "initial\n",
+	}
+	v1Flat := map[string]string{"SKILL.md": v1Body, "log.md": "initial\n"}
+	v1SHA := expectedDirSHA(t, v1Flat)
+	src1 := "shauser1aaaaa"
+	seedTarball(t, cacheDir, "ex", "r", src1, "ex-r-abc", v1Files)
+
+	v2Body := skillMD("foo", "0.2.0", []string{"log.md"})
+	v2Files := map[string]string{
+		"skills/foo/SKILL.md": v2Body,
+		"skills/foo/log.md":   "shipped-v2\n",
+	}
+	v2Flat := map[string]string{"SKILL.md": v2Body, "log.md": "shipped-v2\n"}
+	v2SHA := expectedDirSHA(t, v2Flat)
+	src2 := "shauser2bbbbb"
+	seedTarball(t, cacheDir, "ex", "r", src2, "ex-r-def", v2Files)
+
+	adapter := adapters.Adapter{
+		Name:           "test",
+		InstallTargets: map[string]string{"user": installRoot},
+		DefaultScope:   "user",
+	}
+	engine := NewEngine(cacheDir, manifestPath)
+	engine.Now = func() time.Time { return time.Unix(1700000000, 0).UTC() }
+
+	reg1 := &registry.Registry{
+		SchemaVersion: registry.SchemaVersion,
+		Source:        registry.Source{Repo: "github.com/ex/r", SHA: src1},
+		Skills: []registry.Skill{{
+			Name: "foo", Version: "0.1.0", Path: "skills/foo",
+			Platforms: []string{"test"}, DirSHA: v1SHA,
+			Preserve: []string{"log.md"},
+		}},
+	}
+	plan1, _ := Plan(reg1, "foo")
+	if _, err := engine.Execute(reg1, plan1, ExecuteOpts{
+		Adapters: []adapters.Adapter{adapter}, Platforms: []string{"test"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// User extends their preserve list locally and drops a file.
+	userBody := skillMD("foo", "0.1.0", []string{"log.md", "notes.md"})
+	if err := os.WriteFile(filepath.Join(installRoot, "foo", "SKILL.md"), []byte(userBody), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(installRoot, "foo", "notes.md"), []byte("user-notes\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(installRoot, "foo", "log.md"), []byte("user-log\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	reg2 := &registry.Registry{
+		SchemaVersion: registry.SchemaVersion,
+		Source:        registry.Source{Repo: "github.com/ex/r", SHA: src2},
+		Skills: []registry.Skill{{
+			Name: "foo", Version: "0.2.0", Path: "skills/foo",
+			Platforms: []string{"test"}, DirSHA: v2SHA,
+			Preserve: []string{"log.md"},
+		}},
+	}
+	plan2, _ := Plan(reg2, "foo")
+	r, err := engine.Execute(reg2, plan2, ExecuteOpts{
+		Adapters: []adapters.Adapter{adapter}, Platforms: []string{"test"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(r.Warnings) != 0 {
+		t.Errorf("unexpected warnings: %+v", r.Warnings)
+	}
+
+	if got, _ := os.ReadFile(filepath.Join(installRoot, "foo", "log.md")); string(got) != "user-log\n" {
+		t.Errorf("log.md: want user-log, got %q", got)
+	}
+	if got, err := os.ReadFile(filepath.Join(installRoot, "foo", "notes.md")); err != nil || string(got) != "user-notes\n" {
+		t.Errorf("notes.md: want user-notes, got %q err=%v", got, err)
+	}
+
+	// The rewritten SKILL.md must keep the user's preserve list AND ship
+	// upstream's version/body bump. This is the merge-preserve-key contract.
+	finalSKILL, err := os.ReadFile(filepath.Join(installRoot, "foo", "SKILL.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(finalSKILL), "- notes.md") {
+		t.Errorf("SKILL.md should carry the user's notes.md preserve entry; got:\n%s", finalSKILL)
+	}
+	if !strings.Contains(string(finalSKILL), "version: 0.2.0") {
+		t.Errorf("SKILL.md should have v2 version from upstream; got:\n%s", finalSKILL)
+	}
+}
+
+// TestUpdate_MergesPreserveKeyKeepsUpstreamBody: verify the merge-preserve
+// contract - every non-preserve frontmatter key and the markdown body flow
+// from upstream on update, while the user's preserve list rides along.
+func TestUpdate_MergesPreserveKeyKeepsUpstreamBody(t *testing.T) {
+	root := t.TempDir()
+	cacheDir := filepath.Join(root, "cache")
+	installRoot := filepath.Join(root, "home", ".claude", "skills")
+	manifestPath := filepath.Join(root, "manifest.json")
+
+	v1Body := skillMD("foo", "0.1.0", []string{"log.md"})
+	v1Files := map[string]string{
+		"skills/foo/SKILL.md": v1Body,
+		"skills/foo/log.md":   "initial\n",
+	}
+	v1Flat := map[string]string{"SKILL.md": v1Body, "log.md": "initial\n"}
+	v1SHA := expectedDirSHA(t, v1Flat)
+	src1 := "shamrg1aaaaa"
+	seedTarball(t, cacheDir, "ex", "r", src1, "ex-r-abc", v1Files)
+
+	// v2 SKILL.md has a richer body so we can prove it flows through.
+	v2Body := "---\nname: foo\ndescription: v2 rewrite\nversion: 0.2.0\npreserve:\n  - log.md\n---\n\n# foo v2\n\nBrand new body with a warning.\n"
+	v2Files := map[string]string{
+		"skills/foo/SKILL.md": v2Body,
+		"skills/foo/log.md":   "shipped-v2\n",
+	}
+	v2Flat := map[string]string{"SKILL.md": v2Body, "log.md": "shipped-v2\n"}
+	v2SHA := expectedDirSHA(t, v2Flat)
+	src2 := "shamrg2bbbbb"
+	seedTarball(t, cacheDir, "ex", "r", src2, "ex-r-def", v2Files)
+
+	adapter := adapters.Adapter{
+		Name:           "test",
+		InstallTargets: map[string]string{"user": installRoot},
+		DefaultScope:   "user",
+	}
+	engine := NewEngine(cacheDir, manifestPath)
+	engine.Now = func() time.Time { return time.Unix(1700000000, 0).UTC() }
+
+	reg1 := &registry.Registry{
+		SchemaVersion: registry.SchemaVersion,
+		Source:        registry.Source{Repo: "github.com/ex/r", SHA: src1},
+		Skills: []registry.Skill{{
+			Name: "foo", Version: "0.1.0", Path: "skills/foo",
+			Platforms: []string{"test"}, DirSHA: v1SHA,
+			Preserve: []string{"log.md"},
+		}},
+	}
+	plan1, _ := Plan(reg1, "foo")
+	if _, err := engine.Execute(reg1, plan1, ExecuteOpts{
+		Adapters: []adapters.Adapter{adapter}, Platforms: []string{"test"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// User extends preserve with a custom entry.
+	userBody := skillMD("foo", "0.1.0", []string{"log.md", "decisions.md"})
+	if err := os.WriteFile(filepath.Join(installRoot, "foo", "SKILL.md"), []byte(userBody), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(installRoot, "foo", "decisions.md"), []byte("d1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	reg2 := &registry.Registry{
+		SchemaVersion: registry.SchemaVersion,
+		Source:        registry.Source{Repo: "github.com/ex/r", SHA: src2},
+		Skills: []registry.Skill{{
+			Name: "foo", Version: "0.2.0", Path: "skills/foo",
+			Platforms: []string{"test"}, DirSHA: v2SHA,
+			Preserve: []string{"log.md"}, // upstream never listed decisions.md
+		}},
+	}
+	plan2, _ := Plan(reg2, "foo")
+	if _, err := engine.Execute(reg2, plan2, ExecuteOpts{
+		Adapters: []adapters.Adapter{adapter}, Platforms: []string{"test"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(installRoot, "foo", "SKILL.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(got)
+	// Upstream bits: description bumped, version bumped, body copied.
+	if !strings.Contains(s, "description: v2 rewrite") {
+		t.Errorf("SKILL.md missing v2 description:\n%s", s)
+	}
+	if !strings.Contains(s, "version: 0.2.0") {
+		t.Errorf("SKILL.md missing v2 version:\n%s", s)
+	}
+	if !strings.Contains(s, "Brand new body with a warning.") {
+		t.Errorf("SKILL.md body not refreshed from upstream:\n%s", s)
+	}
+	// User bit: their custom preserve entry survived.
+	if !strings.Contains(s, "- decisions.md") {
+		t.Errorf("SKILL.md lost user's decisions.md preserve entry:\n%s", s)
+	}
+	if !strings.Contains(s, "- log.md") {
+		t.Errorf("SKILL.md lost log.md preserve entry:\n%s", s)
+	}
+	// And the user-only file should still exist too.
+	if _, err := os.Stat(filepath.Join(installRoot, "foo", "decisions.md")); err != nil {
+		t.Errorf("decisions.md user file missing after update: %v", err)
+	}
+}
+
+// TestUpdate_PreserveSurvivesMultipleUpdates: the rewritten SKILL.md must
+// carry the user's preserve list so the NEXT update continues to honour it
+// without the user having to re-edit every time.
+func TestUpdate_PreserveSurvivesMultipleUpdates(t *testing.T) {
+	root := t.TempDir()
+	cacheDir := filepath.Join(root, "cache")
+	installRoot := filepath.Join(root, "home", ".claude", "skills")
+	manifestPath := filepath.Join(root, "manifest.json")
+
+	build := func(version string) (string, string, map[string]string, string) {
+		body := skillMD("foo", version, []string{"log.md"})
+		files := map[string]string{
+			"skills/foo/SKILL.md": body,
+			"skills/foo/log.md":   "shipped-" + version + "\n",
+		}
+		flat := map[string]string{"SKILL.md": body, "log.md": "shipped-" + version + "\n"}
+		return body, expectedDirSHA(t, flat), files, version
+	}
+	_, v1SHA, v1Files, _ := build("0.1.0")
+	_, v2SHA, v2Files, _ := build("0.2.0")
+	_, v3SHA, v3Files, _ := build("0.3.0")
+	src1, src2, src3 := "shamul1aaaaa", "shamul2bbbbb", "shamul3ccccc"
+	seedTarball(t, cacheDir, "ex", "r", src1, "ex-r-v1", v1Files)
+	seedTarball(t, cacheDir, "ex", "r", src2, "ex-r-v2", v2Files)
+	seedTarball(t, cacheDir, "ex", "r", src3, "ex-r-v3", v3Files)
+
+	adapter := adapters.Adapter{
+		Name:           "test",
+		InstallTargets: map[string]string{"user": installRoot},
+		DefaultScope:   "user",
+	}
+	engine := NewEngine(cacheDir, manifestPath)
+	engine.Now = func() time.Time { return time.Unix(1700000000, 0).UTC() }
+
+	reg := func(version, sha, dirSHA string) *registry.Registry {
+		return &registry.Registry{
+			SchemaVersion: registry.SchemaVersion,
+			Source:        registry.Source{Repo: "github.com/ex/r", SHA: sha},
+			Skills: []registry.Skill{{
+				Name: "foo", Version: version, Path: "skills/foo",
+				Platforms: []string{"test"}, DirSHA: dirSHA,
+				Preserve: []string{"log.md"},
+			}},
+		}
+	}
+
+	plan1, _ := Plan(reg("0.1.0", src1, v1SHA), "foo")
+	if _, err := engine.Execute(reg("0.1.0", src1, v1SHA), plan1, ExecuteOpts{
+		Adapters: []adapters.Adapter{adapter}, Platforms: []string{"test"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// User extends preserve with references/ dir.
+	userBody := skillMD("foo", "0.1.0", []string{"log.md", "references/"})
+	if err := os.WriteFile(filepath.Join(installRoot, "foo", "SKILL.md"), []byte(userBody), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(installRoot, "foo", "references"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(installRoot, "foo", "references", "note.md"), []byte("keep-me\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Update v1 -> v2.
+	plan2, _ := Plan(reg("0.2.0", src2, v2SHA), "foo")
+	if _, err := engine.Execute(reg("0.2.0", src2, v2SHA), plan2, ExecuteOpts{
+		Adapters: []adapters.Adapter{adapter}, Platforms: []string{"test"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Update v2 -> v3 WITHOUT re-editing SKILL.md. The user's preserve
+	// list should still ride through because the previous update wrote
+	// it back into the on-disk SKILL.md.
+	plan3, _ := Plan(reg("0.3.0", src3, v3SHA), "foo")
+	if _, err := engine.Execute(reg("0.3.0", src3, v3SHA), plan3, ExecuteOpts{
+		Adapters: []adapters.Adapter{adapter}, Platforms: []string{"test"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(installRoot, "foo", "references", "note.md"))
+	if err != nil || string(got) != "keep-me\n" {
+		t.Errorf("references/note.md lost across two updates: got=%q err=%v", got, err)
+	}
+	skillMDAfter, _ := os.ReadFile(filepath.Join(installRoot, "foo", "SKILL.md"))
+	if !strings.Contains(string(skillMDAfter), "- references/") {
+		t.Errorf("SKILL.md lost user's references/ preserve entry after two updates:\n%s", skillMDAfter)
+	}
+	if !strings.Contains(string(skillMDAfter), "version: 0.3.0") {
+		t.Errorf("SKILL.md should have v3 version; got:\n%s", skillMDAfter)
+	}
+}
+
+// TestUpdate_LocalPreserveRemovedEntryWipes: user cleared their local
+// preserve list, so an entry the registry still preserves now gets the
+// upstream bytes instead of the user's.
+func TestUpdate_LocalPreserveRemovedEntryWipes(t *testing.T) {
+	root := t.TempDir()
+	cacheDir := filepath.Join(root, "cache")
+	installRoot := filepath.Join(root, "home", ".claude", "skills")
+	manifestPath := filepath.Join(root, "manifest.json")
+
+	v1Body := skillMD("foo", "0.1.0", []string{"log.md"})
+	v1Files := map[string]string{
+		"skills/foo/SKILL.md": v1Body,
+		"skills/foo/log.md":   "initial\n",
+	}
+	v1Flat := map[string]string{"SKILL.md": v1Body, "log.md": "initial\n"}
+	v1SHA := expectedDirSHA(t, v1Flat)
+	src1 := "sharmv1aaaaaa"
+	seedTarball(t, cacheDir, "ex", "r", src1, "ex-r-abc", v1Files)
+
+	v2Body := skillMD("foo", "0.2.0", []string{"log.md"})
+	v2Files := map[string]string{
+		"skills/foo/SKILL.md": v2Body,
+		"skills/foo/log.md":   "shipped-v2\n",
+	}
+	v2Flat := map[string]string{"SKILL.md": v2Body, "log.md": "shipped-v2\n"}
+	v2SHA := expectedDirSHA(t, v2Flat)
+	src2 := "sharmv2bbbbbb"
+	seedTarball(t, cacheDir, "ex", "r", src2, "ex-r-def", v2Files)
+
+	adapter := adapters.Adapter{
+		Name:           "test",
+		InstallTargets: map[string]string{"user": installRoot},
+		DefaultScope:   "user",
+	}
+	engine := NewEngine(cacheDir, manifestPath)
+	engine.Now = func() time.Time { return time.Unix(1700000000, 0).UTC() }
+
+	reg1 := &registry.Registry{
+		SchemaVersion: registry.SchemaVersion,
+		Source:        registry.Source{Repo: "github.com/ex/r", SHA: src1},
+		Skills: []registry.Skill{{
+			Name: "foo", Version: "0.1.0", Path: "skills/foo",
+			Platforms: []string{"test"}, DirSHA: v1SHA,
+			Preserve: []string{"log.md"},
+		}},
+	}
+	plan1, _ := Plan(reg1, "foo")
+	if _, err := engine.Execute(reg1, plan1, ExecuteOpts{
+		Adapters: []adapters.Adapter{adapter}, Platforms: []string{"test"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// User opts out of preserving anything AND edits log.md.
+	userBody := skillMD("foo", "0.1.0", nil)
+	if err := os.WriteFile(filepath.Join(installRoot, "foo", "SKILL.md"), []byte(userBody), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(installRoot, "foo", "log.md"), []byte("user-log\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	reg2 := &registry.Registry{
+		SchemaVersion: registry.SchemaVersion,
+		Source:        registry.Source{Repo: "github.com/ex/r", SHA: src2},
+		Skills: []registry.Skill{{
+			Name: "foo", Version: "0.2.0", Path: "skills/foo",
+			Platforms: []string{"test"}, DirSHA: v2SHA,
+			Preserve: []string{"log.md"}, // registry still preserves, but user opted out.
+		}},
+	}
+	plan2, _ := Plan(reg2, "foo")
+	if _, err := engine.Execute(reg2, plan2, ExecuteOpts{
+		Adapters: []adapters.Adapter{adapter}, Platforms: []string{"test"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if got, _ := os.ReadFile(filepath.Join(installRoot, "foo", "log.md")); string(got) != "shipped-v2\n" {
+		t.Errorf("log.md: user opted out of preserve, want shipped-v2, got %q", got)
+	}
+}
+
+// TestUpdate_LocalSkillMdUnparseable_FallsBackToRegistry: a mangled SKILL.md
+// must not cause user-data loss. The engine falls back to the registry's
+// preserve list and emits a warning.
+func TestUpdate_LocalSkillMdUnparseable_FallsBackToRegistry(t *testing.T) {
+	root := t.TempDir()
+	cacheDir := filepath.Join(root, "cache")
+	installRoot := filepath.Join(root, "home", ".claude", "skills")
+	manifestPath := filepath.Join(root, "manifest.json")
+
+	v1Body := skillMD("foo", "0.1.0", []string{"log.md"})
+	v1Files := map[string]string{
+		"skills/foo/SKILL.md": v1Body,
+		"skills/foo/log.md":   "initial\n",
+	}
+	v1Flat := map[string]string{"SKILL.md": v1Body, "log.md": "initial\n"}
+	v1SHA := expectedDirSHA(t, v1Flat)
+	src1 := "shaunp1aaaaa"
+	seedTarball(t, cacheDir, "ex", "r", src1, "ex-r-abc", v1Files)
+
+	v2Body := skillMD("foo", "0.2.0", []string{"log.md"})
+	v2Files := map[string]string{
+		"skills/foo/SKILL.md": v2Body,
+		"skills/foo/log.md":   "shipped-v2\n",
+	}
+	v2Flat := map[string]string{"SKILL.md": v2Body, "log.md": "shipped-v2\n"}
+	v2SHA := expectedDirSHA(t, v2Flat)
+	src2 := "shaunp2bbbbb"
+	seedTarball(t, cacheDir, "ex", "r", src2, "ex-r-def", v2Files)
+
+	adapter := adapters.Adapter{
+		Name:           "test",
+		InstallTargets: map[string]string{"user": installRoot},
+		DefaultScope:   "user",
+	}
+	engine := NewEngine(cacheDir, manifestPath)
+	engine.Now = func() time.Time { return time.Unix(1700000000, 0).UTC() }
+
+	reg1 := &registry.Registry{
+		SchemaVersion: registry.SchemaVersion,
+		Source:        registry.Source{Repo: "github.com/ex/r", SHA: src1},
+		Skills: []registry.Skill{{
+			Name: "foo", Version: "0.1.0", Path: "skills/foo",
+			Platforms: []string{"test"}, DirSHA: v1SHA,
+			Preserve: []string{"log.md"},
+		}},
+	}
+	plan1, _ := Plan(reg1, "foo")
+	if _, err := engine.Execute(reg1, plan1, ExecuteOpts{
+		Adapters: []adapters.Adapter{adapter}, Platforms: []string{"test"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Corrupt the on-disk SKILL.md.
+	if err := os.WriteFile(filepath.Join(installRoot, "foo", "SKILL.md"), []byte(":::not yaml:::\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(installRoot, "foo", "log.md"), []byte("user-log\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	reg2 := &registry.Registry{
+		SchemaVersion: registry.SchemaVersion,
+		Source:        registry.Source{Repo: "github.com/ex/r", SHA: src2},
+		Skills: []registry.Skill{{
+			Name: "foo", Version: "0.2.0", Path: "skills/foo",
+			Platforms: []string{"test"}, DirSHA: v2SHA,
+			Preserve: []string{"log.md"},
+		}},
+	}
+	plan2, _ := Plan(reg2, "foo")
+	r, err := engine.Execute(reg2, plan2, ExecuteOpts{
+		Adapters: []adapters.Adapter{adapter}, Platforms: []string{"test"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got, _ := os.ReadFile(filepath.Join(installRoot, "foo", "log.md")); string(got) != "user-log\n" {
+		t.Errorf("log.md: fallback to registry preserve should keep user bytes, got %q", got)
+	}
+	if len(r.Warnings) == 0 {
+		t.Errorf("expected a warning about unparseable SKILL.md")
+	}
+}
+
+// TestUpdate_LocalPreserveInvalid_FallsBackToRegistry: the local SKILL.md
+// parses but carries an invalid preserve list (e.g. a `..` traversal).
+// Engine rejects it, warns, and falls back to the registry list.
+func TestUpdate_LocalPreserveInvalid_FallsBackToRegistry(t *testing.T) {
+	root := t.TempDir()
+	cacheDir := filepath.Join(root, "cache")
+	installRoot := filepath.Join(root, "home", ".claude", "skills")
+	manifestPath := filepath.Join(root, "manifest.json")
+
+	v1Body := skillMD("foo", "0.1.0", []string{"log.md"})
+	v1Files := map[string]string{
+		"skills/foo/SKILL.md": v1Body,
+		"skills/foo/log.md":   "initial\n",
+	}
+	v1Flat := map[string]string{"SKILL.md": v1Body, "log.md": "initial\n"}
+	v1SHA := expectedDirSHA(t, v1Flat)
+	src1 := "shainv1aaaaa"
+	seedTarball(t, cacheDir, "ex", "r", src1, "ex-r-abc", v1Files)
+
+	v2Body := skillMD("foo", "0.2.0", []string{"log.md"})
+	v2Files := map[string]string{
+		"skills/foo/SKILL.md": v2Body,
+		"skills/foo/log.md":   "shipped-v2\n",
+	}
+	v2Flat := map[string]string{"SKILL.md": v2Body, "log.md": "shipped-v2\n"}
+	v2SHA := expectedDirSHA(t, v2Flat)
+	src2 := "shainv2bbbbb"
+	seedTarball(t, cacheDir, "ex", "r", src2, "ex-r-def", v2Files)
+
+	adapter := adapters.Adapter{
+		Name:           "test",
+		InstallTargets: map[string]string{"user": installRoot},
+		DefaultScope:   "user",
+	}
+	engine := NewEngine(cacheDir, manifestPath)
+	engine.Now = func() time.Time { return time.Unix(1700000000, 0).UTC() }
+
+	reg1 := &registry.Registry{
+		SchemaVersion: registry.SchemaVersion,
+		Source:        registry.Source{Repo: "github.com/ex/r", SHA: src1},
+		Skills: []registry.Skill{{
+			Name: "foo", Version: "0.1.0", Path: "skills/foo",
+			Platforms: []string{"test"}, DirSHA: v1SHA,
+			Preserve: []string{"log.md"},
+		}},
+	}
+	plan1, _ := Plan(reg1, "foo")
+	if _, err := engine.Execute(reg1, plan1, ExecuteOpts{
+		Adapters: []adapters.Adapter{adapter}, Platforms: []string{"test"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	userBody := skillMD("foo", "0.1.0", []string{"../evil"})
+	if err := os.WriteFile(filepath.Join(installRoot, "foo", "SKILL.md"), []byte(userBody), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(installRoot, "foo", "log.md"), []byte("user-log\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	reg2 := &registry.Registry{
+		SchemaVersion: registry.SchemaVersion,
+		Source:        registry.Source{Repo: "github.com/ex/r", SHA: src2},
+		Skills: []registry.Skill{{
+			Name: "foo", Version: "0.2.0", Path: "skills/foo",
+			Platforms: []string{"test"}, DirSHA: v2SHA,
+			Preserve: []string{"log.md"},
+		}},
+	}
+	plan2, _ := Plan(reg2, "foo")
+	r, err := engine.Execute(reg2, plan2, ExecuteOpts{
+		Adapters: []adapters.Adapter{adapter}, Platforms: []string{"test"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got, _ := os.ReadFile(filepath.Join(installRoot, "foo", "log.md")); string(got) != "user-log\n" {
+		t.Errorf("log.md: fallback should keep user bytes, got %q", got)
+	}
+	if len(r.Warnings) == 0 {
+		t.Errorf("expected a warning about invalid preserve list")
 	}
 }
 

--- a/cli/internal/install/events.go
+++ b/cli/internal/install/events.go
@@ -21,11 +21,15 @@ const (
 	PhaseRunDone Phase = "run_done"
 	// PhaseError fires when a target fails; the caller can show Err and abort.
 	PhaseError Phase = "error"
+	// PhaseWarn is a non-fatal notice the caller may want to surface (e.g.
+	// fell back from a broken local preserve list to the registry list). Msg
+	// holds the human-readable detail.
+	PhaseWarn Phase = "warn"
 )
 
 // Event is a single progress notification emitted by the engine. Not every
 // field is populated for every Phase — Total is only meaningful on RunStart,
-// Outcome only on TargetDone, Err only on Error.
+// Outcome only on TargetDone, Err only on Error, Msg only on Warn.
 type Event struct {
 	Phase    Phase
 	Skill    string
@@ -35,6 +39,7 @@ type Event struct {
 	Total    int
 	Outcome  Outcome
 	Err      error
+	Msg      string
 }
 
 // EventSink receives engine progress events. Callers that don't care about

--- a/cli/internal/install/preserve.go
+++ b/cli/internal/install/preserve.go
@@ -1,0 +1,192 @@
+package install
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/jjfantini/humblSKILLS/cli/internal/frontmatter"
+)
+
+// loadLocalPreserve reads SKILL.md at installPath and returns the preserve
+// list the user currently has on disk, validated. The semantics are:
+//
+//   - ok == true: list is safe to apply (may be empty, which means "preserve
+//     nothing"). Callers must honor the empty list - it's how users opt into
+//     a clean overwrite of previously-preserved paths.
+//   - ok == false: something went wrong parsing or validating; reason holds a
+//     short diagnostic suitable for a warning event. Callers should fall back
+//     to the registry's preserve list to avoid accidentally destroying data
+//     over a broken YAML edit.
+func loadLocalPreserve(installPath string) (entries []string, ok bool, reason string) {
+	skillMD := filepath.Join(installPath, "SKILL.md")
+	data, err := os.ReadFile(skillMD)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, false, "SKILL.md missing"
+		}
+		return nil, false, "SKILL.md read failed: " + err.Error()
+	}
+	fm, _, err := frontmatter.Parse(data)
+	if err != nil {
+		return nil, false, "SKILL.md frontmatter parse failed: " + err.Error()
+	}
+	if perrs := frontmatter.ValidatePreserve(fm.Preserve); len(perrs) > 0 {
+		return nil, false, "invalid preserve list: " + strings.Join(perrs, "; ")
+	}
+	return fm.Preserve, true, ""
+}
+
+const frontmatterDelimiter = "---"
+
+// mergePreserveIntoSkillMD rewrites path so its frontmatter's `preserve:` key
+// matches preserve. Every other frontmatter key and the body below are kept
+// byte-for-byte from the existing file, save for YAML re-serialization of the
+// mapping itself (which may normalize whitespace and drops comments inside
+// the YAML block).
+//
+// This is what lets users edit only the `preserve:` list and still receive
+// upstream changes to the rest of SKILL.md on every update. Whenever the
+// caller has determined the user "owns" their preserve list, it should call
+// this against the per-target staging SKILL.md before the final replaceDir.
+//
+// When preserve is empty (nil or len 0), the key is written as an explicit
+// empty flow sequence (`preserve: []`) so the next update still sees it as
+// user-authored rather than defaulting back to the registry's list.
+func mergePreserveIntoSkillMD(path string, preserve []string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", path, err)
+	}
+
+	yamlStart, yamlEnd, bodyStart, err := frontmatterBounds(data)
+	if err != nil {
+		return fmt.Errorf("%s: %w", path, err)
+	}
+
+	var root yaml.Node
+	if err := yaml.Unmarshal(data[yamlStart:yamlEnd], &root); err != nil {
+		return fmt.Errorf("%s: parse frontmatter: %w", path, err)
+	}
+	if root.Kind != yaml.DocumentNode || len(root.Content) == 0 {
+		return fmt.Errorf("%s: unexpected frontmatter shape", path)
+	}
+	mapping := root.Content[0]
+	if mapping.Kind != yaml.MappingNode {
+		return fmt.Errorf("%s: frontmatter is not a mapping", path)
+	}
+
+	setPreserveKey(mapping, preserve)
+
+	var yamlOut bytes.Buffer
+	enc := yaml.NewEncoder(&yamlOut)
+	enc.SetIndent(2)
+	if err := enc.Encode(&root); err != nil {
+		return fmt.Errorf("%s: encode frontmatter: %w", path, err)
+	}
+	if err := enc.Close(); err != nil {
+		return fmt.Errorf("%s: close yaml encoder: %w", path, err)
+	}
+
+	var out bytes.Buffer
+	out.WriteString(frontmatterDelimiter + "\n")
+	out.Write(yamlOut.Bytes())
+	out.WriteString(frontmatterDelimiter + "\n")
+	out.Write(data[bodyStart:])
+
+	fi, statErr := os.Stat(path)
+	mode := os.FileMode(0o644)
+	if statErr == nil {
+		mode = fi.Mode().Perm()
+	}
+	return os.WriteFile(path, out.Bytes(), mode)
+}
+
+// frontmatterBounds locates the YAML block inside a SKILL.md-shaped file.
+// Returns offsets into data: [yamlStart, yamlEnd) is the YAML body (between
+// the two `---` delimiters, excluding them), bodyStart is the first byte
+// after the trailing `---\n` (where the markdown body begins).
+func frontmatterBounds(data []byte) (yamlStart, yamlEnd, bodyStart int, err error) {
+	// Strip BOM + leading whitespace for the delimiter search, but we need
+	// to return offsets into the original data so the markdown body stays
+	// byte-exact.
+	stripped := bytes.TrimPrefix(data, []byte{0xEF, 0xBB, 0xBF})
+	prefixSkipped := len(data) - len(stripped)
+	ws := len(stripped) - len(bytes.TrimLeft(stripped, " \t\r\n"))
+	cursor := prefixSkipped + ws
+	if !bytes.HasPrefix(data[cursor:], []byte(frontmatterDelimiter)) {
+		return 0, 0, 0, errors.New("missing leading '---' frontmatter delimiter")
+	}
+	cursor += len(frontmatterDelimiter)
+	// Accept optional trailing whitespace on the opening line.
+	for cursor < len(data) && (data[cursor] == ' ' || data[cursor] == '\t' || data[cursor] == '\r') {
+		cursor++
+	}
+	if cursor >= len(data) || data[cursor] != '\n' {
+		return 0, 0, 0, errors.New("opening '---' must be followed by a newline")
+	}
+	cursor++
+	yamlStart = cursor
+
+	// Find the closing delimiter on its own line.
+	for cursor < len(data) {
+		lineEnd := bytes.IndexByte(data[cursor:], '\n')
+		var line []byte
+		if lineEnd < 0 {
+			line = data[cursor:]
+		} else {
+			line = data[cursor : cursor+lineEnd]
+		}
+		if bytes.Equal(bytes.TrimRight(line, " \t\r"), []byte(frontmatterDelimiter)) {
+			yamlEnd = cursor
+			if lineEnd < 0 {
+				bodyStart = len(data)
+			} else {
+				bodyStart = cursor + lineEnd + 1
+			}
+			return yamlStart, yamlEnd, bodyStart, nil
+		}
+		if lineEnd < 0 {
+			break
+		}
+		cursor += lineEnd + 1
+	}
+	return 0, 0, 0, errors.New("missing closing '---' frontmatter delimiter")
+}
+
+// setPreserveKey replaces or inserts the `preserve` key in a mapping node.
+// Unknown keys stay intact and in their original positions; the mapping keeps
+// its existing order (new key appended at the end).
+func setPreserveKey(mapping *yaml.Node, preserve []string) {
+	value := preserveSeqNode(preserve)
+	for i := 0; i+1 < len(mapping.Content); i += 2 {
+		if mapping.Content[i].Value == "preserve" {
+			mapping.Content[i+1] = value
+			return
+		}
+	}
+	key := &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: "preserve"}
+	mapping.Content = append(mapping.Content, key, value)
+}
+
+// preserveSeqNode builds a YAML sequence node for a preserve list. An empty
+// list becomes `[]` (flow style) so the key stays visible and machine-readable
+// in the rewritten SKILL.md.
+func preserveSeqNode(preserve []string) *yaml.Node {
+	seq := &yaml.Node{Kind: yaml.SequenceNode, Tag: "!!seq"}
+	if len(preserve) == 0 {
+		seq.Style = yaml.FlowStyle
+		return seq
+	}
+	for _, s := range preserve {
+		seq.Content = append(seq.Content, &yaml.Node{
+			Kind: yaml.ScalarNode, Tag: "!!str", Value: s,
+		})
+	}
+	return seq
+}


### PR DESCRIPTION
## Summary

- `humblskills update` reads `preserve:` from each **installed** `SKILL.md` instead of the registry, so user edits survive updates. Every other frontmatter key and the markdown body still flow through from upstream.
- Only the `preserve:` key is treated as user-owned. On update, the engine merges the user's list into the staging SKILL.md so edits persist across multiple updates - no re-editing after each bump.
- `--force` on `update`/`install` bypasses local preserve entirely and reinstalls cleanly from the registry. Equivalent to `uninstall && install`.
- Fallback: unparseable / invalid local preserve list -> fall back to registry list + emit a warning event. Broken YAML never wipes user data silently.

### Breaking change

`update` previously ran with `Force: true`, which under the new semantics would wipe every preserve entry on every update. A `--force` flag is now exposed on `update` and the default is no-force. Scripts that relied on the old "update always reinstalls cleanly" behavior need to pass `--force`.

## Test plan

- [x] `go test ./...` across all packages (every existing preserve test still green + 6 new ones)
- [x] `TestInstall_ForceBypassesPreserve` - `--force` wipes preserved files (inverted from old contract)
- [x] `TestUpdate_UsesLocalPreserveList` - user-added preserve entry survives update; SKILL.md ends up with user's list + upstream's version
- [x] `TestUpdate_LocalPreserveRemovedEntryWipes` - clearing local preserve -> path gets upstream bytes
- [x] `TestUpdate_LocalSkillMdUnparseable_FallsBackToRegistry` - broken YAML -> fall back + warn, user files intact
- [x] `TestUpdate_LocalPreserveInvalid_FallsBackToRegistry` - `../evil` rejected, fall back + warn
- [x] `TestUpdate_MergesPreserveKeyKeepsUpstreamBody` - v2 description/version/body flow through, user's custom preserve entry rides along
- [x] `TestUpdate_PreserveSurvivesMultipleUpdates` - v1 -> v2 -> v3 with no re-edit keeps user's `references/` preserve entry

## Implementation notes

- New helper `loadLocalPreserve` in [cli/internal/install/preserve.go](cli/internal/install/preserve.go) reads the installed `SKILL.md` and validates the preserve list.
- New helper `mergePreserveIntoSkillMD` rewrites staging's SKILL.md frontmatter so only the `preserve:` key is replaced (via `yaml.Node` round-trip). Unknown frontmatter keys are preserved in place; the markdown body is kept byte-for-byte from upstream.
- `ValidatePreserve` is now exported from the frontmatter package so the engine reuses the same shape checks (`..` traversal, absolute paths, overlap, duplicates).
- `install.Result` gained a `Warnings []Warning` slice; `PhaseWarn` + `Event.Msg` let progress UIs surface them live.

Made with [Cursor](https://cursor.com)