### PR TITLE
chore: merge develop (docs MkDocs fix for Pages)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ vendor/
 
 # MkDocs
 /site/
+.venv/
 
 # goreleaser
 /dist/

--- a/docs/mkdocs_hooks.py
+++ b/docs/mkdocs_hooks.py
@@ -1,0 +1,12 @@
+"""Remove MkDocs built-in fenced_code so pymdownx.superfences handles fenced blocks."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def on_config(config: Any, **kwargs: Any) -> Any:
+    config["markdown_extensions"] = [
+        ext for ext in config["markdown_extensions"] if ext != "fenced_code"
+    ]
+    return config

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,6 @@
 mkdocs==1.6.1
 mkdocs-material==9.6.7
 pymdown-extensions==10.14.3
+# Pygments 2.18+ can pass filename=None into html.escape via HtmlFormatter on Python 3.9,
+# which breaks pymdownx.highlight and causes fenced blocks to fail silently.
+pygments==2.17.2

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -75,9 +75,17 @@ theme:
 plugins:
   - search
 
+hooks:
+  - docs/mkdocs_hooks.py
+
 markdown_extensions:
   - tables
   - admonition
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
   - pymdownx.superfences:
       custom_fences:
         - name: mermaid


### PR DESCRIPTION
Promotes the MkDocs fenced-code / Pygments fix to `main` so the Docs workflow deploys an updated GitHub Pages site (`docs.yml` uploads artifacts on `main` pushes).

Includes PR #65 changes already merged to `develop`.

Made with [Cursor](https://cursor.com)