### PR TITLE
docs: add pointer to GitHub Pages site at top of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # humblSKILLS
 
+📖 **Full documentation:** [jjfantini.github.io/humblSKILLS](https://jjfantini.github.io/humblSKILLS/)
+
 A personal skill registry and a single-binary Go CLI (`humblskills`) that
 installs [agentskills.io](https://agentskills.io)-format skills into whichever
 agent platform you use — Claude Code, Cursor, Codex, and friends.


### PR DESCRIPTION
## Summary
- Add a prominent link to the published docs site (https://jjfantini.github.io/humblSKILLS/) at the top of the README so visitors can jump straight to the full documentation.

## Test plan
- [x] README renders with the new link above the intro paragraph

🤖 Generated with [Claude Code](https://claude.com/claude-code)