### PR TITLE
docs: metadata.preserve frontmatter examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,8 +171,8 @@ Smart skills often accumulate user-owned content over time - raw sources,
 append-only memory (`log.md`, `decisions.md`, `patterns.md`), LLM-curated
 wiki pages. By default `humblskills update` and `humblskills install`
 overwrite the skill directory with whatever the registry ships. Skills that
-need to keep user content around on update declare a `preserve:` list in
-their SKILL.md frontmatter.
+need to keep user content around on update declare a preserve list under
+`metadata:` in their `SKILL.md` frontmatter.
 
 Entries are relative paths inside the skill directory. A trailing `/` makes
 the entry a directory; anything else is a file. Globs are not supported.
@@ -190,13 +190,14 @@ everything, including preserved content.
 ---
 name: my-smart-skill
 description: ...
-version: 0.2.0
-preserve:
-  - references/log.md
-  - references/patterns.md
-  - references/decisions.md
-  - references/raw/
-  - references/wiki/
+metadata:
+  version: 0.2.0
+  preserve:
+    - references/log.md
+    - references/patterns.md
+    - references/decisions.md
+    - references/raw/
+    - references/wiki/
 ---
 ```
 
@@ -206,10 +207,11 @@ update - that's the deep-merge contract.
 
 ### You own the preserve list after install
 
-The `preserve:` list in the registry is the **seed** - what ships on first
-install. After that, the list belongs to you. `humblskills update` reads
-`preserve:` from the **installed** `SKILL.md` on disk (per target, so each
-platform + scope is independent), not from the upstream registry entry.
+The preserve list under **`metadata.preserve`** in the registry is the **seed**
+- what ships on first install. After that, the list belongs to you.
+`humblskills update` reads **`metadata.preserve`** from the **installed**
+`SKILL.md` on disk (per target, so each platform + scope is independent), not
+from the upstream registry entry.
 
 That means:
 
@@ -217,26 +219,27 @@ That means:
   even if upstream never listed it.
 - Remove an entry locally -> that path gets overwritten by upstream bytes on
   the next update.
-- Empty your `preserve:` list -> the update is a clean overwrite for every
+- Empty **`metadata.preserve`** -> the update is a clean overwrite for every
   path.
 
 Use this to pin author-shipped files in place, protect notes you stash
 inside the skill directory, or stop preserving a directory the author
 reorganized.
 
-Only the `preserve:` key is treated as user-owned. Every other frontmatter
-field (`name`, `description`, `version`, `requires`, `platforms`, `tags`)
-and the full markdown body flow through from upstream on every update. So
-when the author ships a new description, version bump, or prose rewrite,
-you get it; your `preserve:` list rides along untouched. This also means
-your preserve edits survive indefinitely - you don't need to re-edit after
-each update, because the rewritten `SKILL.md` carries your list forward.
+Only **`metadata.preserve`** is treated as user-owned. Top-level agent-skills
+fields (`name`, `description`, and the rest), every other key under
+`metadata:` (`version`, `requires`, `platforms`, `tags`, and so on), and the
+full markdown body flow through from upstream on every update. So when the
+author ships a new description, version bump, or prose rewrite, you get it;
+your preserve list rides along untouched. This also means your preserve edits
+survive indefinitely - you don't need to re-edit after each update, because the
+rewritten `SKILL.md` carries your list forward.
 
 A few nuances:
 
 - If you'd rather freeze the entire `SKILL.md` (maybe you've made prose
-  edits you don't want overwritten), add `SKILL.md` itself to your
-  `preserve:` list. That makes user-wins on the file, so upstream changes
+  edits you don't want overwritten), add `SKILL.md` itself to
+  **`metadata.preserve`**. That makes user-wins on the file, so upstream changes
   to the description/version/body stop flowing - opt-in only.
 - If the installed `SKILL.md` is missing, unparseable, or carries an
   invalid preserve list (e.g. a `..` traversal), the engine falls back to

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ humblSKILLS is a **skill registry** plus a single-binary Go CLI, **`humblskills`
 
 ## What you get
 
-1. **Skill registry** - A monorepo of skills in the agentskills.io shape, with small humblSKILLS extensions in `SKILL.md` frontmatter: `requires`, `platforms`, `tags`, `preserve`.
+1. **Skill registry** - A monorepo of skills in the agentskills.io shape, with humblSKILLS extensions under `metadata:` in `SKILL.md` (`requires`, `platforms`, `tags`, `preserve`, `version`, and similar).
 2. **`humblskills` CLI** - Pulls a skill directory from the registry and installs it in the right place for your platform. No hosted account, no telemetry.
 
 ## Next steps
@@ -12,6 +12,6 @@ humblSKILLS is a **skill registry** plus a single-binary Go CLI, **`humblskills`
 - [Installation](getting_started/installation.md) - **Recommended:** agent prompt + raw `SKILL.md`; Homebrew, shell, Go, releases
 - [Quickstart](getting_started/quickstart.md) - dashboard (`start`), `doctor`, `search`, `install`, `update`
 - [Eval](eval/index.md) - benchmark skills and inspect compound smart-skill runs
-- [Preserving user content](using_humblskills/preserving_user_content.md) - `preserve:` in `SKILL.md`
+- [Preserving user content](using_humblskills/preserving_user_content.md) - `metadata.preserve` in `SKILL.md`
 
 Documentation is hosted on [GitHub Pages](https://jjfantini.github.io/humblSKILLS/); the live site is **published from `main`** so it stays aligned with released, installable `humblskills` builds. Source lives in the [humblSKILLS repo](https://github.com/jjfantini/humblSKILLS).

--- a/docs/using_humblskills/preserving_user_content.md
+++ b/docs/using_humblskills/preserving_user_content.md
@@ -2,7 +2,7 @@
 
 Smart skills often accumulate user-owned content: raw sources, append-only memory (`log.md`, `decisions.md`, `patterns.md`), wiki pages, and so on. By default, `humblskills update` and `humblskills install` **overwrite** the skill directory with what the registry ships.
 
-Skills that must keep user content across updates declare a **`preserve:`** list in `SKILL.md` frontmatter.
+Skills that must keep user content across updates declare a **`preserve`** list under **`metadata:`** in `SKILL.md` frontmatter (see [Registry & skill format](registry_and_format.md)).
 
 ## Rules
 
@@ -21,13 +21,14 @@ Fresh installs always seed everything from the registry. `preserve` applies when
 ---
 name: my-smart-skill
 description: ...
-version: 0.2.0
-preserve:
-  - references/log.md
-  - references/patterns.md
-  - references/decisions.md
-  - references/raw/
-  - references/wiki/
+metadata:
+  version: 0.2.0
+  preserve:
+    - references/log.md
+    - references/patterns.md
+    - references/decisions.md
+    - references/raw/
+    - references/wiki/
 ---
 ```
 
@@ -35,17 +36,17 @@ Authors who ship a **preserve directory** should document that files the author 
 
 ## You own the preserve list after install
 
-The registry’s `preserve:` list is the **seed** on first install. After that, **`humblskills update` reads `preserve:` from the installed `SKILL.md` on disk** (per platform and scope), not from upstream.
+The registry’s preserve list under **`metadata.preserve`** is the **seed** on first install. After that, **`humblskills update` reads that list from the installed `SKILL.md` on disk** (per platform and scope), not from upstream.
 
 - Add an entry locally → that path survives the next update, even if upstream did not list it.
 - Remove an entry locally → that path is overwritten from upstream on the next update.
-- Clear `preserve:` → the next update does a full overwrite for paths that are not listed.
+- Clear **`metadata.preserve`** → the next update does a full overwrite for paths that are not listed.
 
-Only **`preserve:`** is treated as user-owned. Other frontmatter (`name`, `description`, `version`, `requires`, `platforms`, `tags`) and the markdown body are refreshed from upstream on update, while your `preserve:` list is carried forward.
+Only **`metadata.preserve`** is treated as user-owned. Top-level agent-skills fields (`name`, `description`, `license`, `compatibility`, `allowed-tools`, and similar), every other key under **`metadata:`** (`version`, `requires`, `platforms`, `tags`, and so on), and the markdown body are refreshed from upstream on update, while your preserve list is carried forward.
 
 ### Freeze all of `SKILL.md`
 
-To stop upstream from changing description, version, or body, add **`SKILL.md`** itself to `preserve:`. That is opt-in and stops those upstream updates until you remove it.
+To stop upstream from changing description, version, or body, add **`SKILL.md`** itself to **`metadata.preserve`**. That is opt-in and stops those upstream updates until you remove it.
 
 ### Broken or missing frontmatter
 

--- a/docs/using_humblskills/registry_and_format.md
+++ b/docs/using_humblskills/registry_and_format.md
@@ -4,16 +4,17 @@ Skills in this registry follow the [agentskills.io](https://agentskills.io) form
 
 ## humblSKILLS frontmatter extensions
 
-Authors may include extra keys in YAML frontmatter:
+humblSKILLS-specific keys live under the optional **`metadata:`** map so the top level stays aligned with [agentskills.io](https://agentskills.io) (`name`, `description`, and other spec fields only).
 
-| Key | Purpose |
-|-----|---------|
+| Key under `metadata:` | Purpose |
+|-------------------------|---------|
 | `requires` | Dependencies or constraints (as defined by the skill) |
 | `platforms` | Which agent platforms the skill targets |
 | `tags` | Discovery / grouping |
+| `version` | Skill package version (semver) |
 | `preserve` | Paths to keep on `update` when replacing an installed skill (see [Preserving user content](preserving_user_content.md)) |
 
-Other frontmatter fields (for example `name`, `description`, `version`) follow the normal agentskills.io expectations.
+Other top-level frontmatter follows the normal agentskills.io expectations.
 
 ## Where skills live in the repo
 


### PR DESCRIPTION
Updates preserving user content, registry format, docs index, and README so humblSKILLS fields (version, preserve, etc.) appear under `metadata:`, matching agentskills.io top-level shape and the CLI merge behavior.

Made with [Cursor](https://cursor.com)