### PR TITLE
fix(ci): release-please release PRs + dashboard quickstart

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,10 +3,14 @@ name: release
 # Single entry-point release pipeline.
 #
 # Automated path (push: main):
-#   release-please (skip-github-pull-request) evaluates conventional commits on
-#   main. When a release is due, it creates the `vX.Y.Z` tag and GitHub release
-#   in the same run, then this workflow continues into goreleaser - publishing
-#   binaries and updating the `jjfantini/homebrew-humbl` tap.
+#   release-please evaluates conventional commits on main. When a release is
+#   due, it opens a release PR (changelog + manifest bump). Merging that PR
+#   triggers another push to main; release-please then creates the `vX.Y.Z`
+#   tag and GitHub release, and this workflow continues into goreleaser -
+#   publishing binaries and updating the `jjfantini/homebrew-humbl` tap.
+#
+#   Do not set skip-github-pull-request: true with this layout - it breaks
+#   tagging/releases when using manifest + release PRs (see release-please#937).
 #
 # Manual backfill (workflow_dispatch):
 #   Re-run goreleaser against an existing tag. Skips release-please.

--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ Each release also publishes `checksums.txt` with SHA-256 sums.
 
 ## Quickstart
 
+In a terminal, run **`humblskills`** or **`humblskills start`** to open the
+interactive **dashboard** (tile grid with fuzzy search into every command).
+Use explicit subcommands below for scripts, CI, or non-TTY environments.
+
 ```sh
 humblskills doctor                    # verify the environment
 humblskills search                    # browse the registry

--- a/docs/getting_started/index.md
+++ b/docs/getting_started/index.md
@@ -5,6 +5,6 @@ Use this section to install `humblskills` and run your first commands.
 | Page | What it covers |
 |------|----------------|
 | [Installation](installation.md) | Homebrew (recommended), shell installer, `go install`, release archives |
-| [Quickstart](quickstart.md) | Core commands, `--json`, `--yes` |
+| [Quickstart](quickstart.md) | `humblskills start` / dashboard, core commands, `--json`, `--yes` |
 
 If you plan to run [eval](../eval/index.md), you will also configure runners and API keys as described there.

--- a/docs/getting_started/quickstart.md
+++ b/docs/getting_started/quickstart.md
@@ -1,5 +1,22 @@
 # Quickstart
 
+## Interactive dashboard (TUI)
+
+On a normal terminal, **`humblskills`** with no subcommand opens the same experience as **`humblskills start`**: a full-screen **dashboard** (tile grid with fuzzy search) that routes into install, list, update, search, uninstall, profile, eval, doctor, registry refresh, and version. Press **ESC** from a sub-screen to return to the grid.
+
+```sh
+humblskills          # TTY: open dashboard; non-TTY: print command summary
+humblskills start    # always explicit
+```
+
+Optional global flag:
+
+- **`--fullscreen`** - use full-screen TUI mode (also valid on `start`; requires a TTY).
+
+Non-interactive environments (pipes, CI, agents) do not get the TUI: the binary prints a short command summary instead. Use **`--json`**, **`--yes`**, and explicit subcommands (below) for scripts.
+
+## Core commands (CLI)
+
 ```sh
 humblskills doctor                    # verify the environment
 humblskills search                    # browse the registry

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@ humblSKILLS is a **skill registry** plus a single-binary Go CLI, **`humblskills`
 ## Next steps
 
 - [Installation](getting_started/installation.md) - Homebrew (recommended), shell, Go, releases
-- [Quickstart](getting_started/quickstart.md) - `doctor`, `search`, `install`, `update`
+- [Quickstart](getting_started/quickstart.md) - dashboard (`start`), `doctor`, `search`, `install`, `update`
 - [Eval](eval/index.md) - benchmark skills and inspect compound smart-skill runs
 - [Preserving user content](using_humblskills/preserving_user_content.md) - `preserve:` in `SKILL.md`
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "go",
-  "skip-github-pull-request": true,
+  "skip-github-pull-request": false,
   "include-component-in-tag": false,
   "packages": {
     ".": {


### PR DESCRIPTION
## Release flow

`skip-github-pull-request: true` in `release-please-config.json` breaks the standard manifest workflow: the bot can still open a release PR (e.g. [#64](https://github.com/jjfantini/humblSKILLS/pull/64)), but tagging/GitHub releases do not complete as intended when that flag is true ([release-please-action#937](https://github.com/googleapis/release-please-action/issues/937)).

This PR sets it to `false` and documents the intended flow in `.github/workflows/release.yml`.

**After this merges:** merge the open **Release 2.5.0** PR when you are ready (or let release-please refresh it on the next `main` push). The follow-up push from that merge should create `v2.5.0` and run GoReleaser.

## Docs

- Quickstart: `humblskills` / `humblskills start`, dashboard behavior, `--fullscreen`, non-TTY fallback.
- README + docs home/getting-started index blurbs.

Made with [Cursor](https://cursor.com)