### PR TITLE
feat(cli): humblskills dashboard with in-TUI navigation

### DIFF
--- a/cli/cmd/humblskills/browse_skills.go
+++ b/cli/cmd/humblskills/browse_skills.go
@@ -174,7 +174,7 @@ func buildSkillItems(skills []registry.Skill, m *manifest.Manifest) []skillItem 
 //
 // Pressing `p` opens the profile editor inline and re-enters the picker so
 // every surface that uses this browser gets the same footer shortcut.
-func runSkillBrowser(app *App, section string, skills []skillItem, mode skillsBrowseMode, emptyMsg string) (string, string, error) {
+func runSkillBrowser(app *App, section string, skills []skillItem, mode skillsBrowseMode, emptyMsg string, fromDashboard bool) (string, string, error) {
 	if len(skills) == 0 {
 		app.UI.Info(emptyMsg)
 		return "", "", nil
@@ -225,7 +225,7 @@ func runSkillBrowser(app *App, section string, skills []skillItem, mode skillsBr
 	}
 
 	for {
-		res, err := tui.RunListDetail(tui.Config{
+		cfg := tui.Config{
 			Theme:      app.UI.Theme(),
 			Version:    resolveVersion().Version,
 			Section:    section,
@@ -235,7 +235,12 @@ func runSkillBrowser(app *App, section string, skills []skillItem, mode skillsBr
 			RightTitle: "DETAIL",
 			Actions:    actions,
 			EmptyMsg:   emptyMsg,
-		})
+		}
+		if fromDashboard {
+			cfg.BackKey = "esc"
+			cfg.BackLabel = "back"
+		}
+		res, err := tui.RunListDetail(cfg)
 		if err != nil {
 			return "", "", err
 		}

--- a/cli/cmd/humblskills/install.go
+++ b/cli/cmd/humblskills/install.go
@@ -35,7 +35,7 @@ func newInstallCmd(app *App) *cobra.Command {
 				skill = args[0]
 			}
 			f.platformsSet = cmd.Flags().Changed("platform")
-			return runInstall(app, skill, f)
+			return runInstall(app, skill, f, false)
 		},
 	}
 	cmd.Flags().StringSliceVar(&f.platforms, "platform", nil, "restrict install to these adapters (default: all detected)")
@@ -44,7 +44,7 @@ func newInstallCmd(app *App) *cobra.Command {
 	return cmd
 }
 
-func runInstall(app *App, skill string, f installFlags) error {
+func runInstall(app *App, skill string, f installFlags, fromDashboard bool) error {
 	adapterList, err := app.Adapters()
 	if err != nil {
 		return fmt.Errorf("load adapters: %w", err)
@@ -56,8 +56,11 @@ func runInstall(app *App, skill string, f installFlags) error {
 	}
 
 	if skill == "" {
-		skill, err = pickSkill(app, reg)
+		skill, err = pickSkill(app, reg, fromDashboard)
 		if err != nil {
+			if fromDashboard && err.Error() == "no skill selected" {
+				return nil
+			}
 			return err
 		}
 	}
@@ -71,6 +74,9 @@ func runInstall(app *App, skill string, f installFlags) error {
 			return err
 		}
 		if !ok {
+			if fromDashboard {
+				return nil
+			}
 			return fmt.Errorf("install cancelled")
 		}
 		platforms = plats
@@ -245,7 +251,7 @@ func promptInstallTargets(app *App, adapterList []adapters.Adapter, skill string
 // pickSkill opens the shared two-pane skill browser over the registry and
 // returns the chosen skill's name. Matches the search surface 1:1 so the user
 // can't tell them apart — a zero-arg install IS a searchable picker.
-func pickSkill(app *App, reg *registry.Registry) (string, error) {
+func pickSkill(app *App, reg *registry.Registry, fromDashboard bool) (string, error) {
 	if len(reg.Skills) == 0 {
 		return "", fmt.Errorf("registry is empty")
 	}
@@ -262,7 +268,7 @@ func pickSkill(app *App, reg *registry.Registry) (string, error) {
 	}
 	items := buildSkillItems(skills, m)
 
-	skill, action, err := runSkillBrowser(app, "Install", items, modeSearch, "registry is empty")
+	skill, action, err := runSkillBrowser(app, "Install", items, modeSearch, "registry is empty", fromDashboard)
 	if err != nil {
 		return "", err
 	}

--- a/cli/cmd/humblskills/list.go
+++ b/cli/cmd/humblskills/list.go
@@ -18,35 +18,42 @@ func newListCmd(app *App) *cobra.Command {
 		Use:   "list",
 		Short: "List installed skills",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			m, err := manifest.Load(app.Config.ManifestPath)
-			if err != nil {
-				return err
-			}
-			if app.Config.JSON {
-				return app.UI.JSON(m)
-			}
-			if len(m.Installations) == 0 {
-				app.UI.Info("no skills installed — try 'humblskills install <name>'")
-				return nil
-			}
-			installs := append([]manifest.Installation(nil), m.Installations...)
-			sort.Slice(installs, func(i, j int) bool {
-				if installs[i].Skill != installs[j].Skill {
-					return installs[i].Skill < installs[j].Skill
-				}
-				if installs[i].Platform != installs[j].Platform {
-					return installs[i].Platform < installs[j].Platform
-				}
-				return installs[i].Scope < installs[j].Scope
-			})
-
-			if tui.ShouldUseTUI(app.Config.JSON, app.Config.Quiet, app.Config.Yes) {
-				return runListTUI(app, m)
-			}
-			renderListTable(app, installs)
-			return nil
+			return runList(app, false)
 		},
 	}
+}
+
+// runList is the package-level entry point. `fromDashboard` softens ESC/quit
+// semantics so the launcher loop in start.go can re-enter the dashboard
+// instead of exiting the process.
+func runList(app *App, fromDashboard bool) error {
+	m, err := manifest.Load(app.Config.ManifestPath)
+	if err != nil {
+		return err
+	}
+	if app.Config.JSON {
+		return app.UI.JSON(m)
+	}
+	if len(m.Installations) == 0 {
+		app.UI.Info("no skills installed — try 'humblskills install <name>'")
+		return nil
+	}
+	installs := append([]manifest.Installation(nil), m.Installations...)
+	sort.Slice(installs, func(i, j int) bool {
+		if installs[i].Skill != installs[j].Skill {
+			return installs[i].Skill < installs[j].Skill
+		}
+		if installs[i].Platform != installs[j].Platform {
+			return installs[i].Platform < installs[j].Platform
+		}
+		return installs[i].Scope < installs[j].Scope
+	})
+
+	if tui.ShouldUseTUI(app.Config.JSON, app.Config.Quiet, app.Config.Yes) {
+		return runListTUI(app, m, fromDashboard)
+	}
+	renderListTable(app, installs)
+	return nil
 }
 
 // renderListTable prints installs as a bordered table using the shared theme.
@@ -84,7 +91,7 @@ func renderListTable(app *App, installs []manifest.Installation) {
 // runListTUI opens the shared two-pane browser in installed-only mode so list
 // looks identical to search, differing only in which skills are shown and
 // which actions are wired up.
-func runListTUI(app *App, m *manifest.Manifest) error {
+func runListTUI(app *App, m *manifest.Manifest, fromDashboard bool) error {
 	// Pull the registry to know whether each installed skill has drifted. If
 	// the registry is unreachable, fall back to the manifest versions.
 	reg, _, _ := registry.NewFetcher(app.Config.RegistryURL, app.Config.CacheDir).Load()
@@ -112,7 +119,7 @@ func runListTUI(app *App, m *manifest.Manifest) error {
 
 	items := buildSkillItems(skills, m)
 
-	skill, action, err := runSkillBrowser(app, "Installed", items, modeInstalledOnly, "no skills installed")
+	skill, action, err := runSkillBrowser(app, "Installed", items, modeInstalledOnly, "no skills installed", fromDashboard)
 	if err != nil {
 		return err
 	}

--- a/cli/cmd/humblskills/registry.go
+++ b/cli/cmd/humblskills/registry.go
@@ -31,33 +31,37 @@ func newRegistryRefreshCmd(app *App) *cobra.Command {
 		Use:   "refresh",
 		Short: "Force a refresh of the cached registry",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			f := registry.NewFetcher(app.Config.RegistryURL, app.Config.CacheDir)
-			var (
-				reg    *registry.Registry
-				origin registry.Origin
-			)
-			err := tui.RunWithSpinner(app.UI.Theme(), "refreshing registry…", func() error {
-				r, o, e := f.Refresh()
-				reg, origin = r, o
-				return e
-			})
-			if err != nil {
-				return err
-			}
-			info := f.Inspect()
-			res := refreshResult{
-				URL:       app.Config.RegistryURL,
-				Source:    string(origin),
-				Skills:    len(reg.Skills),
-				FetchedAt: info.FetchedAt,
-				CachePath: info.Path,
-			}
-			if app.Config.JSON {
-				return app.UI.JSON(res)
-			}
-			app.UI.Success("registry refreshed: %d skill%s from %s", res.Skills, plural(res.Skills), res.Source)
-			app.UI.Detail("  cache: %s", res.CachePath)
-			return nil
+			return runRegistryRefresh(app)
 		},
 	}
+}
+
+func runRegistryRefresh(app *App) error {
+	f := registry.NewFetcher(app.Config.RegistryURL, app.Config.CacheDir)
+	var (
+		reg    *registry.Registry
+		origin registry.Origin
+	)
+	err := tui.RunWithSpinner(app.UI.Theme(), "refreshing registry…", func() error {
+		r, o, e := f.Refresh()
+		reg, origin = r, o
+		return e
+	})
+	if err != nil {
+		return err
+	}
+	info := f.Inspect()
+	res := refreshResult{
+		URL:       app.Config.RegistryURL,
+		Source:    string(origin),
+		Skills:    len(reg.Skills),
+		FetchedAt: info.FetchedAt,
+		CachePath: info.Path,
+	}
+	if app.Config.JSON {
+		return app.UI.JSON(res)
+	}
+	app.UI.Success("registry refreshed: %d skill%s from %s", res.Skills, plural(res.Skills), res.Source)
+	app.UI.Detail("  cache: %s", res.CachePath)
+	return nil
 }

--- a/cli/cmd/humblskills/root.go
+++ b/cli/cmd/humblskills/root.go
@@ -58,8 +58,15 @@ func newRootCmd() *cobra.Command {
 		Long:          "humblskills installs curated skills (agentskills.io format) into Claude Code, Cursor, and friends — single binary, no server, no telemetry.",
 		SilenceUsage:  true,
 		SilenceErrors: true,
+		Args:          cobra.NoArgs,
 		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
 			return configureApp(cmd, app, g)
+		},
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			// Bare `humblskills` on an interactive TTY launches the
+			// dashboard. Non-TTY falls through to the help-style fallback so
+			// pipes, agents, and --json callers still get something useful.
+			return runStart(app)
 		},
 	}
 
@@ -75,6 +82,7 @@ func newRootCmd() *cobra.Command {
 	f.BoolVarP(&g.yes, "yes", "y", false, "skip confirmation prompts (auto-accept)")
 
 	cmd.AddCommand(
+		newStartCmd(app),
 		newVersionCmd(app),
 		newDoctorCmd(app),
 		newRegistryCmd(app),

--- a/cli/cmd/humblskills/search.go
+++ b/cli/cmd/humblskills/search.go
@@ -54,7 +54,7 @@ func newSearchCmd(app *App) *cobra.Command {
 			// two-pane browser so search == install-picker visually.
 			useTUI := query == "" && tui.ShouldUseTUI(app.Config.JSON, app.Config.Quiet, app.Config.Yes)
 			if useTUI {
-				return runSearchTUI(app, hits)
+				return runSearchTUI(app, hits, false)
 			}
 
 			app.UI.Println(renderSearchResults(app.UI.Theme(), hits, query))
@@ -80,21 +80,21 @@ func matches(s registry.Skill, q string) bool {
 
 // runSearchTUI opens the shared skill browser over hits and, if the user picks
 // one, hands the skill to runInstall so one TUI flows into the next.
-func runSearchTUI(app *App, hits []registry.Skill) error {
+func runSearchTUI(app *App, hits []registry.Skill, fromDashboard bool) error {
 	m, err := manifest.Load(app.Config.ManifestPath)
 	if err != nil {
 		m = &manifest.Manifest{}
 	}
 	items := buildSkillItems(hits, m)
 
-	skill, action, err := runSkillBrowser(app, "Search", items, modeSearch, "no skills match")
+	skill, action, err := runSkillBrowser(app, "Search", items, modeSearch, "no skills match", fromDashboard)
 	if err != nil {
 		return err
 	}
 	if action != "install" || skill == "" {
 		return nil
 	}
-	return runInstall(app, skill, installFlags{})
+	return runInstall(app, skill, installFlags{}, fromDashboard)
 }
 
 // renderSearchResults returns a multi-line, themed string listing every hit.

--- a/cli/cmd/humblskills/start.go
+++ b/cli/cmd/humblskills/start.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/jjfantini/humblSKILLS/cli/internal/install"
+	"github.com/jjfantini/humblSKILLS/cli/internal/manifest"
+	"github.com/jjfantini/humblSKILLS/cli/internal/registry"
+	"github.com/jjfantini/humblSKILLS/cli/internal/tui"
+)
+
+func newStartCmd(app *App) *cobra.Command {
+	return &cobra.Command{
+		Use:   "start",
+		Short: "Open the humblskills dashboard (default when run on a TTY)",
+		Long: "start opens the interactive dashboard — a tile grid with fuzzy " +
+			"search that routes into every humblskills command. When stdout " +
+			"isn't a terminal, prints the same command table as `--help`.",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runStart(app)
+		},
+	}
+}
+
+// runStart is the launcher loop. It re-enters the dashboard after every
+// sub-command returns, so ESC in any sub-screen bounces back to the grid.
+// Non-TTY paths fall through to the Cobra help text via printStartFallback.
+func runStart(app *App) error {
+	if !tui.ShouldUseTUI(app.Config.JSON, app.Config.Quiet, app.Config.Yes) {
+		return printStartFallback(app)
+	}
+
+	for {
+		cfg := tui.DashboardConfig{
+			Theme:    app.UI.Theme(),
+			Version:  resolveVersion().Version,
+			Greeting: tui.BuildDashboardGreeting(countDrifted(app)),
+			Tiles:    tui.DefaultDashboardTiles(),
+		}
+		res, err := tui.RunDashboard(cfg)
+		if err != nil {
+			return err
+		}
+		if res.Quit || res.Command == "" {
+			return nil
+		}
+		if err := dispatchDashboardCommand(app, res.Command); err != nil {
+			// Surface the error, then loop back so the user can keep working.
+			app.UI.Error("%s: %v", res.Command, err)
+		}
+	}
+}
+
+func dispatchDashboardCommand(app *App, cmd string) error {
+	switch cmd {
+	case "install":
+		return runInstall(app, "", installFlags{}, true)
+	case "list":
+		return runList(app, true)
+	case "update":
+		return runUpdate(app, nil, updateFlags{})
+	case "search":
+		reg, _, err := registry.NewFetcher(app.Config.RegistryURL, app.Config.CacheDir).Load()
+		if err != nil {
+			return err
+		}
+		hits := append([]registry.Skill(nil), reg.Skills...)
+		return runSearchTUI(app, hits, true)
+	case "uninstall":
+		return runUninstallPicker(app, true)
+	case "profile":
+		return runProfileEditor(app)
+	case "doctor":
+		return runDoctor(app)
+	case "registry":
+		return runRegistryRefresh(app)
+	case "version":
+		return runVersion(app)
+	}
+	return fmt.Errorf("unknown dashboard command: %s", cmd)
+}
+
+// countDrifted counts how many installed skills have a newer registry version.
+// Returns 0 on any error — the banner treats it as "up-to-date".
+func countDrifted(app *App) int {
+	m, err := manifest.Load(app.Config.ManifestPath)
+	if err != nil || m == nil {
+		return 0
+	}
+	reg, _, err := registry.NewFetcher(app.Config.RegistryURL, app.Config.CacheDir).Load()
+	if err != nil || reg == nil {
+		return 0
+	}
+	return len(install.PlanUpdates(reg, m, nil))
+}
+
+func printStartFallback(app *App) error {
+	th := app.UI.Theme()
+	out := app.UI.Out()
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "  "+th.Brand.Render("humblskills")+"  "+th.Crumb.Render("— skill installer for Claude Code, Cursor, and friends"))
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "  "+th.SectionTitle.Render("COMMANDS"))
+	cmds := []struct{ name, desc string }{
+		{"install", "add a skill to every detected platform"},
+		{"list", "show installed skills"},
+		{"update", "pull newer registry versions"},
+		{"search", "browse the registry"},
+		{"uninstall", "remove a skill"},
+		{"profile", "edit install defaults"},
+		{"doctor", "inspect adapter health"},
+		{"registry refresh", "refresh the registry cache"},
+		{"version", "print version + commit"},
+	}
+	for _, c := range cmds {
+		fmt.Fprintf(out, "  %s  %s\n", th.Name.Render(padRight(c.name, 18)), th.Detail.Render(c.desc))
+	}
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "  "+th.Crumb.Render("run 'humblskills <cmd> --help' for flags"))
+	fmt.Fprintln(out)
+	return nil
+}

--- a/cli/cmd/humblskills/uninstall.go
+++ b/cli/cmd/humblskills/uninstall.go
@@ -22,14 +22,14 @@ func newUninstallCmd(app *App) *cobra.Command {
 			if len(args) == 1 {
 				return runUninstall(app, args[0])
 			}
-			return runUninstallPicker(app)
+			return runUninstallPicker(app, false)
 		},
 	}
 }
 
 // runUninstallPicker opens the shared two-pane browser over installed skills
 // so the user can pick-and-remove without leaving the TUI.
-func runUninstallPicker(app *App) error {
+func runUninstallPicker(app *App, fromDashboard bool) error {
 	if !tui.ShouldUseTUI(app.Config.JSON, app.Config.Quiet, app.Config.Yes) {
 		return fmt.Errorf("skill name required — usage: humblskills uninstall <skill>")
 	}
@@ -60,7 +60,7 @@ func runUninstallPicker(app *App) error {
 	}
 	items := buildSkillItems(skills, m)
 
-	skill, action, err := runSkillBrowser(app, "Uninstall", items, modeInstalledOnly, "no skills installed")
+	skill, action, err := runSkillBrowser(app, "Uninstall", items, modeInstalledOnly, "no skills installed", fromDashboard)
 	if err != nil {
 		return err
 	}

--- a/cli/cmd/humblskills/version.go
+++ b/cli/cmd/humblskills/version.go
@@ -24,25 +24,29 @@ func newVersionCmd(app *App) *cobra.Command {
 		Use:   "version",
 		Short: "Print humblskills version and commit",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			info := resolveVersion()
-			if app.Config.JSON {
-				return app.UI.JSON(info)
-			}
-			th := app.UI.Theme()
-			suffix := ""
-			if info.Dirty {
-				suffix = th.Warn.Render(" (dirty)")
-			}
-			wordmark := th.Brand.Render("humblskills")
-			ver := th.Version.Render(info.Version)
-			sha := th.Detail.Render("commit " + info.Commit)
-			fmt.Fprintln(app.UI.Out(), "")
-			fmt.Fprintln(app.UI.Out(), "  "+wordmark+"  "+ver+suffix)
-			fmt.Fprintln(app.UI.Out(), "  "+sha)
-			fmt.Fprintln(app.UI.Out(), "")
-			return nil
+			return runVersion(app)
 		},
 	}
+}
+
+func runVersion(app *App) error {
+	info := resolveVersion()
+	if app.Config.JSON {
+		return app.UI.JSON(info)
+	}
+	th := app.UI.Theme()
+	suffix := ""
+	if info.Dirty {
+		suffix = th.Warn.Render(" (dirty)")
+	}
+	wordmark := th.Brand.Render("humblskills")
+	ver := th.Version.Render(info.Version)
+	sha := th.Detail.Render("commit " + info.Commit)
+	fmt.Fprintln(app.UI.Out(), "")
+	fmt.Fprintln(app.UI.Out(), "  "+wordmark+"  "+ver+suffix)
+	fmt.Fprintln(app.UI.Out(), "  "+sha)
+	fmt.Fprintln(app.UI.Out(), "")
+	return nil
 }
 
 func resolveVersion() versionInfo {

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/charmbracelet/huh v0.6.0
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/muesli/termenv v0.16.0
+	github.com/sahilm/fuzzy v0.1.1
 	github.com/spf13/cobra v1.10.2
 	golang.org/x/mod v0.17.0
 	golang.org/x/term v0.24.0

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -41,6 +41,8 @@ github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97MGsxSvLiUE2X8qFplwetxpGLQrlU1Q9AUEIzCaM=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
+github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=
 github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
@@ -63,6 +65,8 @@ github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJ
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/sahilm/fuzzy v0.1.1 h1:ceu5RHF8DGgoi+/dR5PsECjCDH1BE3Fnmpo7aVXOdRA=
+github.com/sahilm/fuzzy v0.1.1/go.mod h1:VFvziUEIMCrT6A6tw2RFIXPXXmzXbOsSHF0DOI8ZK9Y=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
 github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
 github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=

--- a/cli/internal/tui/dashboard.go
+++ b/cli/internal/tui/dashboard.go
@@ -1,0 +1,478 @@
+package tui
+
+import (
+	"fmt"
+	"os"
+	"os/user"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/sahilm/fuzzy"
+
+	"github.com/jjfantini/humblSKILLS/cli/internal/ui"
+)
+
+// DashboardResult is what RunDashboard returns to the launcher loop.
+// Command is one of the Tile.Command values (or "" on quit).
+type DashboardResult struct {
+	Command string
+	Quit    bool
+}
+
+// DashboardTile is one launchable action in the grid.
+type DashboardTile struct {
+	Command string   // "install", "list", etc. — surfaced to the launcher
+	Label   string   // displayed name
+	Hotkey  string   // single-key shortcut (e.g. "i", "/", "R")
+	Desc    string   // one-line description
+	Sub     string   // muted foot line ("skills · deps · conflicts")
+	Status  string   // optional badge text ("3 available", "5 drift", "ok")
+	Aliases []string // additional fuzzy-search keywords
+}
+
+// DashboardGreeting is the banner displayed above the tile grid.
+type DashboardGreeting struct {
+	User     string // username ("jennings")
+	Updates  int    // how many drifted installs
+	Cwd      string // working dir
+	LastScan string // "18:04" or ""
+}
+
+// DashboardConfig bundles everything RunDashboard needs.
+type DashboardConfig struct {
+	Theme    *ui.Theme
+	Version  string
+	Greeting DashboardGreeting
+	Tiles    []DashboardTile
+}
+
+// RunDashboard opens the full-screen launcher (bubbletea alt-screen) and
+// returns once the user picks a tile or quits.
+func RunDashboard(cfg DashboardConfig) (DashboardResult, error) {
+	if cfg.Theme == nil {
+		cfg.Theme = ui.DefaultTheme()
+	}
+	m := dashboardModel{
+		cfg:      cfg,
+		cursor:   0,
+		searchOn: false,
+	}
+	m.rebuildVisible()
+	out, err := Run(m)
+	if err != nil {
+		return DashboardResult{}, err
+	}
+	fm, ok := out.(dashboardModel)
+	if !ok {
+		return DashboardResult{}, nil
+	}
+	return fm.result, nil
+}
+
+// DefaultDashboardTiles returns the 9-tile layout from the design handoff.
+func DefaultDashboardTiles() []DashboardTile {
+	return []DashboardTile{
+		{Command: "install", Label: "install", Hotkey: "i", Desc: "add a skill to every detected platform", Sub: "registry → adapters", Aliases: []string{"add", "get"}},
+		{Command: "list", Label: "list", Hotkey: "l", Desc: "what's installed, where, and what drifted", Sub: "manifest · adapters", Aliases: []string{"ls", "installed"}},
+		{Command: "update", Label: "update", Hotkey: "u", Desc: "pull newer registry versions onto installs", Sub: "diff · apply", Aliases: []string{"upgrade"}},
+		{Command: "search", Label: "search", Hotkey: "/", Desc: "browse every skill in the registry", Sub: "fuzzy over name, tag, desc", Aliases: []string{"find", "browse"}},
+		{Command: "uninstall", Label: "uninstall", Hotkey: "x", Desc: "remove a skill from every target", Sub: "manifest-aware", Aliases: []string{"remove", "rm", "delete"}},
+		{Command: "profile", Label: "profile", Hotkey: "p", Desc: "edit install defaults (platforms, scope)", Sub: "user-wide preferences", Aliases: []string{"config", "prefs"}},
+		{Command: "doctor", Label: "doctor", Hotkey: "d", Desc: "inspect adapters and environment health", Sub: "adapters · writability", Aliases: []string{"check", "status"}},
+		{Command: "registry", Label: "registry", Hotkey: "R", Desc: "refresh the local registry cache", Sub: "http · etag", Aliases: []string{"refresh", "sync"}},
+		{Command: "version", Label: "version", Hotkey: "V", Desc: "show build info", Sub: "version · commit", Aliases: []string{"about", "ver"}},
+	}
+}
+
+// BuildDashboardGreeting fills the defaults the dashboard banner needs.
+func BuildDashboardGreeting(updates int) DashboardGreeting {
+	g := DashboardGreeting{Updates: updates}
+	if u, err := user.Current(); err == nil && u.Username != "" {
+		g.User = u.Username
+	}
+	if cwd, err := os.Getwd(); err == nil {
+		g.Cwd = compactPath(cwd)
+	}
+	return g
+}
+
+func compactPath(p string) string {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return p
+	}
+	if strings.HasPrefix(p, home) {
+		return "~" + strings.TrimPrefix(p, home)
+	}
+	return p
+}
+
+// dashboardModel is the bubbletea model for the launcher.
+type dashboardModel struct {
+	cfg     DashboardConfig
+	cursor  int // index into visible tiles
+	visible []int
+
+	// Search
+	searchOn bool
+	query    string
+
+	width, height int
+	done          bool
+	result        DashboardResult
+}
+
+func (m dashboardModel) Init() tea.Cmd { return nil }
+
+func (m dashboardModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width, m.height = msg.Width, msg.Height
+		return m, nil
+	case tea.KeyMsg:
+		if m.searchOn {
+			return m.updateSearch(msg)
+		}
+		return m.updateGrid(msg)
+	}
+	return m, nil
+}
+
+func (m dashboardModel) updateGrid(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	k := msg.String()
+	switch k {
+	case "ctrl+c", "q", "esc":
+		m.result = DashboardResult{Quit: true}
+		m.done = true
+		return m, tea.Quit
+	case "/":
+		m.searchOn = true
+		m.query = ""
+		m.rebuildVisible()
+		return m, nil
+	case "up", "k":
+		m = m.moveCursor(-m.cols())
+		return m, nil
+	case "down", "j":
+		m = m.moveCursor(m.cols())
+		return m, nil
+	case "left", "h":
+		m = m.moveCursor(-1)
+		return m, nil
+	case "right", "l":
+		m = m.moveCursor(1)
+		return m, nil
+	case "tab":
+		m = m.moveCursor(1)
+		return m, nil
+	case "shift+tab":
+		m = m.moveCursor(-1)
+		return m, nil
+	case "enter":
+		return m.launchCursor()
+	default:
+		// Hotkey letter match.
+		if len(k) == 1 {
+			for _, t := range m.cfg.Tiles {
+				if t.Hotkey == k {
+					m.result = DashboardResult{Command: t.Command}
+					m.done = true
+					return m, tea.Quit
+				}
+			}
+		}
+	}
+	return m, nil
+}
+
+func (m dashboardModel) updateSearch(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	k := msg.String()
+	switch k {
+	case "ctrl+c":
+		m.result = DashboardResult{Quit: true}
+		m.done = true
+		return m, tea.Quit
+	case "esc":
+		m.searchOn = false
+		m.query = ""
+		m.rebuildVisible()
+		return m, nil
+	case "enter":
+		return m.launchCursor()
+	case "up", "down", "left", "right", "tab", "shift+tab":
+		// Let navigation work while typing.
+		return m.updateGrid(msg)
+	case "backspace":
+		if len(m.query) > 0 {
+			m.query = m.query[:len(m.query)-1]
+		}
+		m.rebuildVisible()
+		return m, nil
+	default:
+		if len(k) == 1 {
+			m.query += k
+			m.rebuildVisible()
+		}
+		return m, nil
+	}
+}
+
+func (m dashboardModel) launchCursor() (tea.Model, tea.Cmd) {
+	if m.cursor < 0 || m.cursor >= len(m.visible) {
+		return m, nil
+	}
+	t := m.cfg.Tiles[m.visible[m.cursor]]
+	m.result = DashboardResult{Command: t.Command}
+	m.done = true
+	return m, tea.Quit
+}
+
+func (m *dashboardModel) rebuildVisible() {
+	q := strings.TrimSpace(m.query)
+	if q == "" {
+		m.visible = make([]int, len(m.cfg.Tiles))
+		for i := range m.cfg.Tiles {
+			m.visible[i] = i
+		}
+		if m.cursor >= len(m.visible) {
+			m.cursor = 0
+		}
+		return
+	}
+	// Fuzzy over "label alias1 alias2 desc".
+	haystack := make([]string, len(m.cfg.Tiles))
+	for i, t := range m.cfg.Tiles {
+		haystack[i] = strings.ToLower(t.Label + " " + strings.Join(t.Aliases, " ") + " " + t.Desc)
+	}
+	matches := fuzzy.Find(strings.ToLower(q), haystack)
+	vis := make([]int, 0, len(matches))
+	for _, mm := range matches {
+		vis = append(vis, mm.Index)
+	}
+	m.visible = vis
+	if m.cursor >= len(m.visible) {
+		m.cursor = 0
+	}
+}
+
+func (m dashboardModel) moveCursor(delta int) dashboardModel {
+	if len(m.visible) == 0 {
+		return m
+	}
+	next := m.cursor + delta
+	if next < 0 {
+		next = 0
+	}
+	if next >= len(m.visible) {
+		next = len(m.visible) - 1
+	}
+	m.cursor = next
+	return m
+}
+
+func (m dashboardModel) cols() int {
+	if m.width >= 120 {
+		return 3
+	}
+	if m.width >= 80 {
+		return 2
+	}
+	return 1
+}
+
+func (m dashboardModel) View() string {
+	if m.width == 0 || m.height == 0 {
+		return ""
+	}
+	th := m.cfg.Theme
+	header := Header(th, HeaderSpec{
+		Version: m.cfg.Version,
+		Section: "Dashboard",
+	}, m.width)
+
+	body := m.renderBody()
+	right := th.Meta.Render("focused: ") + th.Brand.Render(m.focusedLabel())
+	footer := Footer(th, m.hints(), right, m.width)
+
+	bodyH := m.height - lipgloss.Height(header) - lipgloss.Height(footer) - 1
+	if bodyH < 5 {
+		bodyH = 5
+	}
+	return Frame(header, body, footer, bodyH)
+}
+
+func (m dashboardModel) focusedLabel() string {
+	if m.searchOn {
+		return "search"
+	}
+	if len(m.visible) == 0 {
+		return "—"
+	}
+	return m.cfg.Tiles[m.visible[m.cursor]].Label
+}
+
+func (m dashboardModel) hints() []KeyHint {
+	if m.searchOn {
+		return []KeyHint{
+			{Keys: "type", Label: "filter"},
+			{Keys: "↵", Label: "launch"},
+			{Keys: "esc", Label: "clear"},
+		}
+	}
+	return []KeyHint{
+		{Keys: "hjkl", Label: "move"},
+		{Keys: "↵", Label: "launch"},
+		{Keys: "/", Label: "search"},
+		{Keys: "esc", Label: "quit"},
+	}
+}
+
+func (m dashboardModel) renderBody() string {
+	th := m.cfg.Theme
+	var sb strings.Builder
+	sb.WriteString(m.renderBanner())
+	sb.WriteString("\n")
+	sb.WriteString(m.renderSearchBar())
+	sb.WriteString("\n\n")
+	sb.WriteString(m.renderGrid())
+	if len(m.visible) == 0 {
+		sb.WriteString("\n  " + th.Crumb.Render("no command matches "+fmt.Sprintf("%q", m.query)))
+	}
+	return sb.String()
+}
+
+func (m dashboardModel) renderBanner() string {
+	th := m.cfg.Theme
+	wordmark := th.Brand.Render("humblskills")
+	greet := "hello"
+	if m.cfg.Greeting.User != "" {
+		greet = "hi " + m.cfg.Greeting.User
+	}
+	parts := []string{th.Name.Render(greet)}
+	if m.cfg.Greeting.Updates > 0 {
+		parts = append(parts, th.Warn.Render(fmt.Sprintf("%d update%s available", m.cfg.Greeting.Updates, pluralDash(m.cfg.Greeting.Updates))))
+	} else {
+		parts = append(parts, th.Detail.Render("all skills up-to-date"))
+	}
+	if m.cfg.Greeting.Cwd != "" {
+		parts = append(parts, th.Detail.Render("in "+m.cfg.Greeting.Cwd))
+	}
+	line := strings.Join(parts, th.Crumb.Render("  ·  "))
+	return "  " + wordmark + "  " + line
+}
+
+func (m dashboardModel) renderSearchBar() string {
+	th := m.cfg.Theme
+	width := m.width - 4
+	if width < 20 {
+		width = 20
+	}
+	sigil := th.Brand.Render("❯")
+	query := m.query
+	if query == "" && !m.searchOn {
+		query = th.Crumb.Render("press / to search")
+	} else if query == "" {
+		query = th.Crumb.Render("type to filter…")
+	} else {
+		query = th.Name.Render(query)
+	}
+	count := th.Crumb.Render(fmt.Sprintf("%d / %d", len(m.visible), len(m.cfg.Tiles)))
+	inner := sigil + "  " + query
+	gap := width - lipgloss.Width(inner) - lipgloss.Width(count) - 2
+	if gap < 1 {
+		gap = 1
+	}
+	line := inner + strings.Repeat(" ", gap) + count
+	border := lipgloss.NormalBorder()
+	borderColor := th.Palette.Border
+	if m.searchOn {
+		borderColor = th.Palette.Magenta
+	}
+	box := lipgloss.NewStyle().
+		Border(border).
+		BorderForeground(borderColor).
+		Padding(0, 1).
+		Width(width - 2).
+		Render(line)
+	return "  " + box
+}
+
+func (m dashboardModel) renderGrid() string {
+	if len(m.visible) == 0 {
+		return ""
+	}
+	cols := m.cols()
+	colW := (m.width - 6 - (cols-1)*2) / cols
+	if colW < 24 {
+		colW = 24
+	}
+
+	rows := [][]string{}
+	var row []string
+	for i, idx := range m.visible {
+		tile := m.renderTile(m.cfg.Tiles[idx], i == m.cursor, colW)
+		row = append(row, tile)
+		if len(row) == cols {
+			rows = append(rows, row)
+			row = nil
+		}
+	}
+	if len(row) > 0 {
+		// Pad with blanks so JoinHorizontal aligns.
+		for len(row) < cols {
+			row = append(row, strings.Repeat(" ", colW+2))
+		}
+		rows = append(rows, row)
+	}
+
+	var sb strings.Builder
+	for i, r := range rows {
+		sb.WriteString("  ")
+		sb.WriteString(lipgloss.JoinHorizontal(lipgloss.Top, r...))
+		if i < len(rows)-1 {
+			sb.WriteString("\n")
+		}
+	}
+	return sb.String()
+}
+
+func (m dashboardModel) renderTile(t DashboardTile, selected bool, width int) string {
+	th := m.cfg.Theme
+	borderColor := th.Palette.Border
+	if selected {
+		borderColor = th.Palette.Magenta
+	}
+	nameStyle := th.RowUnselected
+	if selected {
+		nameStyle = th.RowSelected
+	}
+
+	hot := th.KbdKey.Render(t.Hotkey)
+	name := nameStyle.Render(t.Label)
+	header := padBetween(name, hot, width-2)
+
+	desc := th.Desc.Width(width - 2).Render(t.Desc)
+
+	footLeft := th.Detail.Render(t.Sub)
+	footRight := ""
+	if t.Status != "" {
+		footRight = th.BadgeGhost.Render(t.Status)
+	}
+	foot := padBetween(footLeft, footRight, width-2)
+
+	body := header + "\n\n" + desc + "\n\n" + foot
+	return lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(borderColor).
+		Padding(0, 1).
+		Width(width).
+		Render(body) + "  "
+}
+
+func pluralDash(n int) string {
+	if n == 1 {
+		return ""
+	}
+	return "s"
+}

--- a/cli/internal/tui/install_modal.go
+++ b/cli/internal/tui/install_modal.go
@@ -1,0 +1,414 @@
+package tui
+
+import (
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/jjfantini/humblSKILLS/cli/internal/adapters"
+	"github.com/jjfantini/humblSKILLS/cli/internal/profile"
+	"github.com/jjfantini/humblSKILLS/cli/internal/ui"
+)
+
+// RunInstallPlatformModal asks the user which detected platforms to install
+// `skill` into, and at which scope. Default selections come from the profile.
+// It is a hand-rolled bubbletea model so ESC navigates back cleanly and the
+// chrome matches the rest of the TUI (no huh flicker, no alt-screen re-entry).
+//
+// Returns Confirmed=false if the user cancelled, and EditProfile=true if they
+// chose the "edit profile" action.
+func RunInstallPlatformModal(
+	theme *ui.Theme,
+	skill string,
+	adapterList []adapters.Adapter,
+	detected map[string]bool,
+	p *profile.Profile,
+) (InstallModalResult, error) {
+	if p == nil {
+		p = &profile.Profile{}
+	}
+
+	selected := map[string]bool{}
+	if len(p.DefaultPlatforms) > 0 {
+		for _, name := range p.DefaultPlatforms {
+			if detected[name] {
+				selected[name] = true
+			}
+		}
+	} else {
+		for _, a := range adapterList {
+			if detected[a.Name] {
+				selected[a.Name] = true
+			}
+		}
+	}
+
+	scopes := []scopeOpt{
+		{label: "adapter default", value: ""},
+		{label: "user", value: "user"},
+		{label: "project", value: "project"},
+	}
+	scopeIdx := 0
+	for i, s := range scopes {
+		if s.value == p.DefaultScope {
+			scopeIdx = i
+			break
+		}
+	}
+
+	actions := []actionOpt{
+		{label: "install", value: "install"},
+		{label: "edit profile defaults", value: "profile"},
+		{label: "cancel", value: "cancel"},
+	}
+
+	m := installModalModel{
+		theme:       theme,
+		skill:       skill,
+		adapters:    adapterList,
+		detected:    detected,
+		selected:    selected,
+		scopes:      scopes,
+		scopeIdx:    scopeIdx,
+		actions:     actions,
+		actionIdx:   0,
+		group:       groupPlatforms,
+		cursor:      0,
+		firstSelect: true,
+	}
+
+	out, err := Run(m)
+	if err != nil {
+		return InstallModalResult{}, err
+	}
+	fm, ok := out.(installModalModel)
+	if !ok {
+		return InstallModalResult{}, nil
+	}
+	return fm.result, nil
+}
+
+type scopeOpt struct{ label, value string }
+type actionOpt struct{ label, value string }
+
+type modalGroup int
+
+const (
+	groupPlatforms modalGroup = iota
+	groupScope
+	groupAction
+)
+
+type installModalModel struct {
+	theme    *ui.Theme
+	skill    string
+	adapters []adapters.Adapter
+	detected map[string]bool
+
+	selected  map[string]bool
+	scopes    []scopeOpt
+	scopeIdx  int
+	actions   []actionOpt
+	actionIdx int
+
+	group  modalGroup
+	cursor int
+
+	width, height int
+	firstSelect   bool
+	done          bool
+	result        InstallModalResult
+}
+
+func (m installModalModel) Init() tea.Cmd { return nil }
+
+func (m installModalModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width, m.height = msg.Width, msg.Height
+		return m, nil
+	case tea.KeyMsg:
+		k := msg.String()
+		switch k {
+		case "ctrl+c", "q":
+			m.done = true
+			return m, tea.Quit
+		case "esc":
+			m.done = true
+			return m, tea.Quit
+		case "tab":
+			return m.nextGroup(1), nil
+		case "shift+tab":
+			return m.nextGroup(-1), nil
+		case "up", "k":
+			m.cursor = clamp(m.cursor-1, 0, m.groupLen()-1)
+			m.syncGroupIndex()
+			return m, nil
+		case "down", "j":
+			m.cursor = clamp(m.cursor+1, 0, m.groupLen()-1)
+			m.syncGroupIndex()
+			return m, nil
+		case " ":
+			if m.group == groupPlatforms {
+				m = m.togglePlatform()
+			}
+			return m, nil
+		case "enter":
+			return m.onEnter()
+		}
+	}
+	return m, nil
+}
+
+func (m installModalModel) nextGroup(dir int) installModalModel {
+	m.group = modalGroup((int(m.group) + dir + 3) % 3)
+	switch m.group {
+	case groupPlatforms:
+		m.cursor = 0
+	case groupScope:
+		m.cursor = m.scopeIdx
+	case groupAction:
+		m.cursor = m.actionIdx
+	}
+	return m
+}
+
+func (m *installModalModel) syncGroupIndex() {
+	switch m.group {
+	case groupScope:
+		m.scopeIdx = m.cursor
+	case groupAction:
+		m.actionIdx = m.cursor
+	}
+}
+
+func (m installModalModel) togglePlatform() installModalModel {
+	if m.cursor < 0 || m.cursor >= len(m.adapters) {
+		return m
+	}
+	name := m.adapters[m.cursor].Name
+	if m.selected[name] {
+		delete(m.selected, name)
+	} else {
+		m.selected[name] = true
+	}
+	return m
+}
+
+func (m installModalModel) onEnter() (tea.Model, tea.Cmd) {
+	switch m.group {
+	case groupPlatforms:
+		// Enter toggles in the platforms group, matching `space`.
+		return m.togglePlatform(), nil
+	case groupScope:
+		m.scopeIdx = m.cursor
+		return m.nextGroup(1), nil
+	case groupAction:
+		m.actionIdx = m.cursor
+		return m.commit()
+	}
+	return m, nil
+}
+
+func (m installModalModel) commit() (tea.Model, tea.Cmd) {
+	sel := m.actions[m.actionIdx].value
+	switch sel {
+	case "profile":
+		m.result = InstallModalResult{EditProfile: true}
+	case "cancel":
+		m.result = InstallModalResult{}
+	default:
+		plats := make([]string, 0, len(m.selected))
+		for _, a := range m.adapters {
+			if m.selected[a.Name] {
+				plats = append(plats, a.Name)
+			}
+		}
+		m.result = InstallModalResult{
+			Platforms: plats,
+			Scope:     m.scopes[m.scopeIdx].value,
+			Confirmed: true,
+		}
+	}
+	m.done = true
+	return m, tea.Quit
+}
+
+func (m installModalModel) groupLen() int {
+	switch m.group {
+	case groupPlatforms:
+		return len(m.adapters)
+	case groupScope:
+		return len(m.scopes)
+	case groupAction:
+		return len(m.actions)
+	}
+	return 0
+}
+
+func (m installModalModel) View() string {
+	if m.width == 0 || m.height == 0 {
+		return ""
+	}
+	th := m.theme
+
+	header := Header(th, HeaderSpec{
+		Version: versionString,
+		Section: "Install",
+		Meta:    th.Meta.Render("skill: ") + th.Brand.Render(m.skill),
+	}, m.width)
+
+	body := m.renderBody()
+	focused := th.Meta.Render("focused: ") + th.Brand.Render(m.groupLabel())
+	footer := Footer(th, m.hints(), focused, m.width)
+
+	bodyH := m.height - lipgloss.Height(header) - lipgloss.Height(footer) - 1
+	if bodyH < 5 {
+		bodyH = 5
+	}
+	return Frame(header, body, footer, bodyH)
+}
+
+func (m installModalModel) groupLabel() string {
+	switch m.group {
+	case groupPlatforms:
+		return "platforms"
+	case groupScope:
+		return "scope"
+	case groupAction:
+		return "action"
+	}
+	return ""
+}
+
+func (m installModalModel) renderBody() string {
+	th := m.theme
+	width := m.width - 4
+	if width < 40 {
+		width = 40
+	}
+
+	var sb strings.Builder
+	sb.WriteString("  ")
+	sb.WriteString(th.DetailTitle.Render("Install " + m.skill + " to:"))
+	sb.WriteString("\n\n")
+
+	sb.WriteString(m.renderGroup(groupPlatforms, "PLATFORMS", m.platformRows(), width))
+	sb.WriteString("\n")
+	sb.WriteString(m.renderGroup(groupScope, "SCOPE", m.scopeRows(), width))
+	sb.WriteString("\n")
+	sb.WriteString(m.renderGroup(groupAction, "ACTION", m.actionRows(), width))
+
+	return sb.String()
+}
+
+func (m installModalModel) renderGroup(g modalGroup, label string, rows []string, width int) string {
+	th := m.theme
+	var sb strings.Builder
+	titleStyle := th.SectionTitle
+	if m.group == g {
+		titleStyle = th.Brand
+	}
+	sb.WriteString("  " + titleStyle.Render(label) + "\n")
+	for _, r := range rows {
+		sb.WriteString("  " + r + "\n")
+	}
+	_ = width
+	return sb.String()
+}
+
+func (m installModalModel) platformRows() []string {
+	th := m.theme
+	rows := make([]string, 0, len(m.adapters))
+	for i, a := range m.adapters {
+		box := "[ ]"
+		if m.selected[a.Name] {
+			box = "[✓]"
+		}
+		label := a.Name
+		if m.detected[a.Name] {
+			label += "  " + th.Detail.Render("(detected)")
+		} else {
+			label += "  " + th.RowDim.Render("(not detected)")
+		}
+		cursorHere := m.group == groupPlatforms && i == m.cursor
+		var line string
+		switch {
+		case cursorHere:
+			line = th.Bullet.Render("▸") + " " + th.RowSelected.Render(box+" "+a.Name) + "  " + label[len(a.Name)+2:]
+		case m.selected[a.Name]:
+			line = "  " + th.Success.Render(box) + " " + th.RowUnselected.Render(a.Name) + "  " + label[len(a.Name)+2:]
+		default:
+			line = "  " + th.RowDim.Render(box) + " " + th.RowUnselected.Render(a.Name) + "  " + label[len(a.Name)+2:]
+		}
+		rows = append(rows, line)
+	}
+	return rows
+}
+
+func (m installModalModel) scopeRows() []string {
+	th := m.theme
+	rows := make([]string, 0, len(m.scopes))
+	for i, s := range m.scopes {
+		cursorHere := m.group == groupScope && i == m.cursor
+		isCurrent := i == m.scopeIdx
+		marker := "( )"
+		if isCurrent {
+			marker = "(●)"
+		}
+		var line string
+		switch {
+		case cursorHere:
+			line = th.Bullet.Render("▸") + " " + th.RowSelected.Render(marker+" "+s.label)
+		case isCurrent:
+			line = "  " + th.Success.Render(marker) + " " + th.RowUnselected.Render(s.label)
+		default:
+			line = "  " + th.RowDim.Render(marker) + " " + th.RowUnselected.Render(s.label)
+		}
+		rows = append(rows, line)
+	}
+	return rows
+}
+
+func (m installModalModel) actionRows() []string {
+	th := m.theme
+	rows := make([]string, 0, len(m.actions))
+	for i, a := range m.actions {
+		cursorHere := m.group == groupAction && i == m.cursor
+		var line string
+		if cursorHere {
+			line = th.Bullet.Render("▸") + " " + th.RowSelected.Render(a.label)
+		} else {
+			line = "  " + th.RowUnselected.Render(a.label)
+		}
+		rows = append(rows, line)
+	}
+	return rows
+}
+
+func (m installModalModel) hints() []KeyHint {
+	base := []KeyHint{
+		{Keys: "↑↓", Label: "select"},
+		{Keys: "tab", Label: "next group"},
+	}
+	switch m.group {
+	case groupPlatforms:
+		base = append(base, KeyHint{Keys: "space", Label: "toggle"})
+	}
+	base = append(base,
+		KeyHint{Keys: "↵", Label: "confirm"},
+		KeyHint{Keys: "esc", Label: "back"},
+	)
+	return base
+}
+
+func clamp(v, lo, hi int) int {
+	if v < lo {
+		return lo
+	}
+	if v > hi {
+		return hi
+	}
+	return v
+}

--- a/cli/internal/tui/listdetail.go
+++ b/cli/internal/tui/listdetail.go
@@ -72,6 +72,12 @@ type Config struct {
 	// FocusedLabel overrides the default "focused: <key>" right-anchored footer
 	// context. Return "" for no context.
 	FocusedLabel func(items []Item, cursor int) string
+	// BackLabel overrides the quit-hint label. Default is "quit". Set to
+	// "back" (with BackKey = "esc") when the model is launched from a parent
+	// navigator so ESC feels like "go back" instead of "quit".
+	BackLabel string
+	// BackKey overrides the quit-hint key. Default is "q".
+	BackKey string
 }
 
 // Result is what the caller inspects after the model returns.
@@ -177,7 +183,7 @@ func (m Model) updateFilter(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 func (m Model) updateNav(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch {
-	case key.Matches(msg, m.keys.Quit):
+	case key.Matches(msg, m.keys.Quit), key.Matches(msg, m.keys.Back):
 		m.result = Result{Quit: true}
 		m.done = true
 		return m, tea.Quit
@@ -495,7 +501,15 @@ func (m Model) hints() []KeyHint {
 		}
 		hints = append(hints, KeyHint{Keys: keyStr, Label: label})
 	}
-	hints = append(hints, KeyHint{Keys: "q", Label: "quit"})
+	backKey := m.cfg.BackKey
+	if backKey == "" {
+		backKey = "q"
+	}
+	backLabel := m.cfg.BackLabel
+	if backLabel == "" {
+		backLabel = "quit"
+	}
+	hints = append(hints, KeyHint{Keys: backKey, Label: backLabel})
 	return hints
 }
 

--- a/cli/internal/tui/profile.go
+++ b/cli/internal/tui/profile.go
@@ -1,12 +1,10 @@
 package tui
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/charmbracelet/huh"
 	"github.com/charmbracelet/lipgloss"
 
 	"github.com/jjfantini/humblSKILLS/cli/internal/adapters"
@@ -501,105 +499,13 @@ func plural2(n int) string {
 	return "s"
 }
 
-// --- per-install modal (unchanged) ------------------------------------------
+// --- per-install modal (moved) ----------------------------------------------
 
-// InstallModalResult is what the install platform picker returns.
+// InstallModalResult is what the install platform picker returns. The modal
+// implementation lives in install_modal.go (hand-rolled bubbletea model).
 type InstallModalResult struct {
 	Platforms   []string
 	Scope       string
 	Confirmed   bool
 	EditProfile bool
-}
-
-// RunInstallPlatformModal opens a huh form asking the user which detected
-// platforms to install `skill` into, and at which scope. Default selections
-// come from the profile. Returns Confirmed=false if the user cancelled, and
-// EditProfile=true if they chose the "edit profile" action.
-func RunInstallPlatformModal(
-	theme *ui.Theme,
-	skill string,
-	adapterList []adapters.Adapter,
-	detected map[string]bool,
-	p *profile.Profile,
-) (InstallModalResult, error) {
-	if p == nil {
-		p = &profile.Profile{}
-	}
-
-	platforms := make([]string, 0)
-	if len(p.DefaultPlatforms) > 0 {
-		for _, name := range p.DefaultPlatforms {
-			if detected[name] {
-				platforms = append(platforms, name)
-			}
-		}
-	} else {
-		for _, a := range adapterList {
-			if detected[a.Name] {
-				platforms = append(platforms, a.Name)
-			}
-		}
-	}
-
-	opts := make([]huh.Option[string], 0, len(adapterList))
-	for _, a := range adapterList {
-		label := a.Name
-		if detected[a.Name] {
-			label += "  (detected)"
-		} else {
-			label += "  (not detected)"
-		}
-		opts = append(opts, huh.NewOption(label, a.Name))
-	}
-
-	scope := p.DefaultScope
-	scopeOpts := []huh.Option[string]{
-		huh.NewOption("adapter default", ""),
-		huh.NewOption("user", "user"),
-		huh.NewOption("project", "project"),
-	}
-
-	action := "install"
-	actionOpts := []huh.Option[string]{
-		huh.NewOption("install", "install"),
-		huh.NewOption("edit profile defaults", "profile"),
-		huh.NewOption("cancel", "cancel"),
-	}
-
-	form := huh.NewForm(
-		huh.NewGroup(
-			huh.NewMultiSelect[string]().
-				Title("Install "+skill+" to:").
-				Options(opts...).
-				Value(&platforms),
-			huh.NewSelect[string]().
-				Title("Scope").
-				Options(scopeOpts...).
-				Value(&scope),
-			huh.NewSelect[string]().
-				Title("Action").
-				Options(actionOpts...).
-				Value(&action),
-		),
-	).WithTheme(ui.HuhTheme(theme))
-
-	if err := form.Run(); err != nil {
-		if errors.Is(err, huh.ErrUserAborted) {
-			return InstallModalResult{}, nil
-		}
-		return InstallModalResult{}, err
-	}
-
-	switch action {
-	case "profile":
-		return InstallModalResult{EditProfile: true}, nil
-	case "cancel":
-		return InstallModalResult{}, nil
-	}
-
-	return InstallModalResult{
-		Platforms: platforms,
-		Scope:     scope,
-		Confirmed: true,
-	}, nil
 }


### PR DESCRIPTION
## Summary
- New `humblskills start` opens a dashboard (banner + fuzzy search + tile grid) inspired by Variation 02 of the design mockups. Bare `humblskills` on a TTY routes here; non-TTY prints a command table.
- Every sub-screen (install, search, list, uninstall, update, profile, doctor, registry, version) is reachable from the dashboard and returns to it on ESC. Footer hint swaps "quit" for "back" via a new `BackKey`/`BackLabel` on `tui.Config`.
- `RunInstallPlatformModal` rewritten as a hand-rolled Bubble Tea model so the install flow stays inside the same alt-screen (no more huh form flicker).
- Non-TTY / `--json` / `--quiet` / `--yes` paths are untouched — agents, pipes, and scripts keep working.

## Test plan
- [ ] `go build ./...`, `go vet ./...`, `go test ./...`, `go mod tidy` (all green locally)
- [ ] Bare `humblskills` on a TTY opens the dashboard
- [ ] `humblskills --help` prints Cobra help; `humblskills | cat` prints the command table
- [ ] Launch each tile; ESC returns to the dashboard
- [ ] `humblskills install <name> --json | jq .` unchanged
- [ ] `humblskills install foo --yes` skips the modal and installs

🤖 Generated with [Claude Code](https://claude.com/claude-code)