### PR TITLE
fix(cli): prevent search bar wrap that hides dashboard header

### DIFF
--- a/cli/internal/tui/dashboard.go
+++ b/cli/internal/tui/dashboard.go
@@ -497,17 +497,23 @@ func (m dashboardModel) renderSearchBar() string {
 	prefixW := lipgloss.Width(prefix)
 	countW := lipgloss.Width(countStyled)
 
-	// Right-anchor the count. Reserve prefix + query + ≥1 gap + count
-	// within `inner`. When the terminal is too narrow to fit the count
-	// (tight splits, SSH), drop it and let the query take the row so
-	// the box never overflows to a second line.
+	// Pack content to `budget = inner - 2`, giving a 2-cell safety margin
+	// inside the outer Width(inner). Some glyphs (notably ❯ U+276F) are
+	// reported as 1-cell by runewidth but render 2 cells in several
+	// terminals — packing to exactly `inner` then wraps the search bar to
+	// a 2nd line, which shoves the header off-screen on alt-screen. The
+	// buffer ensures the outer `.Width(inner)` always pads (never wraps).
+	budget := inner - 2
+	if budget < prefixW+1 {
+		budget = prefixW + 1
+	}
 	var line string
-	if inner-prefixW-countW-1 < 1 {
-		line = prefix + queryStyle.Render(truncateDisplay(queryRaw, inner-prefixW))
+	if budget-prefixW-countW-1 < 1 {
+		line = prefix + queryStyle.Render(truncateDisplay(queryRaw, budget-prefixW))
 	} else {
-		maxQueryW := inner - prefixW - countW - 1
+		maxQueryW := budget - prefixW - countW - 1
 		q := truncateDisplay(queryRaw, maxQueryW)
-		pad := inner - prefixW - lipgloss.Width(q) - countW
+		pad := budget - prefixW - lipgloss.Width(q) - countW
 		if pad < 1 {
 			pad = 1
 		}


### PR DESCRIPTION
## Summary
- Fix the dashboard search bar wrapping to a 2nd line, which was pushing the top header off-screen in alt-screen mode.
- Root cause: the `❯` sigil (U+276F) is measured as 1 cell by runewidth but renders as 2 cells in many terminals. Right-anchoring `9/9` to *exactly* `inner` cells meant a single glyph-width miscount would overflow the outer `.Width(inner)` and wrap.
- Pack content to `inner - 2` so the outer box always pads rather than wraps, regardless of glyph-width miscounts.

## Test plan
- [x] `go build ./...` and `go vet ./...` clean
- [x] Existing install/tui tests pass
- [ ] Run `humblskills start` in the embedded Claude Code terminal: header visible, `9/9` right-anchored on one line
- [ ] Resize terminal narrow → wide: counter stays right-anchored, no wrap

🤖 Generated with [Claude Code](https://claude.com/claude-code)