### PR TITLE
fix(docs): MkDocs fenced code blocks and Pygments pin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ vendor/
 
 # MkDocs
 /site/
+.venv/
 
 # goreleaser
 /dist/

--- a/docs/mkdocs_hooks.py
+++ b/docs/mkdocs_hooks.py
@@ -1,0 +1,12 @@
+"""Remove MkDocs built-in fenced_code so pymdownx.superfences handles fenced blocks."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def on_config(config: Any, **kwargs: Any) -> Any:
+    config["markdown_extensions"] = [
+        ext for ext in config["markdown_extensions"] if ext != "fenced_code"
+    ]
+    return config

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,6 @@
 mkdocs==1.6.1
 mkdocs-material==9.6.7
 pymdown-extensions==10.14.3
+# Pygments 2.18+ can pass filename=None into html.escape via HtmlFormatter on Python 3.9,
+# which breaks pymdownx.highlight and causes fenced blocks to fail silently.
+pygments==2.17.2

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -75,9 +75,17 @@ theme:
 plugins:
   - search
 
+hooks:
+  - docs/mkdocs_hooks.py
+
 markdown_extensions:
   - tables
   - admonition
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
   - pymdownx.superfences:
       custom_fences:
         - name: mermaid


### PR DESCRIPTION
Fixes broken fenced code / YAML on GitHub Pages.

Root cause: Pygments 2.18+ can pass `filename=None` into `html.escape` via HtmlFormatter on the Python versions pymdown uses, so pymdownx.highlight throws inside SuperFences; the error is swallowed and fences fall back to broken paragraph-level code spans. Pin Pygments 2.17.2.

Also align the Material markdown stack (highlight + inlinehilite before superfences) and remove MkDocs built-in `fenced_code` via a hook so only pymdownx.superfences handles fences.

Verification: `python3 -m venv .venv && pip install -r docs/requirements.txt && mkdocs build --strict`.

Made with [Cursor](https://cursor.com)