### PR TITLE
fix(cli): dashboard scroll, alignment, shared header, version TUI

### DIFF
--- a/cli/cmd/humblskills/browse_skills.go
+++ b/cli/cmd/humblskills/browse_skills.go
@@ -208,7 +208,7 @@ func runSkillBrowser(app *App, section string, skills []skillItem, mode skillsBr
 			outdatedCount++
 		}
 	}
-	meta := func(items []tui.Item, _ int) string {
+	localMeta := func(items []tui.Item, _ int) string {
 		parts := []string{fmt.Sprintf("%d skill%s", len(items), plural(len(items)))}
 		if installedCount > 0 {
 			parts = append(parts, fmt.Sprintf("%d installed", installedCount))
@@ -217,6 +217,17 @@ func runSkillBrowser(app *App, section string, skills []skillItem, mode skillsBr
 			parts = append(parts, fmt.Sprintf("%d outdated", outdatedCount))
 		}
 		return strings.Join(parts, " · ")
+	}
+	// When launched from the dashboard, mirror the shared status line
+	// ("● healthy · N platforms · M skills"); otherwise show the command-local
+	// counts so direct `humblskills install`/`search` still feel informative.
+	meta := localMeta
+	if app.Nav.Crumb != "" {
+		status := app.Nav.Status
+		theme := app.UI.Theme()
+		meta = func(_ []tui.Item, _ int) string {
+			return tui.RenderStatusMeta(theme, status)
+		}
 	}
 
 	leftTitle := "SKILLS"
@@ -228,7 +239,7 @@ func runSkillBrowser(app *App, section string, skills []skillItem, mode skillsBr
 		cfg := tui.Config{
 			Theme:      app.UI.Theme(),
 			Version:    resolveVersion().Version,
-			Section:    section,
+			Section:    app.headerSection(section),
 			Meta:       meta,
 			Items:      items,
 			LeftTitle:  leftTitle,

--- a/cli/cmd/humblskills/doctor.go
+++ b/cli/cmd/humblskills/doctor.go
@@ -217,7 +217,7 @@ func runDoctorTUI(app *App, r doctorReport) (bool, error) {
 			detected++
 		}
 	}
-	meta := func(_ []tui.Item, _ int) string {
+	localMeta := func(_ []tui.Item, _ int) string {
 		parts := []string{
 			fmt.Sprintf("%d / %d detected", detected, len(r.Adapters)),
 		}
@@ -231,11 +231,18 @@ func runDoctorTUI(app *App, r doctorReport) (bool, error) {
 		}
 		return strings.Join(parts, " · ")
 	}
+	meta := localMeta
+	if app.Nav.Crumb != "" {
+		status := app.Nav.Status
+		meta = func(_ []tui.Item, _ int) string {
+			return tui.RenderStatusMeta(th, status)
+		}
+	}
 
 	res, err := tui.RunListDetail(tui.Config{
 		Theme:      th,
 		Version:    ver,
-		Section:    "Doctor",
+		Section:    app.headerSection("Doctor"),
 		Meta:       meta,
 		Items:      items,
 		LeftTitle:  "CHECKS",

--- a/cli/cmd/humblskills/profile.go
+++ b/cli/cmd/humblskills/profile.go
@@ -90,7 +90,10 @@ func runProfileEditor(app *App) error {
 	if err != nil {
 		return err
 	}
-	updated, saved, err := tui.RunProfileEditor(app.UI.Theme(), adapterList, p)
+	updated, saved, err := tui.RunProfileEditorWith(app.UI.Theme(), adapterList, p, tui.ProfileHeaderSpec{
+		Section: app.headerSection("Profile"),
+		Meta:    app.headerMeta(""),
+	})
 	if err != nil {
 		return err
 	}

--- a/cli/cmd/humblskills/root.go
+++ b/cli/cmd/humblskills/root.go
@@ -12,6 +12,7 @@ import (
 	"github.com/jjfantini/humblSKILLS/cli/internal/manifest"
 	"github.com/jjfantini/humblSKILLS/cli/internal/profile"
 	"github.com/jjfantini/humblSKILLS/cli/internal/registry"
+	"github.com/jjfantini/humblSKILLS/cli/internal/tui"
 	"github.com/jjfantini/humblSKILLS/cli/internal/ui"
 )
 
@@ -21,6 +22,18 @@ type App struct {
 	Prompt   *ui.Prompter
 	Config   Config
 	Adapters func() ([]adapters.Adapter, error)
+
+	// Nav is populated when a sub-command is launched from the dashboard loop.
+	// Sub-screens mirror this into their HeaderSpec so the top header stays
+	// consistent ("Dashboard > Install") with the shared status line.
+	Nav NavContext
+}
+
+// NavContext carries the breadcrumb + status line that sub-screens render in
+// their shared header when the user is navigating from the dashboard.
+type NavContext struct {
+	Crumb  string // "Dashboard > Install" (empty when entered via a direct CLI invocation)
+	Status tui.DashboardStatus
 }
 
 // Config captures every flag/env-resolved setting used by subcommands.

--- a/cli/cmd/humblskills/start.go
+++ b/cli/cmd/humblskills/start.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -40,16 +41,16 @@ func runStart(app *App) error {
 
 	for {
 		summary := buildDashboardSummary(app)
+		status := tui.DashboardStatus{
+			Healthy:   summary.drifted == 0,
+			Platforms: summary.platforms,
+			Skills:    summary.skills,
+		}
 		cfg := tui.DashboardConfig{
-			Theme:    app.UI.Theme(),
-			Version:  resolveVersion().Version,
-			Greeting: tui.BuildDashboardGreeting(summary.drifted),
-			Status: tui.DashboardStatus{
-				Healthy:   summary.drifted == 0,
-				Platforms: summary.platforms,
-				Skills:    summary.skills,
-			},
-			Tiles: tui.DefaultDashboardTiles(),
+			Theme:   app.UI.Theme(),
+			Version: resolveVersion().Version,
+			Status:  status,
+			Tiles:   tui.DefaultDashboardTiles(),
 		}
 		res, err := tui.RunDashboard(cfg)
 		if err != nil {
@@ -58,11 +59,28 @@ func runStart(app *App) error {
 		if res.Quit || res.Command == "" {
 			return nil
 		}
+		// Stash the breadcrumb + status on the App so every sub-screen renders
+		// the same top header as the dashboard.
+		app.Nav = NavContext{
+			Crumb:  "Dashboard > " + crumbLabel(res.Command),
+			Status: status,
+		}
 		if err := dispatchDashboardCommand(app, res.Command); err != nil {
 			// Surface the error, then loop back so the user can keep working.
 			app.UI.Error("%s: %v", res.Command, err)
 		}
+		app.Nav = NavContext{}
 	}
+}
+
+// crumbLabel maps a dashboard command back to its display label for the
+// breadcrumb. Falls back to Title-case of the command itself.
+func crumbLabel(cmd string) string {
+	switch cmd {
+	case "install", "list", "update", "search", "uninstall", "profile", "doctor", "registry", "version":
+		return strings.ToUpper(cmd[:1]) + cmd[1:]
+	}
+	return cmd
 }
 
 func dispatchDashboardCommand(app *App, cmd string) error {
@@ -95,8 +113,7 @@ func dispatchDashboardCommand(app *App, cmd string) error {
 }
 
 // dashboardSummary is the data we pull once per dashboard re-entry to
-// populate both the banner ("N updates available") and the right-anchored
-// status line ("healthy · N platforms · M skills").
+// populate the top header status line (healthy · N platforms · M skills).
 type dashboardSummary struct {
 	drifted   int
 	platforms int
@@ -131,6 +148,27 @@ func buildDashboardSummary(app *App) dashboardSummary {
 		s.drifted = len(install.PlanUpdates(reg, m, nil))
 	}
 	return s
+}
+
+// headerSection returns the header Section string the caller should render.
+// If Nav has a breadcrumb (we got here from the dashboard), use that; otherwise
+// fall back to the caller-provided default (direct CLI invocation path).
+func (a *App) headerSection(fallback string) string {
+	if a.Nav.Crumb != "" {
+		return a.Nav.Crumb
+	}
+	return fallback
+}
+
+// headerMeta returns the right-anchored header Meta string. If Nav is set
+// (dashboard-launched sub-screen), render the shared status line; otherwise
+// fall back to the caller-provided default (often "" or a command-specific
+// summary).
+func (a *App) headerMeta(fallback string) string {
+	if a.Nav.Crumb != "" {
+		return tui.RenderStatusMeta(a.UI.Theme(), a.Nav.Status)
+	}
+	return fallback
 }
 
 func printStartFallback(app *App) error {

--- a/cli/cmd/humblskills/update.go
+++ b/cli/cmd/humblskills/update.go
@@ -173,14 +173,22 @@ func chooseUpdates(app *App, plans []install.UpdatePlan, all bool) ([]install.Up
 		items = append(items, updatePlanItem{p: p})
 	}
 
-	meta := func(items []tui.Item, _ int) string {
+	localMeta := func(items []tui.Item, _ int) string {
 		return fmt.Sprintf("%d drifted", len(items))
+	}
+	meta := localMeta
+	if app.Nav.Crumb != "" {
+		status := app.Nav.Status
+		theme := app.UI.Theme()
+		meta = func(_ []tui.Item, _ int) string {
+			return tui.RenderStatusMeta(theme, status)
+		}
 	}
 
 	res, err := tui.RunListDetail(tui.Config{
 		Theme:      app.UI.Theme(),
 		Version:    resolveVersion().Version,
-		Section:    "Update",
+		Section:    app.headerSection("Update"),
 		Meta:       meta,
 		Items:      items,
 		LeftTitle:  "DRIFTED",

--- a/cli/cmd/humblskills/version.go
+++ b/cli/cmd/humblskills/version.go
@@ -5,6 +5,8 @@ import (
 	"runtime/debug"
 
 	"github.com/spf13/cobra"
+
+	"github.com/jjfantini/humblSKILLS/cli/internal/tui"
 )
 
 // These are optionally overridden via -ldflags at release time.
@@ -34,6 +36,24 @@ func runVersion(app *App) error {
 	if app.Config.JSON {
 		return app.UI.JSON(info)
 	}
+
+	// When a TTY is available, render the version info as a proper TUI page so
+	// the user stays inside the alt-screen experience (ESC returns to the
+	// dashboard when launched from there; quits otherwise).
+	if tui.ShouldUseTUI(app.Config.JSON, app.Config.Quiet, app.Config.Yes) {
+		return tui.RunVersionScreen(tui.VersionScreenConfig{
+			Theme:   app.UI.Theme(),
+			Section: app.headerSection("Version"),
+			Meta:    app.headerMeta(""),
+			Info: tui.VersionInfo{
+				Version: info.Version,
+				Commit:  info.Commit,
+				Dirty:   info.Dirty,
+			},
+		})
+	}
+
+	// Non-TTY fallback — preserves the existing pipe-friendly output.
 	th := app.UI.Theme()
 	suffix := ""
 	if info.Dirty {

--- a/cli/internal/tui/dashboard.go
+++ b/cli/internal/tui/dashboard.go
@@ -6,6 +6,7 @@ import (
 	"os/user"
 	"strings"
 
+	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/sahilm/fuzzy"
@@ -31,16 +32,19 @@ type DashboardTile struct {
 	Aliases []string // additional fuzzy-search keywords
 }
 
-// DashboardGreeting is the banner displayed above the tile grid.
+// DashboardGreeting is retained for API compatibility but is no longer
+// rendered in the dashboard body — the top header already shows the status
+// line, so a duplicate greeting row was redundant noise.
 type DashboardGreeting struct {
-	User     string // username ("jennings")
-	Updates  int    // how many drifted installs
-	Cwd      string // working dir
-	LastScan string // "18:04" or ""
+	User     string
+	Updates  int
+	Cwd      string
+	LastScan string
 }
 
 // DashboardStatus feeds the header's right-anchored summary
-// (● healthy · N platforms · M skills).
+// (● healthy · N platforms · M skills). This is also what every sub-screen
+// echoes in its own header so the layout is consistent across screens.
 type DashboardStatus struct {
 	Healthy   bool
 	Platforms int // detected adapters
@@ -82,19 +86,21 @@ func RunDashboard(cfg DashboardConfig) (DashboardResult, error) {
 // DefaultDashboardTiles returns the 9-tile layout from the design handoff.
 func DefaultDashboardTiles() []DashboardTile {
 	return []DashboardTile{
-		{Command: "install", Label: "install", Hotkey: "i", Desc: "add a skill to every detected platform", Sub: "registry → adapters", Aliases: []string{"add", "get"}},
-		{Command: "list", Label: "list", Hotkey: "l", Desc: "what's installed, where, and what drifted", Sub: "manifest · adapters", Aliases: []string{"ls", "installed"}},
+		{Command: "install", Label: "install", Hotkey: "i", Desc: "add a skill to every detected platform", Sub: "registry → platforms", Aliases: []string{"add", "get"}},
+		{Command: "list", Label: "list", Hotkey: "l", Desc: "what's installed, where, and what drifted", Sub: "manifest · platforms", Aliases: []string{"ls", "installed"}},
 		{Command: "update", Label: "update", Hotkey: "u", Desc: "pull newer registry versions onto installs", Sub: "diff · apply", Aliases: []string{"upgrade"}},
 		{Command: "search", Label: "search", Hotkey: "/", Desc: "browse every skill in the registry", Sub: "fuzzy over name, tag, desc", Aliases: []string{"find", "browse"}},
 		{Command: "uninstall", Label: "uninstall", Hotkey: "x", Desc: "remove a skill from every target", Sub: "manifest-aware", Aliases: []string{"remove", "rm", "delete"}},
 		{Command: "profile", Label: "profile", Hotkey: "p", Desc: "edit install defaults (platforms, scope)", Sub: "user-wide preferences", Aliases: []string{"config", "prefs"}},
-		{Command: "doctor", Label: "doctor", Hotkey: "d", Desc: "inspect adapters and environment health", Sub: "adapters · writability", Aliases: []string{"check", "status"}},
+		{Command: "doctor", Label: "doctor", Hotkey: "d", Desc: "inspect platforms and environment health", Sub: "platforms · writability", Aliases: []string{"check", "status"}},
 		{Command: "registry", Label: "registry", Hotkey: "R", Desc: "refresh the local registry cache", Sub: "http · etag", Aliases: []string{"refresh", "sync"}},
 		{Command: "version", Label: "version", Hotkey: "V", Desc: "show build info", Sub: "version · commit", Aliases: []string{"about", "ver"}},
 	}
 }
 
 // BuildDashboardGreeting fills the defaults the dashboard banner needs.
+// Kept for API compatibility — callers may still pass this, but it isn't
+// rendered. (See DashboardGreeting.)
 func BuildDashboardGreeting(updates int) DashboardGreeting {
 	g := DashboardGreeting{Updates: updates}
 	if u, err := user.Current(); err == nil && u.Username != "" {
@@ -127,6 +133,9 @@ type dashboardModel struct {
 	searchOn bool
 	query    string
 
+	vp    viewport.Model
+	ready bool
+
 	width, height int
 	done          bool
 	result        DashboardResult
@@ -138,12 +147,29 @@ func (m dashboardModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
 		m.width, m.height = msg.Width, msg.Height
+		m = m.resizeViewport()
 		return m, nil
 	case tea.KeyMsg:
+		var out tea.Model
+		var cmd tea.Cmd
 		if m.searchOn {
-			return m.updateSearch(msg)
+			out, cmd = m.updateSearch(msg)
+		} else {
+			out, cmd = m.updateGrid(msg)
 		}
-		return m.updateGrid(msg)
+		dm, ok := out.(dashboardModel)
+		if !ok || dm.done {
+			return out, cmd
+		}
+		dm = dm.syncViewport()
+		return dm, cmd
+	case tea.MouseMsg:
+		if !m.ready {
+			return m, nil
+		}
+		vp, cmd := m.vp.Update(msg)
+		m.vp = vp
+		return m, cmd
 	}
 	return m, nil
 }
@@ -177,6 +203,16 @@ func (m dashboardModel) updateGrid(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	case "shift+tab":
 		m = m.moveCursor(-1)
+		return m, nil
+	case "pgup":
+		if m.ready {
+			m.vp.ViewUp()
+		}
+		return m, nil
+	case "pgdown":
+		if m.ready {
+			m.vp.ViewDown()
+		}
 		return m, nil
 	case "enter":
 		return m.launchCursor()
@@ -290,6 +326,62 @@ func (m dashboardModel) cols() int {
 	return 1
 }
 
+// gridHeight is the number of rows available to the scrollable grid view.
+// Total vertical budget = height. Non-grid lines: header(2) + blank(1) +
+// search(3) + blank(1) + footer(2) = 9. So grid gets whatever is left.
+func (m dashboardModel) gridHeight() int {
+	h := m.height - 9
+	if h < 3 {
+		h = 3
+	}
+	return h
+}
+
+// syncViewport rebuilds the grid content, resizes if needed, and scrolls so
+// the cursor tile is on-screen.
+func (m dashboardModel) syncViewport() dashboardModel {
+	if !m.ready {
+		return m
+	}
+	m.vp.Width = m.width
+	m.vp.Height = m.gridHeight()
+	m.vp.SetContent(m.renderGrid())
+	m = m.ensureCursorVisible()
+	return m
+}
+
+func (m dashboardModel) resizeViewport() dashboardModel {
+	if m.width == 0 || m.height == 0 {
+		return m
+	}
+	if !m.ready {
+		m.vp = viewport.New(m.width, m.gridHeight())
+		m.ready = true
+	}
+	return m.syncViewport()
+}
+
+// ensureCursorVisible nudges the viewport so the tile under the cursor sits
+// inside the visible window. Rows are uniform height (tileDisplayHeight) so we
+// can compute line ranges arithmetically.
+func (m dashboardModel) ensureCursorVisible() dashboardModel {
+	if !m.ready || len(m.visible) == 0 {
+		return m
+	}
+	row := m.cursor / m.cols()
+	tileH := tileDisplayHeight
+	top := row * tileH
+	bottom := top + tileH - 1
+	off := m.vp.YOffset
+	vh := m.vp.Height
+	if top < off {
+		m.vp.SetYOffset(top)
+	} else if bottom >= off+vh {
+		m.vp.SetYOffset(bottom - vh + 1)
+	}
+	return m
+}
+
 func (m dashboardModel) View() string {
 	if m.width == 0 || m.height == 0 {
 		return ""
@@ -298,18 +390,28 @@ func (m dashboardModel) View() string {
 	header := Header(th, HeaderSpec{
 		Version: m.cfg.Version,
 		Section: "Dashboard",
-		Meta:    m.statusLine(),
+		Meta:    RenderStatusMeta(th, m.cfg.Status),
 	}, m.width)
 
-	body := m.renderBody()
 	right := th.Meta.Render("focused: ") + th.Brand.Render(m.focusedLabel())
 	footer := Footer(th, m.hints(), right, m.width)
 
-	bodyH := m.height - lipgloss.Height(header) - lipgloss.Height(footer) - 1
-	if bodyH < 5 {
-		bodyH = 5
+	search := indentBlock(m.renderSearchBar(), 2)
+
+	gridView := ""
+	if m.ready {
+		gridView = indentBlock(m.vp.View(), 2)
 	}
-	return Frame(header, body, footer, bodyH)
+
+	if len(m.visible) == 0 {
+		gridView += "\n  " + th.Crumb.Render("no command matches "+fmt.Sprintf("%q", m.query))
+	}
+
+	// Pad the grid view to exactly gridHeight() lines so the footer sits at
+	// a predictable row regardless of content size.
+	gridView = padToHeight(gridView, m.gridHeight())
+
+	return header + "\n\n" + search + "\n\n" + gridView + "\n" + footer
 }
 
 func (m dashboardModel) focusedLabel() string {
@@ -339,65 +441,34 @@ func (m dashboardModel) hints() []KeyHint {
 	}
 }
 
-// statusLine renders the right-anchored header summary:
-// "● healthy · 2 platforms · 7 skills".
-func (m dashboardModel) statusLine() string {
-	th := m.cfg.Theme
-	dot := th.DotOK
+// RenderStatusMeta is the canonical "● healthy · N platforms · M skills"
+// string shown in the header Meta slot. Shared by the dashboard and every
+// sub-screen so the top-right summary stays consistent as the user navigates.
+func RenderStatusMeta(theme *ui.Theme, status DashboardStatus) string {
+	if theme == nil {
+		theme = ui.DefaultTheme()
+	}
+	dot := theme.DotOK
 	label := "healthy"
-	if !m.cfg.Status.Healthy {
-		dot = th.DotWarn
+	if !status.Healthy {
+		dot = theme.DotWarn
 		label = "drift"
 	}
-	sep := th.Crumb.Render(" · ")
-	return dot.Render("●") + " " + th.Detail.Render(label) +
-		sep + th.Detail.Render(fmt.Sprintf("%d platform%s", m.cfg.Status.Platforms, pluralDash(m.cfg.Status.Platforms))) +
-		sep + th.Detail.Render(fmt.Sprintf("%d skill%s", m.cfg.Status.Skills, pluralDash(m.cfg.Status.Skills)))
-}
-
-func (m dashboardModel) renderBody() string {
-	th := m.cfg.Theme
-	var sb strings.Builder
-	sb.WriteString(m.renderBanner())
-	sb.WriteString("\n\n")
-	sb.WriteString(m.renderSearchBar())
-	sb.WriteString("\n\n")
-	sb.WriteString(m.renderGrid())
-	if len(m.visible) == 0 {
-		sb.WriteString("\n  " + th.Crumb.Render("no command matches "+fmt.Sprintf("%q", m.query)))
-	}
-	return sb.String()
+	sep := theme.Crumb.Render(" · ")
+	return dot.Render("●") + " " + theme.Detail.Render(label) +
+		sep + theme.Detail.Render(fmt.Sprintf("%d platform%s", status.Platforms, pluralDash(status.Platforms))) +
+		sep + theme.Detail.Render(fmt.Sprintf("%d skill%s", status.Skills, pluralDash(status.Skills)))
 }
 
 // bodyWidth is the usable width between left/right margins. Every body
-// element (banner, search bar, tile grid row) targets this width so they
-// all end at the same column.
+// element (search bar, tile grid row) targets this width so they all end at
+// the same column.
 func (m dashboardModel) bodyWidth() int {
 	w := m.width - 4
 	if w < 40 {
 		w = 40
 	}
 	return w
-}
-
-func (m dashboardModel) renderBanner() string {
-	th := m.cfg.Theme
-	wordmark := th.Brand.Render("humblskills")
-	greet := "hello"
-	if m.cfg.Greeting.User != "" {
-		greet = "hi " + m.cfg.Greeting.User
-	}
-	parts := []string{th.Name.Render(greet)}
-	if m.cfg.Greeting.Updates > 0 {
-		parts = append(parts, th.Warn.Render(fmt.Sprintf("%d update%s available", m.cfg.Greeting.Updates, pluralDash(m.cfg.Greeting.Updates))))
-	} else {
-		parts = append(parts, th.Detail.Render("all skills up-to-date"))
-	}
-	if m.cfg.Greeting.Cwd != "" {
-		parts = append(parts, th.Detail.Render("in "+m.cfg.Greeting.Cwd))
-	}
-	line := strings.Join(parts, th.Crumb.Render("  ·  "))
-	return "  " + wordmark + "  " + line
 }
 
 func (m dashboardModel) renderSearchBar() string {
@@ -424,14 +495,18 @@ func (m dashboardModel) renderSearchBar() string {
 	if m.searchOn {
 		borderColor = th.Palette.Magenta
 	}
-	box := lipgloss.NewStyle().
+	return lipgloss.NewStyle().
 		Border(lipgloss.NormalBorder()).
 		BorderForeground(borderColor).
 		Padding(0, 1).
 		Width(inner).
 		Render(line)
-	return "  " + box
 }
+
+// tileDisplayHeight is the fixed rendered height of every tile, in lines:
+// border(2) + header(1) + desc(1) + foot(1) = 5. Staying uniform lets us
+// compute row offsets for scroll-to-cursor.
+const tileDisplayHeight = 5
 
 func (m dashboardModel) renderGrid() string {
 	if len(m.visible) == 0 {
@@ -473,7 +548,6 @@ func (m dashboardModel) renderGrid() string {
 			}
 			parts = append(parts, t)
 		}
-		sb.WriteString("  ")
 		sb.WriteString(lipgloss.JoinHorizontal(lipgloss.Top, parts...))
 		if i < len(rows)-1 {
 			sb.WriteString("\n")
@@ -483,7 +557,8 @@ func (m dashboardModel) renderGrid() string {
 }
 
 // renderTile renders one tile. The returned string is exactly `width`
-// display columns wide (border included) so JoinHorizontal aligns columns.
+// display columns wide and tileDisplayHeight lines tall so the grid is a
+// perfect lattice.
 func (m dashboardModel) renderTile(t DashboardTile, selected bool, width int) string {
 	th := m.cfg.Theme
 	borderColor := th.Palette.Border
@@ -505,16 +580,16 @@ func (m dashboardModel) renderTile(t DashboardTile, selected bool, width int) st
 	name := nameStyle.Render(t.Label)
 	header := padBetween(name, hot, inner)
 
-	desc := th.Desc.Width(inner).Render(t.Desc)
+	desc := th.Desc.Render(truncateDisplay(t.Desc, inner))
 
-	footLeft := th.Detail.Render(t.Sub)
+	footLeft := th.Detail.Render(truncateDisplay(t.Sub, inner))
 	footRight := ""
 	if t.Status != "" {
 		footRight = th.BadgeGhost.Render(t.Status)
 	}
 	foot := padBetween(footLeft, footRight, inner)
 
-	body := header + "\n\n" + desc + "\n\n" + foot
+	body := header + "\n" + desc + "\n" + foot
 	return lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(borderColor).
@@ -523,13 +598,44 @@ func (m dashboardModel) renderTile(t DashboardTile, selected bool, width int) st
 		Render(body)
 }
 
-// renderEmptyTile returns a blank block the same height as a real tile so
-// short final rows still align under a full row above.
+// renderEmptyTile returns a blank block sized like a real tile so short final
+// rows still align under a full row above.
 func (m dashboardModel) renderEmptyTile(width int) string {
 	return lipgloss.NewStyle().
 		Width(width).
-		Height(5).
+		Height(tileDisplayHeight).
 		Render("")
+}
+
+// indentBlock prefixes every line of s with n spaces. Using a naked prefix
+// ("  " + s) only shifts line one and leaves the remaining rows at col 0 —
+// that's the off-center bug that made card tops look pushed to the right.
+func indentBlock(s string, n int) string {
+	if n <= 0 || s == "" {
+		return s
+	}
+	pad := strings.Repeat(" ", n)
+	return pad + strings.ReplaceAll(s, "\n", "\n"+pad)
+}
+
+// truncateDisplay clips s to at most width display cells, appending an ellipsis
+// so the tile rows stay single-line and the grid stays a uniform lattice.
+func truncateDisplay(s string, width int) string {
+	if width <= 0 {
+		return ""
+	}
+	if lipgloss.Width(s) <= width {
+		return s
+	}
+	if width <= 1 {
+		return "…"
+	}
+	runes := []rune(s)
+	// Trim rune-by-rune until we fit with room for the ellipsis.
+	for len(runes) > 0 && lipgloss.Width(string(runes))+1 > width {
+		runes = runes[:len(runes)-1]
+	}
+	return string(runes) + "…"
 }
 
 func pluralDash(n int) string {

--- a/cli/internal/tui/profile.go
+++ b/cli/internal/tui/profile.go
@@ -12,6 +12,14 @@ import (
 	"github.com/jjfantini/humblSKILLS/cli/internal/ui"
 )
 
+// ProfileHeaderSpec lets the caller override the profile editor's top header
+// so sub-screens rendered from the dashboard can show a consistent breadcrumb
+// + status line instead of a bare "Profile" crumb.
+type ProfileHeaderSpec struct {
+	Section string // e.g. "Profile" or "Dashboard > Profile"
+	Meta    string // right-anchored meta — typically tui.RenderStatusMeta(...)
+}
+
 // RunProfileEditor opens a two-pane bubbletea TUI for editing the user
 // profile. The left pane lists settings; pressing enter on a row moves focus
 // into the right pane so the user can toggle checkboxes (platforms) or pick
@@ -20,18 +28,31 @@ import (
 // Returns the edited profile and whether any change was made. Save is the
 // caller's responsibility — this function only mutates the returned value.
 func RunProfileEditor(theme *ui.Theme, adapterList []adapters.Adapter, p *profile.Profile) (*profile.Profile, bool, error) {
+	return RunProfileEditorWith(theme, adapterList, p, ProfileHeaderSpec{})
+}
+
+// RunProfileEditorWith is RunProfileEditor plus a header override. A zero
+// ProfileHeaderSpec falls back to the default "Profile" crumb.
+func RunProfileEditorWith(theme *ui.Theme, adapterList []adapters.Adapter, p *profile.Profile, h ProfileHeaderSpec) (*profile.Profile, bool, error) {
 	if p == nil {
 		p = &profile.Profile{SchemaVersion: profile.SchemaVersion}
 	}
 	initial := *p
 
+	section := h.Section
+	if section == "" {
+		section = "Profile"
+	}
+
 	m := profileModel{
-		theme:       theme,
-		version:     versionString,
-		adapters:    adapterList,
-		profile:     initial,
-		focus:       focusSettings,
-		settingIdx:  0,
+		theme:      theme,
+		version:    versionString,
+		adapters:   adapterList,
+		profile:    initial,
+		focus:      focusSettings,
+		settingIdx: 0,
+		section:    section,
+		meta:       h.Meta,
 	}
 	out, err := Run(m)
 	if err != nil {
@@ -73,6 +94,9 @@ type profileModel struct {
 	focus      profileFocus
 	settingIdx int
 	valueIdx   int
+
+	section string // header crumb (defaults to "Profile")
+	meta    string // right-anchored header text (typically the status line)
 
 	width, height int
 	quit          bool
@@ -232,10 +256,14 @@ func (m profileModel) View() string {
 	}
 	th := m.theme
 
+	section := m.section
+	if section == "" {
+		section = "Profile"
+	}
 	header := Header(th, HeaderSpec{
 		Version: m.version,
-		Section: "Profile",
-		Meta:    "",
+		Section: section,
+		Meta:    m.meta,
 	}, m.width)
 
 	leftW, rightW := m.paneWidths()

--- a/cli/internal/tui/version_screen.go
+++ b/cli/internal/tui/version_screen.go
@@ -1,0 +1,146 @@
+package tui
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/jjfantini/humblSKILLS/cli/internal/ui"
+)
+
+// VersionInfo is the payload the version screen renders.
+type VersionInfo struct {
+	Version string
+	Commit  string
+	Dirty   bool
+}
+
+// VersionScreenConfig bundles every field the version TUI needs — including
+// the shared breadcrumb + status line so the header matches other sub-screens
+// when the user navigates in from the dashboard.
+type VersionScreenConfig struct {
+	Theme   *ui.Theme
+	Section string // "Version" (direct invocation) or "Dashboard > Version" (from launcher)
+	Meta    string // right-anchored meta — typically RenderStatusMeta(theme, status)
+	Info    VersionInfo
+}
+
+// RunVersionScreen opens the version info as a full TUI page so the user
+// stays inside the alt-screen experience instead of dropping back to the
+// shell. Any key exits.
+func RunVersionScreen(cfg VersionScreenConfig) error {
+	if cfg.Theme == nil {
+		cfg.Theme = ui.DefaultTheme()
+	}
+	if cfg.Section == "" {
+		cfg.Section = "Version"
+	}
+	_, err := Run(versionScreenModel{cfg: cfg})
+	return err
+}
+
+type versionScreenModel struct {
+	cfg           VersionScreenConfig
+	width, height int
+}
+
+func (m versionScreenModel) Init() tea.Cmd { return nil }
+
+func (m versionScreenModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width, m.height = msg.Width, msg.Height
+		return m, nil
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "ctrl+c", "q", "esc", "enter", " ":
+			return m, tea.Quit
+		}
+	}
+	return m, nil
+}
+
+func (m versionScreenModel) View() string {
+	if m.width == 0 || m.height == 0 {
+		return ""
+	}
+	th := m.cfg.Theme
+	header := Header(th, HeaderSpec{
+		Version: m.cfg.Info.Version,
+		Section: m.cfg.Section,
+		Meta:    m.cfg.Meta,
+	}, m.width)
+
+	footer := Footer(th, []KeyHint{
+		{Keys: "esc", Label: "back"},
+		{Keys: "q", Label: "quit"},
+	}, "", m.width)
+
+	body := m.renderBody()
+	bodyH := m.height - lipgloss.Height(header) - lipgloss.Height(footer) - 1
+	if bodyH < 3 {
+		bodyH = 3
+	}
+	return Frame(header, body, footer, bodyH)
+}
+
+func (m versionScreenModel) renderBody() string {
+	th := m.cfg.Theme
+	width := m.width - 4
+	if width < 40 {
+		width = 40
+	}
+	inner := width - 4
+	if inner < 20 {
+		inner = 20
+	}
+
+	wordmark := th.Brand.Render("humblskills")
+	ver := th.Version.Render(m.cfg.Info.Version)
+	if m.cfg.Info.Dirty {
+		ver += " " + th.Warn.Render("(dirty)")
+	}
+
+	rows := []struct {
+		label string
+		value string
+	}{
+		{"version", m.cfg.Info.Version},
+		{"commit", m.cfg.Info.Commit},
+		{"go", runtime.Version()},
+		{"os/arch", fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH)},
+	}
+
+	var sb strings.Builder
+	sb.WriteString(wordmark + "   " + ver)
+	if m.cfg.Info.Dirty {
+		sb.WriteString("\n" + th.Warn.Render("working tree is dirty — uncommitted changes baked into this build"))
+	}
+	sb.WriteString("\n\n")
+	for _, r := range rows {
+		sb.WriteString(th.Crumb.Render(padRight(r.label, 10)) + "  " + th.Name.Render(r.value) + "\n")
+	}
+	sb.WriteString("\n")
+	sb.WriteString(th.Detail.Render("press any key to return"))
+
+	box := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(th.Palette.Border).
+		Padding(1, 2).
+		Width(inner).
+		Render(sb.String())
+
+	return indentBlock(box, 2)
+}
+
+// padRight is a small local helper — duplicated from cmd/humblskills to avoid
+// an import cycle. Kept tiny on purpose.
+func padRight(s string, n int) string {
+	if len(s) >= n {
+		return s
+	}
+	return s + strings.Repeat(" ", n-len(s))
+}


### PR DESCRIPTION
## Summary

- **Fix top-of-card shift-right.** `"  "` prefix only indents line 1; new `indentBlock` prefixes every line of the grid and search bar.
- **Scroll when content overflows.** Wraps the grid in a `bubbles/viewport`; selected tile always stays visible (PgUp/PgDn + mouse wheel work too).
- **Drop the greeting row.** "humblskills hi jjfantini..." duplicated the top header — the body is now just search bar + grid.
- **Consistent header across every sub-screen.** Sub-commands (install, list, update, search, uninstall, profile, doctor, version) now render the same breadcrumb (`Dashboard > Install`) and the shared status line (`● healthy · N platforms · M skills`) whenever launched from the dashboard loop.
- **Version as a TUI page.** `humblskills version` now opens a proper TUI screen instead of just printing to stdout; non-TTY / `--json` output is unchanged.

## Test plan

- [ ] `cd cli && go build ./... && go vet ./... && go test ./...`
- [ ] `humblskills` on a TTY — dashboard cards align, no greeting row, top header shows status.
- [ ] Launch each tile from the dashboard — sub-screen header reads `Dashboard > <Name>` with the shared status on the right; ESC returns to dashboard.
- [ ] Resize terminal shorter than the grid — cursor scrolls the grid into view; mouse wheel scrolls.
- [ ] `humblskills install` directly — sub-screen still uses the old `Install` crumb and local meta (no dashboard breadcrumb).
- [ ] `humblskills version --json | jq .` — unchanged JSON bytes.
- [ ] `humblskills start | cat` — command table, exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)