### PR TITLE
ci: use PAT for release-please so release PRs trigger CI + auto-merge

### DIFF
--- a/.github/workflows/release-auto-merge.yml
+++ b/.github/workflows/release-auto-merge.yml
@@ -9,7 +9,10 @@
 #     relax reviews for maintainers). Required *status checks* alone work well.
 #
 # This only targets branches created by release-please (head ref contains
-# release-please--) and PRs authored by github-actions[bot].
+# release-please--). The branch prefix is unique to release-please, so we don't
+# additionally pin on PR author — release-please switched to a PAT-authored
+# identity to escape the GITHUB_TOKEN workflow-trigger suppression, so pinning
+# to github-actions[bot] would lock this workflow out.
 
 name: Auto-merge release-please PR
 
@@ -30,7 +33,6 @@ jobs:
     if: |
       github.base_ref == 'main' &&
       contains(github.head_ref, 'release-please--') &&
-      github.event.pull_request.user.login == 'github-actions[bot]' &&
       github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,12 @@ jobs:
   release_please:
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
+    # The `release` environment scopes RELEASE_PLEASE_TOKEN (a PAT). Using a
+    # PAT instead of GITHUB_TOKEN means the release PR is authored by a human
+    # account, so it escapes GitHub's rule that PRs opened via GITHUB_TOKEN
+    # don't trigger downstream `pull_request` workflows (CI, auto-merge). The
+    # environment has no protection rules, so this is pure secret scoping.
+    environment: release
     outputs:
       release_created: ${{ steps.rp.outputs.release_created }}
       tag_name: ${{ steps.rp.outputs.tag_name }}
@@ -45,6 +51,7 @@ jobs:
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
 
   goreleaser:
     needs: release_please


### PR DESCRIPTION
## Summary
- Pass a PAT (`RELEASE_PLEASE_TOKEN`, scoped via the existing `release` environment) to `release-please-action` so the release PR isn't authored by `GITHUB_TOKEN`. PRs opened with `GITHUB_TOKEN` don't trigger `pull_request` workflows, which is why PR #75 had no CI run, no Registry check, and a gated `action_required` auto-merge run.
- Drop the `github-actions[bot]` author pin in `release-auto-merge.yml` — the PR author changes with the PAT, and the `release-please--` head-ref prefix is already unique to release-please.

## Prerequisite
Create a fine-grained PAT scoped to this repo with **Contents: Read & write** and **Pull requests: Read & write**, store it as `RELEASE_PLEASE_TOKEN` under Settings → Environments → `release`. The `release` environment has no protection rules, so this is pure secret scoping.

## Test plan
- [ ] Merge this PR.
- [ ] On the next qualifying commit to `main`, confirm the new release PR runs CI (test matrix + build), registry-check (if applicable), and `enable-auto-merge` — all three should appear in the PR's checks list instead of only GitGuardian.
- [ ] Confirm `gh pr view <n> --json autoMergeRequest` returns a non-null request after the auto-merge workflow runs.
- [ ] Confirm the PR merges on its own once CI passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)