### PR TITLE
feat(docs): agent-facing SKILL.md URL on GitHub Pages

### DIFF
--- a/docs/getting_started/index.md
+++ b/docs/getting_started/index.md
@@ -6,5 +6,6 @@ Use this section to install `humblskills` and run your first commands.
 |------|----------------|
 | [Installation](installation.md) | Homebrew (recommended), shell installer, `go install`, release archives |
 | [Quickstart](quickstart.md) | `humblskills start` / dashboard, core commands, `--json`, `--yes` |
+| [Agent install SKILL (raw Markdown)](https://jjfantini.github.io/humblSKILLS/getting_started/installation/SKILL.md) | Same install and CLI guidance as plain `SKILL.md` for tools and agents |
 
 If you plan to run [eval](../eval/index.md), you will also configure runners and API keys as described there.

--- a/docs/getting_started/installation-agent/SKILL.md
+++ b/docs/getting_started/installation-agent/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: humblskills-cli
+description: Install the humblskills CLI on Linux, macOS, or Windows, then use registry, install, and non-interactive flags in scripts and agents.
+compatibility: Requires a supported platform build (see releases). Shell installer targets Unix-like systems; Windows uses release archives.
+---
+
+# humblskills CLI (install and use)
+
+Use this skill when the user needs **humblskills** on their machine, in CI, or when an agent must run **`humblskills` with `--json` / `--yes`** instead of the TUI.
+
+Canonical human docs (HTML): [Installation](https://jjfantini.github.io/humblSKILLS/getting_started/installation/) and [Quickstart](https://jjfantini.github.io/humblSKILLS/getting_started/quickstart/).
+
+## Install
+
+### Homebrew (recommended on Linux and macOS)
+
+```sh
+brew install jjfantini/humbl/humblskills
+brew upgrade humblskills
+```
+
+Tap: [jjfantini/homebrew-humbl](https://github.com/jjfantini/homebrew-humbl).
+
+### Shell installer (Linux and macOS)
+
+For scripted installs or when not using Homebrew:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/jjfantini/humblSKILLS/main/scripts/install.sh | sh
+```
+
+Optional:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/jjfantini/humblSKILLS/main/scripts/install.sh | INSTALL_DIR=$HOME/.local/bin sh
+curl -fsSL https://raw.githubusercontent.com/jjfantini/humblSKILLS/main/scripts/install.sh | VERSION=0.1.0 sh
+```
+
+### Go
+
+```sh
+go install github.com/jjfantini/humblSKILLS/cli/cmd/humblskills@latest
+```
+
+### Direct download (including Windows)
+
+Download the archive for your OS and architecture from [GitHub releases](https://github.com/jjfantini/humblSKILLS/releases/latest). Artifacts follow the pattern `humblskills_<version>_<os>_<arch>.<tar.gz|zip>`. Verify with `checksums.txt` in the release.
+
+### Verify
+
+```sh
+humblskills doctor
+```
+
+## CLI behavior
+
+- **Interactive TTY:** `humblskills` or `humblskills start` opens the dashboard. Use **`--fullscreen`** for full-screen TUI when supported.
+- **Non-interactive (CI, pipes, agents):** no TUI; the binary prints a short summary. Use explicit subcommands plus **`--json`** and **`--yes`**.
+
+### Core commands
+
+```sh
+humblskills doctor
+humblskills search
+humblskills install use-smart-skill
+humblskills list
+humblskills update
+humblskills update --all --yes
+humblskills uninstall use-smart-skill
+```
+
+Every command accepts **`--json`** (machine-readable output) and **`--yes`** (skip prompts).
+
+## Deeper topics
+
+- [Registry and skill format](https://jjfantini.github.io/humblSKILLS/using_humblskills/registry_and_format/)
+- [Preserving user content](https://jjfantini.github.io/humblSKILLS/using_humblskills/preserving_user_content/)
+- [Eval quickstart](https://jjfantini.github.io/humblSKILLS/eval/quickstart/)

--- a/docs/mkdocs_hooks.py
+++ b/docs/mkdocs_hooks.py
@@ -2,7 +2,12 @@
 
 from __future__ import annotations
 
+import shutil
+from pathlib import Path
 from typing import Any
+
+_AGENT_SKILL_SRC = Path("getting_started") / "installation-agent" / "SKILL.md"
+_AGENT_SKILL_DEST = Path("getting_started") / "installation" / "SKILL.md"
 
 
 def on_config(config: Any, **kwargs: Any) -> Any:
@@ -10,3 +15,14 @@ def on_config(config: Any, **kwargs: Any) -> Any:
         ext for ext in config["markdown_extensions"] if ext != "fenced_code"
     ]
     return config
+
+
+def on_post_build(config: Any, **kwargs: Any) -> None:
+    docs_dir = Path(config["docs_dir"])
+    site_dir = Path(config["site_dir"])
+    src = docs_dir / _AGENT_SKILL_SRC
+    if not src.is_file():
+        raise FileNotFoundError(f"Agent SKILL source missing: {src}")
+    dest = site_dir / _AGENT_SKILL_DEST
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(src, dest)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,6 +9,7 @@ site_author: Jennings Fantini
 
 exclude_docs: |
   requirements.txt
+  getting_started/installation-agent/SKILL.md
 
 watch:
   - docs/


### PR DESCRIPTION
Adds a raw Markdown SKILL for agents at `getting_started/installation/SKILL.md` on Pages (built via mkdocs hook). Includes install + CLI sections and a link from the getting started index.

Note: branch is `agent-install-skill` because Git cannot create `develop/agent-install-skill` while a branch named `develop` exists.

Made with [Cursor](https://cursor.com)