### PR TITLE
fix(cli): stop flagging installs as drifted after unrelated CLI releases

### DIFF
--- a/cli/internal/install/engine.go
+++ b/cli/internal/install/engine.go
@@ -256,9 +256,13 @@ func (e *Engine) installOne(
 			orphan = existing.Path
 		}
 
+		// Identity is version + per-skill DirSHA (RegistryRef) + on-disk
+		// location. Source.SHA (repo-wide) is intentionally excluded:
+		// it advances on every humblSKILLS commit, even ones unrelated
+		// to this skill, and using it here would make every install
+		// look drifted after each CLI release.
 		upToDate := existing != nil &&
 			existing.Version == skill.Version &&
-			existing.SourceSHA == reg.Source.SHA &&
 			existing.RegistryRef == skill.DirSHA &&
 			existing.Path == dest
 		if _, err := os.Stat(dest); err != nil {

--- a/cli/internal/install/engine_test.go
+++ b/cli/internal/install/engine_test.go
@@ -183,6 +183,70 @@ func TestEngine_InstallReplaceSkipForce(t *testing.T) {
 	}
 }
 
+// TestEngine_SkipOnStaleSourceSHA is the engine-side counterpart to
+// TestPlanUpdates_StaleSourceSHAIsNotDrift: when the humblSKILLS repo
+// SHA advances but the skill's Version and DirSHA are unchanged, a
+// re-run must Skip rather than Replace. Previously Source.SHA was part
+// of the up-to-date check, so every install was marked as replaced (and
+// shown as drifted in the dashboard) after each CLI release.
+func TestEngine_SkipOnStaleSourceSHA(t *testing.T) {
+	root := t.TempDir()
+	cacheDir := filepath.Join(root, "cache")
+	installRoot := filepath.Join(root, "home", ".claude", "skills")
+	manifestPath := filepath.Join(root, "manifest.json")
+
+	skillFiles := map[string]string{"skills/foo/SKILL.md": "# foo\n"}
+	onlyFoo := map[string]string{"SKILL.md": "# foo\n"}
+	dirSHA := expectedDirSHA(t, onlyFoo)
+
+	owner, name := "example", "repo"
+	sha1 := "sha1aaaaaaaaaaaa"
+	sha2 := "sha2bbbbbbbbbbbb"
+	// Both tarballs ship the exact same skill tree — only the repo SHA
+	// differs, simulating an unrelated commit (doc, other-skill, CI).
+	seedTarball(t, cacheDir, owner, name, sha1, owner+"-"+name+"-abc1234", skillFiles)
+	seedTarball(t, cacheDir, owner, name, sha2, owner+"-"+name+"-def5678", skillFiles)
+
+	mkReg := func(sha string) *registry.Registry {
+		return &registry.Registry{
+			SchemaVersion: registry.SchemaVersion,
+			Source:        registry.Source{Repo: "github.com/example/repo", SHA: sha},
+			Skills: []registry.Skill{{
+				Name: "foo", Version: "0.1.0", Path: "skills/foo",
+				Platforms: []string{"test"}, DirSHA: dirSHA,
+			}},
+		}
+	}
+
+	adapter := adapters.Adapter{
+		Name:           "test",
+		InstallTargets: map[string]string{"user": installRoot},
+		DefaultScope:   "user",
+	}
+	engine := NewEngine(cacheDir, manifestPath)
+	engine.Now = func() time.Time { return time.Unix(1700000000, 0).UTC() }
+
+	// Install under sha1.
+	plan1, _ := Plan(mkReg(sha1), "foo")
+	if _, err := engine.Execute(mkReg(sha1), plan1, ExecuteOpts{
+		Adapters: []adapters.Adapter{adapter}, Platforms: []string{"test"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Re-run under sha2 — same version + dir_sha, new repo SHA. Must skip.
+	plan2, _ := Plan(mkReg(sha2), "foo")
+	res, err := engine.Execute(mkReg(sha2), plan2, ExecuteOpts{
+		Adapters: []adapters.Adapter{adapter}, Platforms: []string{"test"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Results) != 1 || res.Results[0].Outcome != OutcomeSkipped {
+		t.Fatalf("expected skipped after source_sha-only change, got %+v", res.Results)
+	}
+}
+
 func TestEngine_ProjectScopeMovesOldInstall(t *testing.T) {
 	root := t.TempDir()
 	cacheDir := filepath.Join(root, "cache")

--- a/cli/internal/install/update.go
+++ b/cli/internal/install/update.go
@@ -63,10 +63,16 @@ func PlanUpdates(reg *registry.Registry, m *manifest.Manifest, only []string) []
 			continue
 		}
 		// Any target that's drifted triggers an UpdatePlan for the skill.
+		//
+		// Drift is keyed on the per-skill signals: version and DirSHA
+		// (RegistryRef). The repo-wide Source.SHA is NOT consulted — it
+		// advances on every commit to the humblSKILLS repo, including
+		// commits that don't touch this skill, which would flag every
+		// installation as drifted after each CLI release. Source.SHA is
+		// kept in the manifest purely as install-time metadata.
 		drifted := false
 		for _, i := range insts {
 			if i.Version != regSkill.Version ||
-				i.SourceSHA != reg.Source.SHA ||
 				i.RegistryRef != regSkill.DirSHA {
 				drifted = true
 				break

--- a/cli/internal/install/update_test.go
+++ b/cli/internal/install/update_test.go
@@ -35,7 +35,11 @@ func TestPlanUpdates(t *testing.T) {
 				Skill: "bar", Version: "1.0.0", Platform: "claude", Scope: "user",
 				Path: "/u/bar", SourceSHA: "newSourceSHA", RegistryRef: "dirSHA-bar-v1",
 			},
-			// baz: same version but source_sha drift should still trigger an update.
+			// baz: version and dir_sha match — a stale source_sha alone
+			// must NOT flag the skill as drifted. Source.SHA advances on
+			// every humblSKILLS repo commit whether or not this skill
+			// changed, so consulting it here produces false positives
+			// after every CLI release.
 			{
 				Skill: "baz", Version: "0.1.0", Platform: "claude", Scope: "user",
 				Path: "/u/baz", SourceSHA: "oldSourceSHA", RegistryRef: "dirSHA-baz",
@@ -57,8 +61,8 @@ func TestPlanUpdates(t *testing.T) {
 	if _, ok := byName["foo"]; !ok {
 		t.Error("foo should be in plans")
 	}
-	if _, ok := byName["baz"]; !ok {
-		t.Error("baz should be in plans (source_sha drift)")
+	if _, ok := byName["baz"]; ok {
+		t.Error("baz should NOT be in plans (source_sha differs but version + dir_sha match)")
 	}
 	if _, ok := byName["bar"]; ok {
 		t.Error("bar should NOT be in plans (up-to-date)")
@@ -78,10 +82,52 @@ func TestPlanUpdates(t *testing.T) {
 		t.Errorf("foo should have 2 targets, got %d", len(foo.Targets))
 	}
 
-	// Filter to "baz": should exclude foo.
-	only := PlanUpdates(reg, m, []string{"baz"})
-	if len(only) != 1 || only[0].Skill != "baz" {
+	// Filter to "foo": should exclude every other skill.
+	only := PlanUpdates(reg, m, []string{"foo"})
+	if len(only) != 1 || only[0].Skill != "foo" {
 		t.Errorf("filter failed: %+v", only)
+	}
+}
+
+// TestPlanUpdates_StaleSourceSHAIsNotDrift reproduces the dashboard bug where
+// every installation was flagged as drifted after a CLI release even though
+// no skill content had changed. Source.SHA is the humblSKILLS repo commit
+// SHA; it advances on every commit, so consulting it as a drift signal
+// produces false positives on every new release. Drift must key only on
+// per-skill signals (version + DirSHA).
+func TestPlanUpdates_StaleSourceSHAIsNotDrift(t *testing.T) {
+	reg := &registry.Registry{
+		SchemaVersion: registry.SchemaVersion,
+		Source:        registry.Source{Repo: "github.com/example/repo", SHA: "sha-after-cli-release"},
+		Skills: []registry.Skill{
+			{Name: "use-smart-humanize-text", Version: "2.0.0", DirSHA: "dirSHA-humanize-v2"},
+			{Name: "use-smart-skill", Version: "1.1.0", DirSHA: "dirSHA-smart-skill-v1-1"},
+		},
+	}
+	m := &manifest.Manifest{
+		SchemaVersion: manifest.SchemaVersion,
+		Installations: []manifest.Installation{
+			{
+				Skill: "use-smart-humanize-text", Version: "2.0.0",
+				Platform: "claude-code", Scope: "user", Path: "/u/humanize",
+				SourceSHA: "sha-before-cli-release", RegistryRef: "dirSHA-humanize-v2",
+			},
+			{
+				Skill: "use-smart-humanize-text", Version: "2.0.0",
+				Platform: "cursor", Scope: "user", Path: "/u/humanize-cursor",
+				SourceSHA: "sha-before-cli-release", RegistryRef: "dirSHA-humanize-v2",
+			},
+			{
+				Skill: "use-smart-skill", Version: "1.1.0",
+				Platform: "claude-code", Scope: "user", Path: "/u/smart-skill",
+				SourceSHA: "sha-before-cli-release", RegistryRef: "dirSHA-smart-skill-v1-1",
+			},
+		},
+	}
+
+	plans := PlanUpdates(reg, m, nil)
+	if len(plans) != 0 {
+		t.Errorf("no skill should drift purely from a stale repo SourceSHA; got %+v", plans)
 	}
 }
 


### PR DESCRIPTION
## Summary
- The Update dashboard showed every installed skill as drifted (e.g. \`2.0.0 → 2.0.0\`) after each CLI release even though no skill content had changed.
- Root cause: drift checks compared the manifest's stored \`SourceSHA\` against \`reg.Source.SHA\`, but \`Source.SHA\` is the humblSKILLS repo commit hash — it advances on every commit regardless of which skill (if any) was touched, so every install looked drifted after each release.
- Fix: drift now keys only on per-skill signals — version and \`DirSHA\` (\`RegistryRef\`). \`Source.SHA\` is kept in the manifest as install-time metadata but no longer drives drift. The engine's up-to-date check is aligned so reinstalls after an unrelated repo commit skip instead of replacing.

## Test plan
- [x] Added \`TestPlanUpdates_StaleSourceSHAIsNotDrift\` — reproduces the dashboard scenario and asserts no drift is reported.
- [x] Added \`TestEngine_SkipOnStaleSourceSHA\` — reinstall after a Source.SHA-only change must return \`OutcomeSkipped\`, not \`OutcomeReplaced\`.
- [x] Updated the existing \`TestPlanUpdates\` \`baz\` case, which previously codified the bug ("source_sha drift should still trigger an update"), to assert the correct behavior.
- [x] \`go test ./...\` / \`go vet ./...\` green.
- [ ] Manual: after merge + release, open the Update dashboard; installs with matching version should no longer appear under \`DRIFTED\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)