### PR TITLE
fix(cli): brighten status dots, drop redundant installed/outdated badges

### DIFF
--- a/cli/cmd/humblskills/browse_skills.go
+++ b/cli/cmd/humblskills/browse_skills.go
@@ -39,22 +39,13 @@ func (s skillItem) FilterValue() string {
 }
 
 // NaturalWidth reports the row's display width: dot + space + name + 2-gap
-// + version + (optional: 2-gap + badge). Kept in lockstep with Row so the
-// two-pane model can size the left column to actual content.
+// + version. Status is encoded entirely in the leading dot colour
+// (green = installed, yellow = outdated, red = not installed), so no
+// trailing badge is needed.
 func (s skillItem) NaturalWidth(th *ui.Theme) int {
+	_ = th
 	versionW := lipgloss.Width("v" + s.s.Version)
-	// 1 (dot) + 1 (space) + name + 2 (gap) + version.
-	w := 1 + 1 + lipgloss.Width(s.s.Name) + 2 + versionW
-	var badge string
-	if s.outdated {
-		badge = tui.Badge(th, tui.BadgeRO, "outdated")
-	} else if s.installed != nil {
-		badge = tui.Badge(th, tui.BadgeDetected, "installed")
-	}
-	if badge != "" {
-		w += 2 + lipgloss.Width(badge)
-	}
-	return w
+	return 1 + 1 + lipgloss.Width(s.s.Name) + 2 + versionW
 }
 
 func (s skillItem) Row(th *ui.Theme, width int, selected bool) string {
@@ -72,25 +63,12 @@ func (s skillItem) Row(th *ui.Theme, width int, selected bool) string {
 	name := rowName(th, s.s.Name, selected, true)
 	version := th.Version.Render("v" + s.s.Version)
 
-	left := dot + " " + name + "  " + version
-
-	var badge string
-	if s.outdated {
-		badge = tui.Badge(th, tui.BadgeRO, "outdated")
-	} else if s.installed != nil {
-		badge = tui.Badge(th, tui.BadgeDetected, "installed")
+	row := dot + " " + name + "  " + version
+	rw := lipgloss.Width(row)
+	if rw >= width {
+		return row
 	}
-	if badge == "" {
-		// Pad to width so unbadged rows end at the same column as badged
-		// ones — otherwise the divider snaps to the widest row and loses
-		// alignment between the header rule and the body divider.
-		lw := lipgloss.Width(left)
-		if lw >= width {
-			return left
-		}
-		return left + strings.Repeat(" ", width-lw)
-	}
-	return rowWithTrailingBadge(left, badge, width)
+	return row + strings.Repeat(" ", width-rw)
 }
 
 func (s skillItem) Detail(th *ui.Theme, width int) string {

--- a/cli/internal/ui/theme.go
+++ b/cli/internal/ui/theme.go
@@ -190,9 +190,11 @@ func buildTheme(p Palette, r *lipgloss.Renderer) *Theme {
 	t.RowDim = r.NewStyle().Foreground(p.Comment)
 	t.RowBg = r.NewStyle().Background(p.BGHL)
 	t.Bullet = r.NewStyle().Foreground(p.Magenta).Bold(true)
-	t.DotOK = r.NewStyle().Foreground(p.Green)
-	t.DotNo = r.NewStyle().Foreground(p.Red)
-	t.DotWarn = r.NewStyle().Foreground(p.Yellow)
+	// Status dots use AdaptiveColor + bold so they pop on light terminals
+	// (the dark-mode pastel Green/Red/Yellow wash out on white backgrounds).
+	t.DotOK = r.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "#15803d", Dark: string(p.Green)}).Bold(true)
+	t.DotNo = r.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "#dc2626", Dark: string(p.Red)}).Bold(true)
+	t.DotWarn = r.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "#ca8a04", Dark: string(p.Yellow)}).Bold(true)
 
 	// Detail pane.
 	t.DetailTitle = r.NewStyle().Foreground(p.FG).Bold(true)


### PR DESCRIPTION
## Summary
- Status dots (`●`) now use `lipgloss.AdaptiveColor` + bold so saturated green/red/yellow variants render on light terminals instead of the washed-out Tokyo Night pastels.
- Removed the green `installed` and yellow `outdated` trailing badges on skill rows — the dot color alone conveys installed / outdated / not installed, and without the badge the signal no longer disappears when a skill name takes up the row.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...`
- [x] `go vet ./...`
- [ ] Manual: open the Install dashboard on a light-mode terminal, confirm dots are vibrant and status still reads correctly for installed / outdated / not-installed skills.

🤖 Generated with [Claude Code](https://claude.com/claude-code)