### PR TITLE
docs: MkDocs site + GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,56 @@
+name: Docs
+
+on:
+  push:
+    branches:
+      - develop
+      - main
+  pull_request:
+    branches:
+      - develop
+  workflow_dispatch:
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: docs/requirements.txt
+
+      - name: Install MkDocs dependencies
+        run: pip install -r docs/requirements.txt
+
+      - name: Build site
+        run: mkdocs build --strict
+
+      - name: Upload Pages artifact
+        if: github.event_name == 'push'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main')
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ vendor/
 /bin/
 /build/
 
+# MkDocs
+/site/
+
 # goreleaser
 /dist/
 

--- a/docs/eval/artifacts.md
+++ b/docs/eval/artifacts.md
@@ -1,0 +1,28 @@
+# Eval artifacts
+
+Each iteration writes artifacts under:
+
+`$XDG_STATE_HOME/humblskills/evals/<skill>/iteration-N/`
+
+Typical layout:
+
+```text
+iteration-N/
+├── benchmark.json      # cross-section stats + deltas
+├── trajectory.json     # per-session time series (smart arm compounds here)
+├── report.html         # single-file Plotly dashboard
+├── report.md           # plaintext mirror (PR-friendly)
+├── report.json         # machine-readable
+├── smart_skill/
+│   └── session-NN/
+│       ├── outputs/              # files the agent wrote
+│       ├── transcript.txt      # full agent transcript
+│       ├── timing.json         # tokens, duration, cost
+│       ├── metrics.json        # tool-call counts + brain reads
+│       ├── brain-snapshot-before/
+│       └── brain-snapshot-after/ # feeds session N+1 for smart arm
+├── flat_skill/...
+└── no_skill/...
+```
+
+Iterations are **persistent** and **append-only**. Use `humblskills eval prune` to cap how many iterations you keep per skill.

--- a/docs/eval/index.md
+++ b/docs/eval/index.md
@@ -1,0 +1,24 @@
+# Eval overview
+
+`humblskills eval` runs a **three-arm** benchmark for any skill:
+
+- **`no_skill`** - baseline without the skill
+- **`flat_skill`** - skill injected without smart multi-session state
+- **`smart_skill`** - full smart skill; sessions run **in order** so brain state (patterns, decisions, log, wiki) carries across runs
+
+Outputs are graded and summarized in a **single-file HTML** dashboard (plus JSON/Markdown mirrors). For smart skills, you get a **trajectory** that shows compounding across sessions.
+
+## Runners
+
+Pick the runner that matches how you authenticate today, or use the mock runner in CI.
+
+| Runner | Auth | Notes |
+|--------|------|-------|
+| `claudecode` | Claude Code login | Wraps `claude -p --output-format stream-json` |
+| `cursor-agent` | Cursor login | Wraps `cursor-agent` headless CLI |
+| `codex` | Codex login | Wraps the OpenAI `codex` CLI |
+| `anthropic-api` | `ANTHROPIC_API_KEY` / keyring | Pure-Go Read/Write/Bash/Glob/Grep tool loop |
+| `openai-api` | `OPENAI_API_KEY` / keyring | Pure-Go tool loop |
+| `mock` | none | Deterministic, zero tokens (CI and dev) |
+
+Next: [Eval quickstart](quickstart.md), [Artifacts](artifacts.md), [Scenarios](scenarios.md).

--- a/docs/eval/quickstart.md
+++ b/docs/eval/quickstart.md
@@ -1,0 +1,27 @@
+# Eval quickstart
+
+```sh
+humblskills doctor                          # check runner availability
+humblskills eval set-key anthropic          # store key in the OS keyring
+humblskills eval runners                    # one-liner per-runner status
+humblskills eval                            # dashboard entry → Eval Home TUI
+humblskills eval run use-smart-skill        # non-TUI run
+humblskills eval showcase                   # canonical demo
+humblskills eval ls                         # iterations per skill
+humblskills eval prune use-smart-skill --keep-last 5
+```
+
+## Secrets
+
+Secrets **do not** land in profile JSON. `eval set-key` resolves credentials in this order:
+
+1. Environment variables
+2. OS keyring
+3. `$XDG_CONFIG_HOME/humblskills/secrets.json` (mode `0600`)
+
+The TUI can prompt with masked input when appropriate.
+
+## See also
+
+- [Artifacts](artifacts.md) - what is written under `evals/<skill>/iteration-N/`
+- [Scenarios](scenarios.md) - `evals/scenarios.json` and assertions

--- a/docs/eval/scenarios.md
+++ b/docs/eval/scenarios.md
@@ -1,0 +1,26 @@
+# Scenarios & authoring
+
+Each skill can ship **`evals/scenarios.json`**. Sessions run **in order** so later sessions can depend on smart-skill brain state from earlier ones.
+
+## Assertions
+
+Assertions may be:
+
+- **`llm`** - judged by a model (flexible, less deterministic)
+- **Scripted** - for example `path_exists`, `exec`, `regex`, `script`, `json_valid` (prefer when you need stable CI)
+
+Scripted checks are usually better than LLM-only judges when you care about reproducibility.
+
+## Scaffold
+
+```sh
+humblskills eval init <skill>
+```
+
+## Reference layout
+
+The canonical example with retention checks across sessions is under:
+
+[`skills/use-smart-skill/evals/`](https://github.com/jjfantini/humblSKILLS/tree/develop/skills/use-smart-skill/evals/)
+
+Use that tree as a template when authoring scenarios for a new skill.

--- a/docs/getting_started/index.md
+++ b/docs/getting_started/index.md
@@ -1,0 +1,10 @@
+# Getting started
+
+Use this section to install `humblskills` and run your first commands.
+
+| Page | What it covers |
+|------|----------------|
+| [Installation](installation.md) | Shell installer, `go install`, release archives, Homebrew |
+| [Quickstart](quickstart.md) | Core commands, `--json`, `--yes` |
+
+If you plan to run [eval](../eval/index.md), you will also configure runners and API keys as described there.

--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -1,0 +1,54 @@
+# Installation
+
+## Shell installer (Linux/macOS)
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/jjfantini/humblSKILLS/main/scripts/install.sh | sh
+```
+
+Installs to `/usr/local/bin` by default (uses `sudo` if needed). Override the destination with `INSTALL_DIR`:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/jjfantini/humblSKILLS/main/scripts/install.sh | INSTALL_DIR=$HOME/.local/bin sh
+```
+
+Pin a version (example: `0.1.0`):
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/jjfantini/humblSKILLS/main/scripts/install.sh | VERSION=0.1.0 sh
+```
+
+## Go
+
+```sh
+go install github.com/jjfantini/humblSKILLS/cli/cmd/humblskills@latest
+```
+
+## Direct download
+
+Grab the archive for your platform from the [releases page](https://github.com/jjfantini/humblSKILLS/releases/latest):
+
+- `humblskills_<version>_linux_amd64.tar.gz`
+- `humblskills_<version>_linux_arm64.tar.gz`
+- `humblskills_<version>_macos_amd64.tar.gz`
+- `humblskills_<version>_macos_arm64.tar.gz`
+- `humblskills_<version>_windows_amd64.zip`
+- `humblskills_<version>_windows_arm64.zip`
+
+Each release publishes `checksums.txt` with SHA-256 sums.
+
+## Homebrew (Linux/macOS)
+
+```sh
+brew install jjfantini/humbl/humblskills
+```
+
+Formulas live in [`jjfantini/homebrew-humbl`](https://github.com/jjfantini/homebrew-humbl) and are bumped by the release workflow.
+
+## Verify
+
+```sh
+humblskills doctor
+```
+
+See [Quickstart](quickstart.md) for everyday commands.

--- a/docs/getting_started/quickstart.md
+++ b/docs/getting_started/quickstart.md
@@ -1,0 +1,26 @@
+# Quickstart
+
+```sh
+humblskills doctor                    # verify the environment
+humblskills search                    # browse the registry
+humblskills install use-smart-skill
+humblskills list
+humblskills update                    # pick which drifted skills to upgrade
+humblskills update --all --yes        # non-interactive bulk upgrade
+humblskills uninstall use-smart-skill
+```
+
+## Machine-friendly output
+
+Every command accepts:
+
+- **`--json`** - machine-readable output
+- **`--yes`** - skip confirmation prompts
+
+Use these in scripts and CI.
+
+## Related topics
+
+- [Registry & skill format](../using_humblskills/registry_and_format.md)
+- [Preserving user content](../using_humblskills/preserving_user_content.md)
+- [Eval quickstart](../eval/quickstart.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,17 @@
+# humblSKILLS
+
+humblSKILLS is a **skill registry** plus a single-binary Go CLI, **`humblskills`**, that installs [agentskills.io](https://agentskills.io)-format skills for the agent stack you already use (Claude Code, Cursor, Codex, and similar).
+
+## What you get
+
+1. **Skill registry** - A monorepo of skills in the agentskills.io shape, with small humblSKILLS extensions in `SKILL.md` frontmatter: `requires`, `platforms`, `tags`, `preserve`.
+2. **`humblskills` CLI** - Pulls a skill directory from the registry and installs it in the right place for your platform. No hosted account, no telemetry.
+
+## Next steps
+
+- [Installation](getting_started/installation.md) - shell, Go, releases, Homebrew
+- [Quickstart](getting_started/quickstart.md) - `doctor`, `search`, `install`, `update`
+- [Eval](eval/index.md) - benchmark skills and inspect compound smart-skill runs
+- [Preserving user content](using_humblskills/preserving_user_content.md) - `preserve:` in `SKILL.md`
+
+Documentation is hosted on [GitHub Pages](https://jjfantini.github.io/humblSKILLS/); source lives in the [humblSKILLS repo](https://github.com/jjfantini/humblSKILLS).

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+mkdocs==1.6.1
+mkdocs-material==9.6.7
+pymdown-extensions==10.14.3

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,7 @@
+# Roadmap
+
+This page is a lightweight stub. Track larger direction in [GitHub Issues](https://github.com/jjfantini/humblSKILLS/issues) and the main [README](https://github.com/jjfantini/humblSKILLS).
+
+Planned doc improvements:
+
+- Auto-generated **CLI reference** (Cobra → Markdown → MkDocs) in a follow-up pass.

--- a/docs/using_humblskills/preserving_user_content.md
+++ b/docs/using_humblskills/preserving_user_content.md
@@ -1,0 +1,66 @@
+# Preserving user content
+
+Smart skills often accumulate user-owned content: raw sources, append-only memory (`log.md`, `decisions.md`, `patterns.md`), wiki pages, and so on. By default, `humblskills update` and `humblskills install` **overwrite** the skill directory with what the registry ships.
+
+Skills that must keep user content across updates declare a **`preserve:`** list in `SKILL.md` frontmatter.
+
+## Rules
+
+Entries are **paths relative to the skill directory**. A trailing **`/`** means a **directory**; otherwise the entry is a **file**. Globs are not supported.
+
+| Entry form | Example | Meaning on update |
+|------------|---------|-------------------|
+| **File** | `references/log.md` | User wins: your bytes survive the update. |
+| **Directory** | `references/wiki/` | Deep merge: staging wins per file; files only on your side are kept. |
+
+Fresh installs always seed everything from the registry. `preserve` applies when **replacing** an existing install. `humblskills uninstall` removes everything, including preserved paths.
+
+### Example `SKILL.md` frontmatter
+
+```yaml
+---
+name: my-smart-skill
+description: ...
+version: 0.2.0
+preserve:
+  - references/log.md
+  - references/patterns.md
+  - references/decisions.md
+  - references/raw/
+  - references/wiki/
+---
+```
+
+Authors who ship a **preserve directory** should document that files the author ships inside that directory may still be overwritten on update (deep-merge contract).
+
+## You own the preserve list after install
+
+The registry’s `preserve:` list is the **seed** on first install. After that, **`humblskills update` reads `preserve:` from the installed `SKILL.md` on disk** (per platform and scope), not from upstream.
+
+- Add an entry locally → that path survives the next update, even if upstream did not list it.
+- Remove an entry locally → that path is overwritten from upstream on the next update.
+- Clear `preserve:` → the next update does a full overwrite for paths that are not listed.
+
+Only **`preserve:`** is treated as user-owned. Other frontmatter (`name`, `description`, `version`, `requires`, `platforms`, `tags`) and the markdown body are refreshed from upstream on update, while your `preserve:` list is carried forward.
+
+### Freeze all of `SKILL.md`
+
+To stop upstream from changing description, version, or body, add **`SKILL.md`** itself to `preserve:`. That is opt-in and stops those upstream updates until you remove it.
+
+### Broken or missing frontmatter
+
+If the installed `SKILL.md` is missing, unparseable, or has an invalid preserve list (for example path traversal with `..`), the engine falls back to the registry list and prints a warning.
+
+YAML round-trip on update may normalize whitespace and drop comments inside the frontmatter block; keys and values stay intact.
+
+## Clean reinstall
+
+Bypass local preserve and match the registry exactly:
+
+```sh
+humblskills update --force <skill>
+humblskills install --force <skill>
+humblskills uninstall <skill> && humblskills install <skill>
+```
+
+`--force` ignores your local preserve edits and replaces the on-disk skill with the registry version.

--- a/docs/using_humblskills/registry_and_format.md
+++ b/docs/using_humblskills/registry_and_format.md
@@ -1,0 +1,20 @@
+# Registry & skill format
+
+Skills in this registry follow the [agentskills.io](https://agentskills.io) format. Each skill is a directory with a `SKILL.md` (and optional supporting files) that agents can load as instructions.
+
+## humblSKILLS frontmatter extensions
+
+Authors may include extra keys in YAML frontmatter:
+
+| Key | Purpose |
+|-----|---------|
+| `requires` | Dependencies or constraints (as defined by the skill) |
+| `platforms` | Which agent platforms the skill targets |
+| `tags` | Discovery / grouping |
+| `preserve` | Paths to keep on `update` when replacing an installed skill (see [Preserving user content](preserving_user_content.md)) |
+
+Other frontmatter fields (for example `name`, `description`, `version`) follow the normal agentskills.io expectations.
+
+## Where skills live in the repo
+
+Published skills live under `skills/<skill-id>/` in the [humblSKILLS repository](https://github.com/jjfantini/humblSKILLS). The CLI reads the bundled registry and installs the matching directory to your configured location for Cursor, Claude Code, Codex, etc.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,100 @@
+site_name: humblSKILLS
+repo_url: https://github.com/jjfantini/humblSKILLS
+site_url: https://jjfantini.github.io/humblSKILLS/
+repo_name: humblSKILLS
+site_dir: site
+copyright: Copyright &copy; 2026 Jennings Fantini
+edit_uri: edit/develop/docs/
+site_author: Jennings Fantini
+
+exclude_docs: |
+  requirements.txt
+
+watch:
+  - docs/
+  - mkdocs.yml
+
+nav:
+  - Home: index.md
+  - Getting Started:
+    - getting_started/index.md
+    - Installation: getting_started/installation.md
+    - Quickstart: getting_started/quickstart.md
+  - Using humblskills:
+    - Registry & skill format: using_humblskills/registry_and_format.md
+    - Preserving user content: using_humblskills/preserving_user_content.md
+  - Eval:
+    - Overview: eval/index.md
+    - Quickstart: eval/quickstart.md
+    - Artifacts: eval/artifacts.md
+    - Scenarios: eval/scenarios.md
+  - Roadmap: roadmap.md
+
+theme:
+  name: material
+  features:
+    - content.action.edit
+    - content.action.view
+    - content.code.copy
+    - navigation.instant
+    - navigation.instant.prefetch
+    - navigation.instant.progress
+    - navigation.instant.preview
+    - navigation.tracking
+    - navigation.tabs
+    - navigation.expand
+    - navigation.path
+    - navigation.indexes
+    - navigation.top
+    - navigation.footer
+    - search.suggest
+    - search.highlight
+    - toc.follow
+  palette:
+    - media: "(prefers-color-scheme)"
+      toggle:
+        icon: material/brightness-auto
+        name: Switch to light mode
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: green
+      accent: green
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: green
+      accent: green
+      toggle:
+        icon: material/brightness-4
+        name: Switch to system preference
+  font:
+    text: Fira Code
+
+plugins:
+  - search
+
+markdown_extensions:
+  - tables
+  - admonition
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+  - pymdownx.details
+  - def_list
+  - attr_list
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+  - toc:
+      permalink: "¤"
+  - pymdownx.tasklist:
+      custom_checkbox: true
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/jjfantini/humblSKILLS


### PR DESCRIPTION
## Summary
Adds a **MkDocs Material** documentation site (user-facing only) and a **GitHub Actions** workflow that builds with `mkdocs build --strict` and deploys to **GitHub Pages** on push to `develop` or `main`. PRs targeting `develop` run the build without deploy.

## Contents
- `mkdocs.yml` - Material theme aligned with humblDATA (extensions, no mkdocstrings/mike)
- `docs/**` - Getting started, eval, registry/preserve guides; `docs/requirements.txt` pinned deps
- `.github/workflows/docs.yml` - build + `upload-pages-artifact` / `deploy-pages`
- `.gitignore` - `site/`

## After merge (manual)
1. Repo **Settings → Pages**: set **Source** to **GitHub Actions** (if not already).
2. Confirm the **Docs** workflow runs on `develop` and the site is available at https://jjfantini.github.io/humblSKILLS/

CLI reference (Cobra → Markdown) is intentionally deferred.

Made with [Cursor](https://cursor.com)