### PR TITLE
docs: recommend Homebrew install on README and docs site

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,20 @@ agent platform you use — Claude Code, Cursor, Codex, and friends.
 
 ## Install
 
+### Homebrew (recommended on Linux and macOS)
+
+If you use [Homebrew](https://brew.sh), install and upgrade with:
+
+```sh
+brew install jjfantini/humbl/humblskills
+```
+
+Formulas live in [`jjfantini/homebrew-humbl`](https://github.com/jjfantini/homebrew-humbl)
+and are bumped automatically by the release workflow. Upgrade with `brew upgrade humblskills`.
+
 ### Shell installer (Linux/macOS)
+
+For machines without Homebrew, or for scripted installs:
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/jjfantini/humblSKILLS/main/scripts/install.sh | sh
@@ -38,7 +51,8 @@ go install github.com/jjfantini/humblSKILLS/cli/cmd/humblskills@latest
 ### Direct download
 
 Grab the archive for your platform from the
-[releases page](https://github.com/jjfantini/humblSKILLS/releases/latest):
+[releases page](https://github.com/jjfantini/humblSKILLS/releases/latest)
+(including Windows):
 
 - `humblskills_<version>_linux_amd64.tar.gz`
 - `humblskills_<version>_linux_arm64.tar.gz`
@@ -48,15 +62,6 @@ Grab the archive for your platform from the
 - `humblskills_<version>_windows_arm64.zip`
 
 Each release also publishes `checksums.txt` with SHA-256 sums.
-
-### Homebrew (Linux/macOS)
-
-```sh
-brew install jjfantini/humbl/humblskills
-```
-
-Formulas live in [`jjfantini/homebrew-humbl`](https://github.com/jjfantini/homebrew-humbl)
-and are bumped automatically by the release workflow.
 
 ## Quickstart
 

--- a/docs/getting_started/index.md
+++ b/docs/getting_started/index.md
@@ -4,7 +4,7 @@ Use this section to install `humblskills` and run your first commands.
 
 | Page | What it covers |
 |------|----------------|
-| [Installation](installation.md) | Shell installer, `go install`, release archives, Homebrew |
+| [Installation](installation.md) | Homebrew (recommended), shell installer, `go install`, release archives |
 | [Quickstart](quickstart.md) | Core commands, `--json`, `--yes` |
 
 If you plan to run [eval](../eval/index.md), you will also configure runners and API keys as described there.

--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -1,6 +1,24 @@
 # Installation
 
+## Homebrew (recommended on Linux and macOS)
+
+If you use [Homebrew](https://brew.sh), this is the simplest way to install and upgrade `humblskills`:
+
+```sh
+brew install jjfantini/humbl/humblskills
+```
+
+Tap and formula live in [`jjfantini/homebrew-humbl`](https://github.com/jjfantini/homebrew-humbl); new releases bump the formula automatically.
+
+Upgrade later with:
+
+```sh
+brew upgrade humblskills
+```
+
 ## Shell installer (Linux/macOS)
+
+Use this when you do not use Homebrew, or for scripted installs (for example in CI):
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/jjfantini/humblSKILLS/main/scripts/install.sh | sh
@@ -26,7 +44,7 @@ go install github.com/jjfantini/humblSKILLS/cli/cmd/humblskills@latest
 
 ## Direct download
 
-Grab the archive for your platform from the [releases page](https://github.com/jjfantini/humblSKILLS/releases/latest):
+Grab the archive for your platform from the [releases page](https://github.com/jjfantini/humblSKILLS/releases/latest) (including **Windows** builds):
 
 - `humblskills_<version>_linux_amd64.tar.gz`
 - `humblskills_<version>_linux_arm64.tar.gz`
@@ -36,14 +54,6 @@ Grab the archive for your platform from the [releases page](https://github.com/j
 - `humblskills_<version>_windows_arm64.zip`
 
 Each release publishes `checksums.txt` with SHA-256 sums.
-
-## Homebrew (Linux/macOS)
-
-```sh
-brew install jjfantini/humbl/humblskills
-```
-
-Formulas live in [`jjfantini/homebrew-humbl`](https://github.com/jjfantini/homebrew-humbl) and are bumped by the release workflow.
 
 ## Verify
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,7 @@ humblSKILLS is a **skill registry** plus a single-binary Go CLI, **`humblskills`
 
 ## Next steps
 
-- [Installation](getting_started/installation.md) - shell, Go, releases, Homebrew
+- [Installation](getting_started/installation.md) - Homebrew (recommended), shell, Go, releases
 - [Quickstart](getting_started/quickstart.md) - `doctor`, `search`, `install`, `update`
 - [Eval](eval/index.md) - benchmark skills and inspect compound smart-skill runs
 - [Preserving user content](using_humblskills/preserving_user_content.md) - `preserve:` in `SKILL.md`


### PR DESCRIPTION
Promotes Homebrew as the recommended way to install `humblskills` on Linux and macOS; reorders README and [docs/getting_started/installation.md](docs/getting_started/installation.md); updates nav blurbs on the docs home and getting started index.

Shell installer, Go, and release archives remain documented as alternatives (including Windows via direct download).

Made with [Cursor](https://cursor.com)