### PR TITLE
feat(cli): scroll the detail pane in list-detail screens

### DIFF
--- a/cli/internal/tui/listdetail.go
+++ b/cli/internal/tui/listdetail.go
@@ -207,6 +207,36 @@ func (m Model) updateNav(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
+	// Detail-pane scroll. List navigation owns up/down, so scrolling uses a
+	// distinct set: pgup/pgdown for full pages, ctrl+u/ctrl+d for half pages
+	// (vim), shift+up/shift+down for single lines. Home/end jump to edges.
+	switch msg.String() {
+	case "pgup":
+		m.preview.ViewUp()
+		return m, nil
+	case "pgdown":
+		m.preview.ViewDown()
+		return m, nil
+	case "ctrl+u":
+		m.preview.HalfViewUp()
+		return m, nil
+	case "ctrl+d":
+		m.preview.HalfViewDown()
+		return m, nil
+	case "shift+up":
+		m.preview.LineUp(1)
+		return m, nil
+	case "shift+down":
+		m.preview.LineDown(1)
+		return m, nil
+	case "home":
+		m.preview.GotoTop()
+		return m, nil
+	case "end":
+		m.preview.GotoBottom()
+		return m, nil
+	}
+
 	k := msg.String()
 	if k == "enter" {
 		// First enabled action absorbs enter so users don't need to learn a
@@ -486,6 +516,7 @@ func (m Model) hints() []KeyHint {
 	if m.cfg.Items != nil {
 		hints = append(hints, KeyHint{Keys: "/", Label: "filter"})
 	}
+	hints = append(hints, KeyHint{Keys: "⇞⇟", Label: "scroll"})
 	// Deduplicate enter when it's absorbed by the first action.
 	seen := map[string]bool{}
 	for _, a := range m.cfg.Actions {


### PR DESCRIPTION
## Summary
- The right-hand DETAIL pane already owns a `viewport.Model`, but no keys were forwarded to it — long descriptions (e.g. `use-smart-skill`) got clipped with no way to scroll.
- Wire up scroll keys that don't collide with list navigation (↑/↓) or action hotkeys (letters).

## Key bindings
- `pgup` / `pgdn` — full page
- `ctrl+u` / `ctrl+d` — half page (vim)
- `shift+↑` / `shift+↓` — line-by-line
- `home` / `end` — jump to edges

Added `⇞⇟ scroll` hint to the footer so the capability is discoverable.

## Test plan
- [x] `go build ./...` and `go vet ./...` clean
- [ ] Run `humblskills install`, focus a skill with a long description → scroll the right pane
- [ ] Confirm list ↑/↓ still changes selection (separate from detail scroll)

🤖 Generated with [Claude Code](https://claude.com/claude-code)