### PR TITLE
fix(cli): dashboard alignment, arrow-key hints, status line, --fullscreen

### DIFF
--- a/cli/cmd/humblskills/root.go
+++ b/cli/cmd/humblskills/root.go
@@ -34,18 +34,20 @@ type Config struct {
 	Verbose      bool
 	Quiet        bool
 	Yes          bool
+	Fullscreen   bool
 }
 
 type globalFlags struct {
-	registry string
-	cacheDir string
-	manifest string
-	profile  string
-	json     bool
-	noColor  bool
-	verbose  bool
-	quiet    bool
-	yes      bool
+	registry   string
+	cacheDir   string
+	manifest   string
+	profile    string
+	json       bool
+	noColor    bool
+	verbose    bool
+	quiet      bool
+	yes        bool
+	fullscreen bool
 }
 
 func newRootCmd() *cobra.Command {
@@ -80,6 +82,7 @@ func newRootCmd() *cobra.Command {
 	f.BoolVarP(&g.verbose, "verbose", "v", false, "print extra detail")
 	f.BoolVarP(&g.quiet, "quiet", "q", false, "suppress non-error output")
 	f.BoolVarP(&g.yes, "yes", "y", false, "skip confirmation prompts (auto-accept)")
+	f.BoolVar(&g.fullscreen, "fullscreen", false, "open the interactive dashboard in full-screen TUI mode")
 
 	cmd.AddCommand(
 		newStartCmd(app),
@@ -125,6 +128,7 @@ func configureApp(_ *cobra.Command, app *App, g globalFlags) error {
 		Verbose:     g.verbose,
 		Quiet:       g.quiet,
 		Yes:         g.yes,
+		Fullscreen:  g.fullscreen,
 	}
 
 	cacheDir, err := resolveCacheDir(firstNonEmpty(g.cacheDir, os.Getenv("HUMBLSKILLS_CACHE_DIR")))

--- a/cli/cmd/humblskills/start.go
+++ b/cli/cmd/humblskills/start.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/jjfantini/humblSKILLS/cli/internal/adapters"
 	"github.com/jjfantini/humblSKILLS/cli/internal/install"
 	"github.com/jjfantini/humblSKILLS/cli/internal/manifest"
 	"github.com/jjfantini/humblSKILLS/cli/internal/registry"
@@ -26,18 +27,29 @@ func newStartCmd(app *App) *cobra.Command {
 
 // runStart is the launcher loop. It re-enters the dashboard after every
 // sub-command returns, so ESC in any sub-screen bounces back to the grid.
-// Non-TTY paths fall through to the Cobra help text via printStartFallback.
+// Non-TTY paths fall through to the Cobra help text via printStartFallback,
+// unless --fullscreen was asked for explicitly — then we surface an error
+// instead of silently printing help.
 func runStart(app *App) error {
 	if !tui.ShouldUseTUI(app.Config.JSON, app.Config.Quiet, app.Config.Yes) {
+		if app.Config.Fullscreen {
+			return fmt.Errorf("--fullscreen requires an interactive terminal (no TTY detected)")
+		}
 		return printStartFallback(app)
 	}
 
 	for {
+		summary := buildDashboardSummary(app)
 		cfg := tui.DashboardConfig{
 			Theme:    app.UI.Theme(),
 			Version:  resolveVersion().Version,
-			Greeting: tui.BuildDashboardGreeting(countDrifted(app)),
-			Tiles:    tui.DefaultDashboardTiles(),
+			Greeting: tui.BuildDashboardGreeting(summary.drifted),
+			Status: tui.DashboardStatus{
+				Healthy:   summary.drifted == 0,
+				Platforms: summary.platforms,
+				Skills:    summary.skills,
+			},
+			Tiles: tui.DefaultDashboardTiles(),
 		}
 		res, err := tui.RunDashboard(cfg)
 		if err != nil {
@@ -82,18 +94,43 @@ func dispatchDashboardCommand(app *App, cmd string) error {
 	return fmt.Errorf("unknown dashboard command: %s", cmd)
 }
 
-// countDrifted counts how many installed skills have a newer registry version.
-// Returns 0 on any error — the banner treats it as "up-to-date".
-func countDrifted(app *App) int {
+// dashboardSummary is the data we pull once per dashboard re-entry to
+// populate both the banner ("N updates available") and the right-anchored
+// status line ("healthy · N platforms · M skills").
+type dashboardSummary struct {
+	drifted   int
+	platforms int
+	skills    int
+}
+
+func buildDashboardSummary(app *App) dashboardSummary {
+	var s dashboardSummary
+
+	if adapterList, err := app.Adapters(); err == nil {
+		for _, r := range adapters.Detect(adapterList) {
+			if r.Detected {
+				s.platforms++
+			}
+		}
+	}
+
 	m, err := manifest.Load(app.Config.ManifestPath)
 	if err != nil || m == nil {
-		return 0
+		return s
 	}
+	seen := map[string]bool{}
+	for _, inst := range m.Installations {
+		if !seen[inst.Skill] {
+			seen[inst.Skill] = true
+			s.skills++
+		}
+	}
+
 	reg, _, err := registry.NewFetcher(app.Config.RegistryURL, app.Config.CacheDir).Load()
-	if err != nil || reg == nil {
-		return 0
+	if err == nil && reg != nil {
+		s.drifted = len(install.PlanUpdates(reg, m, nil))
 	}
-	return len(install.PlanUpdates(reg, m, nil))
+	return s
 }
 
 func printStartFallback(app *App) error {

--- a/cli/internal/tui/dashboard.go
+++ b/cli/internal/tui/dashboard.go
@@ -39,11 +39,20 @@ type DashboardGreeting struct {
 	LastScan string // "18:04" or ""
 }
 
+// DashboardStatus feeds the header's right-anchored summary
+// (● healthy · N platforms · M skills).
+type DashboardStatus struct {
+	Healthy   bool
+	Platforms int // detected adapters
+	Skills    int // installed skills (unique)
+}
+
 // DashboardConfig bundles everything RunDashboard needs.
 type DashboardConfig struct {
 	Theme    *ui.Theme
 	Version  string
 	Greeting DashboardGreeting
+	Status   DashboardStatus
 	Tiles    []DashboardTile
 }
 
@@ -289,6 +298,7 @@ func (m dashboardModel) View() string {
 	header := Header(th, HeaderSpec{
 		Version: m.cfg.Version,
 		Section: "Dashboard",
+		Meta:    m.statusLine(),
 	}, m.width)
 
 	body := m.renderBody()
@@ -316,23 +326,40 @@ func (m dashboardModel) hints() []KeyHint {
 	if m.searchOn {
 		return []KeyHint{
 			{Keys: "type", Label: "filter"},
+			{Keys: "↑↓←→", Label: "move"},
 			{Keys: "↵", Label: "launch"},
 			{Keys: "esc", Label: "clear"},
 		}
 	}
 	return []KeyHint{
-		{Keys: "hjkl", Label: "move"},
+		{Keys: "↑↓←→", Label: "move"},
 		{Keys: "↵", Label: "launch"},
 		{Keys: "/", Label: "search"},
 		{Keys: "esc", Label: "quit"},
 	}
 }
 
+// statusLine renders the right-anchored header summary:
+// "● healthy · 2 platforms · 7 skills".
+func (m dashboardModel) statusLine() string {
+	th := m.cfg.Theme
+	dot := th.DotOK
+	label := "healthy"
+	if !m.cfg.Status.Healthy {
+		dot = th.DotWarn
+		label = "drift"
+	}
+	sep := th.Crumb.Render(" · ")
+	return dot.Render("●") + " " + th.Detail.Render(label) +
+		sep + th.Detail.Render(fmt.Sprintf("%d platform%s", m.cfg.Status.Platforms, pluralDash(m.cfg.Status.Platforms))) +
+		sep + th.Detail.Render(fmt.Sprintf("%d skill%s", m.cfg.Status.Skills, pluralDash(m.cfg.Status.Skills)))
+}
+
 func (m dashboardModel) renderBody() string {
 	th := m.cfg.Theme
 	var sb strings.Builder
 	sb.WriteString(m.renderBanner())
-	sb.WriteString("\n")
+	sb.WriteString("\n\n")
 	sb.WriteString(m.renderSearchBar())
 	sb.WriteString("\n\n")
 	sb.WriteString(m.renderGrid())
@@ -340,6 +367,17 @@ func (m dashboardModel) renderBody() string {
 		sb.WriteString("\n  " + th.Crumb.Render("no command matches "+fmt.Sprintf("%q", m.query)))
 	}
 	return sb.String()
+}
+
+// bodyWidth is the usable width between left/right margins. Every body
+// element (banner, search bar, tile grid row) targets this width so they
+// all end at the same column.
+func (m dashboardModel) bodyWidth() int {
+	w := m.width - 4
+	if w < 40 {
+		w = 40
+	}
+	return w
 }
 
 func (m dashboardModel) renderBanner() string {
@@ -364,36 +402,33 @@ func (m dashboardModel) renderBanner() string {
 
 func (m dashboardModel) renderSearchBar() string {
 	th := m.cfg.Theme
-	width := m.width - 4
-	if width < 20 {
-		width = 20
+	total := m.bodyWidth() // final display width including border
+	// Inner content width = total - 2 (border) - 2 (padding) = total - 4.
+	inner := total - 4
+	if inner < 10 {
+		inner = 10
 	}
 	sigil := th.Brand.Render("❯")
-	query := m.query
-	if query == "" && !m.searchOn {
+	var query string
+	if m.query == "" && !m.searchOn {
 		query = th.Crumb.Render("press / to search")
-	} else if query == "" {
+	} else if m.query == "" {
 		query = th.Crumb.Render("type to filter…")
 	} else {
-		query = th.Name.Render(query)
+		query = th.Name.Render(m.query)
 	}
 	count := th.Crumb.Render(fmt.Sprintf("%d / %d", len(m.visible), len(m.cfg.Tiles)))
-	inner := sigil + "  " + query
-	gap := width - lipgloss.Width(inner) - lipgloss.Width(count) - 2
-	if gap < 1 {
-		gap = 1
-	}
-	line := inner + strings.Repeat(" ", gap) + count
-	border := lipgloss.NormalBorder()
+	left := sigil + "  " + query
+	line := padBetween(left, count, inner)
 	borderColor := th.Palette.Border
 	if m.searchOn {
 		borderColor = th.Palette.Magenta
 	}
 	box := lipgloss.NewStyle().
-		Border(border).
+		Border(lipgloss.NormalBorder()).
 		BorderForeground(borderColor).
 		Padding(0, 1).
-		Width(width - 2).
+		Width(inner).
 		Render(line)
 	return "  " + box
 }
@@ -403,15 +438,18 @@ func (m dashboardModel) renderGrid() string {
 		return ""
 	}
 	cols := m.cols()
-	colW := (m.width - 6 - (cols-1)*2) / cols
-	if colW < 24 {
-		colW = 24
+	gap := 2
+	body := m.bodyWidth()
+	tileW := (body - (cols-1)*gap) / cols
+	if tileW < 24 {
+		tileW = 24
 	}
+	spacer := strings.Repeat(" ", gap)
 
 	rows := [][]string{}
 	var row []string
 	for i, idx := range m.visible {
-		tile := m.renderTile(m.cfg.Tiles[idx], i == m.cursor, colW)
+		tile := m.renderTile(m.cfg.Tiles[idx], i == m.cursor, tileW)
 		row = append(row, tile)
 		if len(row) == cols {
 			rows = append(rows, row)
@@ -419,17 +457,24 @@ func (m dashboardModel) renderGrid() string {
 		}
 	}
 	if len(row) > 0 {
-		// Pad with blanks so JoinHorizontal aligns.
+		empty := m.renderEmptyTile(tileW)
 		for len(row) < cols {
-			row = append(row, strings.Repeat(" ", colW+2))
+			row = append(row, empty)
 		}
 		rows = append(rows, row)
 	}
 
 	var sb strings.Builder
 	for i, r := range rows {
+		parts := make([]string, 0, len(r)*2-1)
+		for j, t := range r {
+			if j > 0 {
+				parts = append(parts, spacer)
+			}
+			parts = append(parts, t)
+		}
 		sb.WriteString("  ")
-		sb.WriteString(lipgloss.JoinHorizontal(lipgloss.Top, r...))
+		sb.WriteString(lipgloss.JoinHorizontal(lipgloss.Top, parts...))
 		if i < len(rows)-1 {
 			sb.WriteString("\n")
 		}
@@ -437,6 +482,8 @@ func (m dashboardModel) renderGrid() string {
 	return sb.String()
 }
 
+// renderTile renders one tile. The returned string is exactly `width`
+// display columns wide (border included) so JoinHorizontal aligns columns.
 func (m dashboardModel) renderTile(t DashboardTile, selected bool, width int) string {
 	th := m.cfg.Theme
 	borderColor := th.Palette.Border
@@ -448,26 +495,41 @@ func (m dashboardModel) renderTile(t DashboardTile, selected bool, width int) st
 		nameStyle = th.RowSelected
 	}
 
+	// Inner width: total minus 2 (border) minus 2 (padding).
+	inner := width - 4
+	if inner < 10 {
+		inner = 10
+	}
+
 	hot := th.KbdKey.Render(t.Hotkey)
 	name := nameStyle.Render(t.Label)
-	header := padBetween(name, hot, width-2)
+	header := padBetween(name, hot, inner)
 
-	desc := th.Desc.Width(width - 2).Render(t.Desc)
+	desc := th.Desc.Width(inner).Render(t.Desc)
 
 	footLeft := th.Detail.Render(t.Sub)
 	footRight := ""
 	if t.Status != "" {
 		footRight = th.BadgeGhost.Render(t.Status)
 	}
-	foot := padBetween(footLeft, footRight, width-2)
+	foot := padBetween(footLeft, footRight, inner)
 
 	body := header + "\n\n" + desc + "\n\n" + foot
 	return lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(borderColor).
 		Padding(0, 1).
+		Width(width - 2).
+		Render(body)
+}
+
+// renderEmptyTile returns a blank block the same height as a real tile so
+// short final rows still align under a full row above.
+func (m dashboardModel) renderEmptyTile(width int) string {
+	return lipgloss.NewStyle().
 		Width(width).
-		Render(body) + "  "
+		Height(5).
+		Render("")
 }
 
 func pluralDash(n int) string {


### PR DESCRIPTION
## Summary
Polish pass on the new dashboard — responds to real-terminal feedback.

- **Grid alignment**: banner, search bar, and tile rows now all target a single `bodyWidth`, so columns line up edge-to-edge. Short final rows are padded with invisible tiles so later rows don't shift left.
- **Arrow keys in the footer**: hint now reads `↑↓←→ move` instead of `hjkl move`. hjkl keys still work — only the hint changed.
- **Status line**: header's right-anchored meta now shows `● healthy · N platforms · M skills`. Flips to a yellow `● drift` dot when installed skills have newer registry versions. "platforms" replaces "adapters" in user-facing copy.
- **`--fullscreen` flag**: new persistent root flag that opens the dashboard explicitly. In a non-TTY context it returns `--fullscreen requires an interactive terminal` instead of silently printing the help table.

## Test plan
- [ ] `go build ./...`, `go vet ./...`, `go test ./...` (green locally)
- [ ] `humblskills` on a TTY → dashboard renders with aligned tiles, status line, arrow-key hint
- [ ] `humblskills --fullscreen` on a TTY → same dashboard
- [ ] `humblskills --fullscreen | cat` → errors out cleanly
- [ ] `humblskills | cat` → command table fallback (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)