### PR TITLE
docs: recommend agent prompt for install

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,15 @@ agent platform you use — Claude Code, Cursor, Codex, and friends.
 
 ## Install
 
-### Homebrew (recommended on Linux and macOS)
+**Recommended:** send this to your agent so it loads the published install + CLI
+`SKILL.md` and walks through setup on your machine (works from any OS the docs
+cover):
+
+```text
+Read https://jjfantini.github.io/humblSKILLS/getting_started/installation/SKILL.md and install humblskills on this machine following those instructions. When finished, run humblskills doctor and fix anything it reports until it passes.
+```
+
+### Homebrew (Linux and macOS)
 
 If you use [Homebrew](https://brew.sh), install and upgrade with:
 

--- a/docs/getting_started/index.md
+++ b/docs/getting_started/index.md
@@ -4,8 +4,8 @@ Use this section to install `humblskills` and run your first commands.
 
 | Page | What it covers |
 |------|----------------|
-| [Installation](installation.md) | Homebrew (recommended), shell installer, `go install`, release archives |
+| [Installation](installation.md) | **Recommended:** agent prompt + raw `SKILL.md`; Homebrew, shell installer, `go install`, release archives |
 | [Quickstart](quickstart.md) | `humblskills start` / dashboard, core commands, `--json`, `--yes` |
-| [Agent install SKILL (raw Markdown)](https://jjfantini.github.io/humblSKILLS/getting_started/installation/SKILL.md) | Same install and CLI guidance as plain `SKILL.md` for tools and agents |
+| [Agent install SKILL (raw Markdown)](https://jjfantini.github.io/humblSKILLS/getting_started/installation/SKILL.md) | Same content as the install `SKILL.md` for fetch-by-URL tools (no HTML) |
 
 If you plan to run [eval](../eval/index.md), you will also configure runners and API keys as described there.

--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -1,8 +1,16 @@
 # Installation
 
-## Homebrew (recommended on Linux and macOS)
+## Using an AI agent (recommended)
 
-If you use [Homebrew](https://brew.sh), this is the simplest way to install and upgrade `humblskills`:
+Paste this into your coding agent (Claude Code, Cursor, Codex, or similar). It loads the published install + CLI [`SKILL.md`](https://jjfantini.github.io/humblSKILLS/getting_started/installation/SKILL.md) so the model can follow OS-specific steps and verify the binary.
+
+```text
+Read https://jjfantini.github.io/humblSKILLS/getting_started/installation/SKILL.md and install humblskills on this machine following those instructions. When finished, run humblskills doctor and fix anything it reports until it passes.
+```
+
+## Homebrew (Linux and macOS)
+
+If you use [Homebrew](https://brew.sh), this is the simplest way to install and upgrade `humblskills` yourself in a terminal:
 
 ```sh
 brew install jjfantini/humbl/humblskills

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,7 @@ humblSKILLS is a **skill registry** plus a single-binary Go CLI, **`humblskills`
 
 ## Next steps
 
-- [Installation](getting_started/installation.md) - Homebrew (recommended), shell, Go, releases
+- [Installation](getting_started/installation.md) - **Recommended:** agent prompt + raw `SKILL.md`; Homebrew, shell, Go, releases
 - [Quickstart](getting_started/quickstart.md) - dashboard (`start`), `doctor`, `search`, `install`, `update`
 - [Eval](eval/index.md) - benchmark skills and inspect compound smart-skill runs
 - [Preserving user content](using_humblskills/preserving_user_content.md) - `preserve:` in `SKILL.md`


### PR DESCRIPTION
Adds the same recommended install prompt to the docs (Installation page, getting started index, site index) and keeps README aligned. Homebrew section clarified as direct terminal install.

Made with [Cursor](https://cursor.com)