### PR TITLE
feat(test): regression safety net for upcoming CLI refactor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,15 @@ jobs:
         run: go vet ./...
         working-directory: cli
       - name: go test (race, coverage)
+        # -race requires a C toolchain the Windows runner doesn't ship
+        # with. Skip race mode on Windows; the ubuntu/macos jobs still
+        # exercise it and coverage travels with them.
+        if: matrix.os != 'windows-latest'
         run: go test -race -count=1 -coverprofile=coverage.out ./...
+        working-directory: cli
+      - name: go test (windows)
+        if: matrix.os == 'windows-latest'
+        run: go test -count=1 ./...
         working-directory: cli
       - name: upload coverage
         if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,42 @@ jobs:
       - name: go vet
         run: go vet ./...
         working-directory: cli
-      - name: go test
-        run: go test ./...
+      - name: go test (race, coverage)
+        run: go test -race -count=1 -coverprofile=coverage.out ./...
         working-directory: cli
+      - name: upload coverage
+        if: matrix.os == 'ubuntu-latest'
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: cli/coverage.out
+
+  fuzz:
+    # Short (10s per target) fuzz pass surfaces panics without blowing
+    # up CI time. Dedicated overnight fuzzing lives elsewhere.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.23"
+          cache-dependency-path: cli/go.sum
+      - name: Run fuzz targets (short)
+        working-directory: cli
+        run: |
+          set -e
+          for target in \
+            "internal/frontmatter FuzzParse" \
+            "internal/frontmatter FuzzParseDep" \
+            "internal/env FuzzParseDotEnv" \
+            "internal/adapters FuzzExpandPath" \
+            "internal/resolver FuzzTopoSort"; do
+            pkg=$(echo "$target" | cut -d' ' -f1)
+            name=$(echo "$target" | cut -d' ' -f2)
+            echo "::group::fuzz $pkg/$name"
+            go test ./$pkg/ -run='^$' -fuzz="^$name$" -fuzztime=10s
+            echo "::endgroup::"
+          done
 
   registry-check:
     runs-on: ubuntu-latest

--- a/cli/cmd/build-registry/main_test.go
+++ b/cli/cmd/build-registry/main_test.go
@@ -1,0 +1,261 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jjfantini/humblSKILLS/cli/internal/registry"
+)
+
+// validSkillMD is a minimal SKILL.md that satisfies frontmatter.Validate.
+func validSkillMD(name, version string) string {
+	return "---\n" +
+		"name: " + name + "\n" +
+		"description: " + name + " description line long enough\n" +
+		"version: " + version + "\n" +
+		"---\n\n# " + name + "\n\nBody.\n"
+}
+
+func writeSkill(t *testing.T, skillsDir, name, version string) {
+	t.Helper()
+	d := filepath.Join(skillsDir, name)
+	if err := os.MkdirAll(d, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(d, "SKILL.md"), []byte(validSkillMD(name, version)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRun_BuildsRegistryForValidSkills(t *testing.T) {
+	root := t.TempDir()
+	skillsDir := filepath.Join(root, "skills")
+	writeSkill(t, skillsDir, "alpha", "1.0.0")
+	writeSkill(t, skillsDir, "beta", "0.9.0")
+
+	out := filepath.Join(root, "registry.json")
+	if err := run(skillsDir, out, "github.com/x/y", "main", "deadbeef", false); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	data, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	var reg registry.Registry
+	if err := json.Unmarshal(data, &reg); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if reg.SchemaVersion != registry.SchemaVersion {
+		t.Errorf("schema = %d", reg.SchemaVersion)
+	}
+	if len(reg.Skills) != 2 {
+		t.Errorf("skills = %d", len(reg.Skills))
+	}
+	// Sorted by name: alpha before beta.
+	if reg.Skills[0].Name != "alpha" || reg.Skills[1].Name != "beta" {
+		t.Errorf("not sorted: %v", []string{reg.Skills[0].Name, reg.Skills[1].Name})
+	}
+	// DirSHA must be set for each skill.
+	for _, s := range reg.Skills {
+		if s.DirSHA == "" {
+			t.Errorf("%s: empty DirSHA", s.Name)
+		}
+	}
+}
+
+func TestRun_DuplicateSkillName(t *testing.T) {
+	root := t.TempDir()
+	skillsDir := filepath.Join(root, "skills")
+	writeSkill(t, skillsDir, "one", "1.0.0")
+	// Second skill directory claims same name in its frontmatter.
+	dir2 := filepath.Join(skillsDir, "other-dir")
+	if err := os.MkdirAll(dir2, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir2, "SKILL.md"), []byte(validSkillMD("one", "2.0.0")), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := run(skillsDir, filepath.Join(root, "registry.json"), "r", "main", "sha", false)
+	if err == nil {
+		t.Fatal("expected duplicate name error")
+	}
+	if !strings.Contains(err.Error(), "duplicate skill name") {
+		t.Errorf("err = %v", err)
+	}
+}
+
+func TestRun_EmptySkillsDir(t *testing.T) {
+	root := t.TempDir()
+	skillsDir := filepath.Join(root, "skills")
+	if err := os.MkdirAll(skillsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	err := run(skillsDir, filepath.Join(root, "registry.json"), "r", "main", "sha", false)
+	if err == nil {
+		t.Fatal("expected 'no skills found' error")
+	}
+}
+
+func TestRun_CheckMode_NoDriftIsClean(t *testing.T) {
+	root := t.TempDir()
+	skillsDir := filepath.Join(root, "skills")
+	writeSkill(t, skillsDir, "alpha", "1.0.0")
+
+	out := filepath.Join(root, "registry.json")
+	if err := run(skillsDir, out, "r", "main", "sha", false); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	// Same inputs → --check should pass.
+	if err := run(skillsDir, out, "r", "main", "sha", true); err != nil {
+		t.Errorf("--check false positive: %v", err)
+	}
+}
+
+func TestRun_CheckMode_DriftFailsLoudly(t *testing.T) {
+	root := t.TempDir()
+	skillsDir := filepath.Join(root, "skills")
+	writeSkill(t, skillsDir, "alpha", "1.0.0")
+
+	out := filepath.Join(root, "registry.json")
+	if err := run(skillsDir, out, "r", "main", "sha", false); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	// Mutate a skill so registry should drift.
+	writeSkill(t, skillsDir, "alpha", "2.0.0")
+
+	err := run(skillsDir, out, "r", "main", "sha", true)
+	if err == nil {
+		t.Fatal("expected drift error in --check mode")
+	}
+	if !strings.Contains(err.Error(), "out of date") {
+		t.Errorf("err = %v", err)
+	}
+}
+
+func TestRun_IgnoresNonSkillDirs(t *testing.T) {
+	root := t.TempDir()
+	skillsDir := filepath.Join(root, "skills")
+	writeSkill(t, skillsDir, "good", "1.0.0")
+	// Hidden dir gets ignored.
+	_ = os.MkdirAll(filepath.Join(skillsDir, ".hidden"), 0o755)
+	// Non-directory entry gets ignored.
+	_ = os.WriteFile(filepath.Join(skillsDir, "README.md"), []byte("x"), 0o644)
+	// Dir without SKILL.md gets silently skipped.
+	_ = os.MkdirAll(filepath.Join(skillsDir, "incomplete"), 0o755)
+
+	out := filepath.Join(root, "registry.json")
+	if err := run(skillsDir, out, "r", "main", "sha", false); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	data, _ := os.ReadFile(out)
+	var reg registry.Registry
+	_ = json.Unmarshal(data, &reg)
+	if len(reg.Skills) != 1 || reg.Skills[0].Name != "good" {
+		t.Errorf("skills = %+v", reg.Skills)
+	}
+}
+
+func TestRun_CycleIsRejected(t *testing.T) {
+	root := t.TempDir()
+	skillsDir := filepath.Join(root, "skills")
+	// a → b → a (cycle)
+	for _, x := range [][2]string{{"a", "b"}, {"b", "a"}} {
+		name, dep := x[0], x[1]
+		body := "---\n" +
+			"name: " + name + "\n" +
+			"description: cycle test skill body long enough\n" +
+			"version: 1.0.0\n" +
+			"metadata:\n" +
+			"  requires:\n" +
+			"    - " + dep + "@1.0.0\n" +
+			"---\n# " + name + "\nBody.\n"
+		d := filepath.Join(skillsDir, name)
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(d, "SKILL.md"), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	err := run(skillsDir, filepath.Join(root, "registry.json"), "r", "main", "sha", false)
+	if err == nil {
+		t.Fatal("expected cycle error")
+	}
+}
+
+func TestRun_DirSHADeterministicAcrossRuns(t *testing.T) {
+	root := t.TempDir()
+	skillsDir := filepath.Join(root, "skills")
+	writeSkill(t, skillsDir, "alpha", "1.0.0")
+
+	out1 := filepath.Join(root, "reg1.json")
+	out2 := filepath.Join(root, "reg2.json")
+	if err := run(skillsDir, out1, "r", "main", "sha", false); err != nil {
+		t.Fatal(err)
+	}
+	if err := run(skillsDir, out2, "r", "main", "sha", false); err != nil {
+		t.Fatal(err)
+	}
+
+	var r1, r2 registry.Registry
+	d1, _ := os.ReadFile(out1)
+	d2, _ := os.ReadFile(out2)
+	_ = json.Unmarshal(d1, &r1)
+	_ = json.Unmarshal(d2, &r2)
+	if r1.Skills[0].DirSHA != r2.Skills[0].DirSHA {
+		t.Errorf("DirSHA non-deterministic: %s vs %s", r1.Skills[0].DirSHA, r2.Skills[0].DirSHA)
+	}
+}
+
+func TestMarshalStable_NoHTMLEscape(t *testing.T) {
+	reg := registry.Registry{
+		SchemaVersion: registry.SchemaVersion,
+		Skills: []registry.Skill{
+			{Name: "a", Description: "uses > and <", Version: "1.0.0"},
+		},
+	}
+	data, err := marshalStable(reg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(data), `\u003c`) || strings.Contains(string(data), `\u003e`) {
+		t.Errorf("HTML escape leaked: %s", data)
+	}
+}
+
+func TestFirstNonEmpty(t *testing.T) {
+	if got := firstNonEmpty("", "b"); got != "b" {
+		t.Errorf("got %q", got)
+	}
+	if got := firstNonEmpty(); got != "" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestSemanticDiff_IgnoresSourceAndGeneratedAt(t *testing.T) {
+	a := []byte(`{"schema_version":1,"generated_at":"t1","source":{"repo":"x","ref":"main","sha":"a"},"skills":[]}`)
+	b := []byte(`{"schema_version":1,"generated_at":"t2","source":{"repo":"x","ref":"main","sha":"b"},"skills":[]}`)
+	diff, err := semanticDiff(a, b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if diff {
+		t.Error("semantic diff should ignore generated_at / source")
+	}
+}
+
+func TestSemanticDiff_DetectsSkillChange(t *testing.T) {
+	a := []byte(`{"schema_version":1,"skills":[{"name":"x","version":"1.0.0"}]}`)
+	b := []byte(`{"schema_version":1,"skills":[{"name":"x","version":"2.0.0"}]}`)
+	diff, err := semanticDiff(a, b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !diff {
+		t.Error("expected diff detected")
+	}
+}

--- a/cli/cmd/humblskills/cli_testutil_helpers_test.go
+++ b/cli/cmd/humblskills/cli_testutil_helpers_test.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"encoding/json"
+
+	"github.com/jjfantini/humblSKILLS/cli/internal/registry"
+)
+
+// registryToJSON is in its own file so cli_testutil_test.go stays
+// free of encoding/json (readability).
+func registryToJSON(r *registry.Registry) ([]byte, error) {
+	return json.MarshalIndent(r, "", "  ")
+}

--- a/cli/cmd/humblskills/cli_testutil_test.go
+++ b/cli/cmd/humblskills/cli_testutil_test.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jjfantini/humblSKILLS/cli/internal/registry"
+	"github.com/jjfantini/humblSKILLS/cli/internal/testutil"
+)
+
+// execResult captures stdout/stderr and the error Cobra surfaced.
+type execResult struct {
+	Out string
+	Err string
+	// RunErr is what RunE returned; non-nil doesn't mean process exit
+	// since main wraps with os.Exit — tests assert on RunErr directly.
+	RunErr error
+}
+
+// runCLI builds the root command tree and executes it with args.
+// Writers are captured so tests can assert on output.
+//
+// Critical: root installs a PersistentPreRunE that reads env / XDG
+// paths. Callers should place runCLI inside a testutil.NewSandbox so
+// those resolve to sandboxed locations.
+func runCLI(t *testing.T, args ...string) execResult {
+	t.Helper()
+	root := newRootCmd()
+
+	outBuf := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	root.SetOut(outBuf)
+	root.SetErr(errBuf)
+	root.SetArgs(args)
+
+	res := execResult{RunErr: root.Execute()}
+
+	// PersistentPreRunE constructs app.UI pointing at os.Stdout/os.Stderr
+	// regardless of SetOut. To capture command output we would need to
+	// inject an app-level writer. For now we capture what Cobra's own
+	// writers receive (error/usage paths); per-command assertions use
+	// the app-level --json flag where possible since JSON output goes
+	// through app.UI.JSON which respects the injected writer via
+	// runCLIWithStdoutCapture below.
+	res.Out = outBuf.String()
+	res.Err = errBuf.String()
+	return res
+}
+
+// runCLIWithStdoutCapture redirects os.Stdout/os.Stderr for the
+// duration of Execute so commands that print via fmt.Fprintln(app.UI.Out())
+// can be asserted against. Slightly heavier than runCLI — prefer
+// this when you need full stdout.
+func runCLIWithStdoutCapture(t *testing.T, args ...string) execResult {
+	t.Helper()
+
+	// Pipe for stdout / stderr.
+	stdoutR, stdoutW, _ := os.Pipe()
+	stderrR, stderrW, _ := os.Pipe()
+	origStdout := os.Stdout
+	origStderr := os.Stderr
+	os.Stdout = stdoutW
+	os.Stderr = stderrW
+	defer func() {
+		os.Stdout = origStdout
+		os.Stderr = origStderr
+	}()
+
+	outCh := make(chan string, 1)
+	errCh := make(chan string, 1)
+	go func() {
+		var b bytes.Buffer
+		_, _ = b.ReadFrom(stdoutR)
+		outCh <- b.String()
+	}()
+	go func() {
+		var b bytes.Buffer
+		_, _ = b.ReadFrom(stderrR)
+		errCh <- b.String()
+	}()
+
+	root := newRootCmd()
+	root.SetArgs(args)
+	res := execResult{RunErr: root.Execute()}
+
+	// Close the writers so the goroutines see EOF.
+	_ = stdoutW.Close()
+	_ = stderrW.Close()
+	res.Out = <-outCh
+	res.Err = <-errCh
+	return res
+}
+
+// seedTestRegistry creates a registry.json file under s.CacheDir and
+// returns the file:// URL to feed via --registry. This lets tests
+// avoid spinning up an httptest server when all they need is a fixed
+// registry document.
+func seedTestRegistry(t *testing.T, s *testutil.Sandbox, fixtures []testutil.SkillFixture) string {
+	t.Helper()
+	reg := testutil.BuildRegistry(t, s.CacheDir, "example", "repo", "0123456789abcdef", fixtures)
+
+	path := filepath.Join(s.Root, "registry.json")
+	data := mustJSON(t, reg)
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("write registry.json: %v", err)
+	}
+	return "file://" + path
+}
+
+func mustJSON(t *testing.T, reg *registry.Registry) []byte {
+	t.Helper()
+	// Use the registry package's own serialization shape via json.
+	// Importing encoding/json here keeps the helper self-contained.
+	data, err := registryToJSON(reg)
+	if err != nil {
+		t.Fatalf("marshal registry: %v", err)
+	}
+	return data
+}
+
+// assertContains fails when haystack doesn't contain needle.
+func assertContains(t *testing.T, haystack, needle string) {
+	t.Helper()
+	if !strings.Contains(haystack, needle) {
+		t.Errorf("expected output to contain %q, got:\n%s", needle, haystack)
+	}
+}
+
+// assertNotContains fails when haystack contains needle.
+func assertNotContains(t *testing.T, haystack, needle string) {
+	t.Helper()
+	if strings.Contains(haystack, needle) {
+		t.Errorf("expected output NOT to contain %q, got:\n%s", needle, haystack)
+	}
+}

--- a/cli/cmd/humblskills/doctor_test.go
+++ b/cli/cmd/humblskills/doctor_test.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/jjfantini/humblSKILLS/cli/internal/testutil"
+)
+
+// Doctor tests exercise the JSON output path (deterministic) rather
+// than the TUI. --json plus an exit code of 0 means "nothing failed".
+
+func extractDoctorJSON(t *testing.T, out string) doctorReport {
+	t.Helper()
+	idx := strings.Index(out, "{")
+	if idx < 0 {
+		t.Fatalf("no JSON in doctor output:\n%s", out)
+	}
+	var r doctorReport
+	if err := json.Unmarshal([]byte(out[idx:]), &r); err != nil {
+		t.Fatalf("parse doctor JSON: %v\n%s", err, out)
+	}
+	return r
+}
+
+func TestDoctor_ReportsAdapters(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	enableClaudeCode(t, s)
+
+	regURL := seedTestRegistry(t, s, []testutil.SkillFixture{
+		{Name: "foo", Version: "1.0.0",
+			Files: testutil.SkillTree{"SKILL.md": sampleSkillMD}},
+	})
+	testutil.UseFakeKeyring(t)
+
+	res := runCLIWithStdoutCapture(t,
+		"doctor",
+		"--registry", regURL,
+		"--cache-dir", s.CacheDir,
+		"--manifest", s.ManifestPath,
+		"--profile", s.ProfilePath,
+		"--json",
+	)
+	// doctor returns errDoctorFailed when any adapter isn't detected,
+	// which is fine for this run — we only verify the report shape.
+	got := extractDoctorJSON(t, res.Out)
+
+	// claude-code enabled in sandbox should be Detected=true.
+	found := false
+	for _, a := range got.Adapters {
+		if a.Name == "claude-code" {
+			found = true
+			if !a.Detected {
+				t.Errorf("claude-code not detected: %+v", a)
+			}
+		}
+	}
+	if !found {
+		t.Errorf("claude-code absent from doctor report")
+	}
+	if got.Registry.Skills != 1 {
+		t.Errorf("registry.skills = %d, want 1", got.Registry.Skills)
+	}
+}
+
+func TestDoctor_DetectsCorruptManifest(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	enableClaudeCode(t, s)
+	testutil.UseFakeKeyring(t)
+
+	// Write a garbage manifest so doctor surfaces a load error.
+	s.WriteFile(t, "xdg/state/humblskills/manifest.json", []byte("{not json"))
+
+	regURL := seedTestRegistry(t, s, []testutil.SkillFixture{
+		{Name: "foo", Version: "1.0.0",
+			Files: testutil.SkillTree{"SKILL.md": sampleSkillMD}},
+	})
+
+	res := runCLIWithStdoutCapture(t,
+		"doctor",
+		"--registry", regURL,
+		"--cache-dir", s.CacheDir,
+		"--manifest", s.ManifestPath,
+		"--profile", s.ProfilePath,
+		"--json",
+	)
+	got := extractDoctorJSON(t, res.Out)
+	found := false
+	for _, iss := range got.Issues {
+		if strings.Contains(iss, "manifest") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected manifest issue, got: %+v", got.Issues)
+	}
+}
+
+func TestDoctor_RegistryUnreachableSurfacedAsIssue(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	enableClaudeCode(t, s)
+	testutil.UseFakeKeyring(t)
+
+	res := runCLIWithStdoutCapture(t,
+		"doctor",
+		// Point at a definitely-missing file URL.
+		"--registry", "file:///nonexistent/registry.json",
+		"--cache-dir", s.CacheDir,
+		"--manifest", s.ManifestPath,
+		"--profile", s.ProfilePath,
+		"--json",
+	)
+	got := extractDoctorJSON(t, res.Out)
+	if got.Registry.Error == "" {
+		t.Error("expected registry error on unreachable URL")
+	}
+}
+
+func TestDoctor_JSONShapeSurvives(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	enableClaudeCode(t, s)
+	testutil.UseFakeKeyring(t)
+
+	regURL := seedTestRegistry(t, s, []testutil.SkillFixture{
+		{Name: "foo", Version: "1.0.0",
+			Files: testutil.SkillTree{"SKILL.md": sampleSkillMD}},
+	})
+
+	res := runCLIWithStdoutCapture(t,
+		"doctor",
+		"--registry", regURL,
+		"--cache-dir", s.CacheDir,
+		"--manifest", s.ManifestPath,
+		"--profile", s.ProfilePath,
+		"--json",
+	)
+	got := extractDoctorJSON(t, res.Out)
+
+	// Contract keys the report consumers (doctor --json, dashboards) rely on.
+	if got.Eval.DefaultRunner == "" {
+		// Empty is valid when no runner is detected, but Runners slice
+		// must still be populated.
+	}
+	if got.Eval.Runners == nil {
+		t.Error("Eval.Runners should be non-nil slice")
+	}
+	if got.Eval.APIKeys == nil {
+		t.Error("Eval.APIKeys should be non-nil slice")
+	}
+}

--- a/cli/cmd/humblskills/install_test.go
+++ b/cli/cmd/humblskills/install_test.go
@@ -1,0 +1,326 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jjfantini/humblSKILLS/cli/internal/manifest"
+	"github.com/jjfantini/humblSKILLS/cli/internal/testutil"
+)
+
+// sampleSkillMD is the minimum valid SKILL.md body the install tests use.
+const sampleSkillMD = `---
+name: foo
+description: Example skill for install tests
+version: 1.0.0
+---
+
+# foo
+
+Body.
+`
+
+func enableClaudeCode(t *testing.T, s *testutil.Sandbox) {
+	t.Helper()
+	// Create ~/.claude so the claude-code adapter's path_exists rule
+	// matches under the sandboxed HOME.
+	if err := os.MkdirAll(filepath.Join(s.Home, ".claude"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestInstall_HappyPath_SingleSkill(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	enableClaudeCode(t, s)
+
+	regURL := seedTestRegistry(t, s, []testutil.SkillFixture{
+		{
+			Name: "foo", Version: "1.0.0",
+			Description: "test skill",
+			Platforms:   []string{"claude-code"},
+			Files: testutil.SkillTree{
+				"SKILL.md": sampleSkillMD,
+			},
+		},
+	})
+
+	res := runCLIWithStdoutCapture(t,
+		"install", "foo",
+		"--registry", regURL,
+		"--cache-dir", s.CacheDir,
+		"--manifest", s.ManifestPath,
+		"--platform", "claude-code",
+		"--scope", "user",
+		"--yes", "--json",
+	)
+	if res.RunErr != nil {
+		t.Fatalf("run: %v\nerr: %s", res.RunErr, res.Err)
+	}
+
+	// Manifest should now have one installation under claude-code/user.
+	m, err := manifest.Load(s.ManifestPath)
+	if err != nil {
+		t.Fatalf("manifest: %v", err)
+	}
+	if len(m.Installations) != 1 {
+		t.Fatalf("installs = %d, body=%s", len(m.Installations), res.Out)
+	}
+	got := m.Installations[0]
+	if got.Skill != "foo" || got.Platform != "claude-code" || got.Scope != "user" {
+		t.Errorf("unexpected install: %+v", got)
+	}
+	if _, err := os.Stat(filepath.Join(got.Path, "SKILL.md")); err != nil {
+		t.Errorf("installed SKILL.md missing: %v", err)
+	}
+}
+
+func TestInstall_IdempotentWhenUpToDate(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	enableClaudeCode(t, s)
+
+	regURL := seedTestRegistry(t, s, []testutil.SkillFixture{
+		{
+			Name: "foo", Version: "1.0.0",
+			Platforms: []string{"claude-code"},
+			Files:     testutil.SkillTree{"SKILL.md": sampleSkillMD},
+		},
+	})
+
+	runOnce := func() execResult {
+		return runCLIWithStdoutCapture(t,
+			"install", "foo",
+			"--registry", regURL,
+			"--cache-dir", s.CacheDir,
+			"--manifest", s.ManifestPath,
+			"--platform", "claude-code",
+			"--scope", "user",
+			"--yes", "--json",
+		)
+	}
+	first := runOnce()
+	if first.RunErr != nil {
+		t.Fatalf("first run: %v\n%s", first.RunErr, first.Err)
+	}
+
+	second := runOnce()
+	if second.RunErr != nil {
+		t.Fatalf("second run: %v\n%s", second.RunErr, second.Err)
+	}
+
+	// Every target on the second run must be "skipped".
+	extractJSON := func(s string) string {
+		idx := strings.Index(s, "{")
+		return s[idx:]
+	}
+	var payload struct {
+		Results []struct {
+			Outcome string `json:"outcome"`
+		} `json:"results"`
+	}
+	if err := json.Unmarshal([]byte(extractJSON(second.Out)), &payload); err != nil {
+		t.Fatalf("parse json: %v\n%s", err, second.Out)
+	}
+	if len(payload.Results) == 0 {
+		t.Fatal("second run reported no results")
+	}
+	for _, r := range payload.Results {
+		if r.Outcome != "skipped" {
+			t.Errorf("second run outcome = %q, want skipped", r.Outcome)
+		}
+	}
+}
+
+func TestInstall_UnknownSkillErrors(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	enableClaudeCode(t, s)
+
+	regURL := seedTestRegistry(t, s, []testutil.SkillFixture{
+		{
+			Name: "foo", Version: "1.0.0",
+			Platforms: []string{"claude-code"},
+			Files:     testutil.SkillTree{"SKILL.md": sampleSkillMD},
+		},
+	})
+	res := runCLIWithStdoutCapture(t,
+		"install", "ghost",
+		"--registry", regURL,
+		"--cache-dir", s.CacheDir,
+		"--manifest", s.ManifestPath,
+		"--platform", "claude-code",
+		"--yes", "--json",
+	)
+	if res.RunErr == nil {
+		t.Fatal("expected error for unknown skill")
+	}
+}
+
+func TestInstall_UnknownPlatformErrors(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	enableClaudeCode(t, s)
+
+	regURL := seedTestRegistry(t, s, []testutil.SkillFixture{
+		{
+			Name: "foo", Version: "1.0.0",
+			Platforms: []string{"claude-code"},
+			Files:     testutil.SkillTree{"SKILL.md": sampleSkillMD},
+		},
+	})
+	res := runCLIWithStdoutCapture(t,
+		"install", "foo",
+		"--registry", regURL,
+		"--cache-dir", s.CacheDir,
+		"--manifest", s.ManifestPath,
+		"--platform", "ghost-platform",
+		"--yes", "--json",
+	)
+	if res.RunErr == nil {
+		t.Fatal("expected error for unknown platform")
+	}
+	if !strings.Contains(res.RunErr.Error(), "unknown platform") {
+		t.Errorf("err: %v", res.RunErr)
+	}
+}
+
+func TestInstall_ForceReinstallsUpToDateTarget(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	enableClaudeCode(t, s)
+
+	regURL := seedTestRegistry(t, s, []testutil.SkillFixture{
+		{
+			Name: "foo", Version: "1.0.0",
+			Platforms: []string{"claude-code"},
+			Files:     testutil.SkillTree{"SKILL.md": sampleSkillMD},
+		},
+	})
+
+	args := []string{
+		"install", "foo",
+		"--registry", regURL,
+		"--cache-dir", s.CacheDir,
+		"--manifest", s.ManifestPath,
+		"--platform", "claude-code",
+		"--scope", "user",
+		"--yes", "--json",
+	}
+	if r := runCLIWithStdoutCapture(t, args...); r.RunErr != nil {
+		t.Fatalf("first run: %v\n%s", r.RunErr, r.Err)
+	}
+
+	// Second run with --force should report "forced" outcomes.
+	forceArgs := append(args, "--force")
+	res := runCLIWithStdoutCapture(t, forceArgs...)
+	if res.RunErr != nil {
+		t.Fatalf("force run: %v\n%s", res.RunErr, res.Err)
+	}
+	if !strings.Contains(res.Out, "forced") {
+		t.Errorf("expected forced outcome in output:\n%s", res.Out)
+	}
+}
+
+func TestInstall_SelectPlatforms_DetectedOnly(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	enableClaudeCode(t, s)
+	// cursor NOT enabled (no ~/.cursor) — it must not appear in selected set.
+
+	regURL := seedTestRegistry(t, s, []testutil.SkillFixture{
+		{
+			Name: "foo", Version: "1.0.0",
+			Platforms: []string{"claude-code", "cursor"},
+			Files:     testutil.SkillTree{"SKILL.md": sampleSkillMD},
+		},
+	})
+
+	// Omit --platform → auto-detect must pick only claude-code.
+	res := runCLIWithStdoutCapture(t,
+		"install", "foo",
+		"--registry", regURL,
+		"--cache-dir", s.CacheDir,
+		"--manifest", s.ManifestPath,
+		"--scope", "user",
+		"--yes", "--json",
+	)
+	if res.RunErr != nil {
+		t.Fatalf("run: %v\nerr: %s", res.RunErr, res.Err)
+	}
+	m, err := manifest.Load(s.ManifestPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, inst := range m.Installations {
+		if inst.Platform == "cursor" {
+			t.Errorf("cursor installed despite not being detected: %+v", inst)
+		}
+	}
+	// claude-code must be present.
+	found := false
+	for _, inst := range m.Installations {
+		if inst.Platform == "claude-code" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("claude-code missing from manifest")
+	}
+}
+
+func TestInstall_NoPlatformsDetectedErrors(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	// Neither ~/.claude nor ~/.cursor exist. Auto-detect yields nothing.
+
+	regURL := seedTestRegistry(t, s, []testutil.SkillFixture{
+		{
+			Name: "foo", Version: "1.0.0",
+			Platforms: []string{"claude-code"},
+			Files:     testutil.SkillTree{"SKILL.md": sampleSkillMD},
+		},
+	})
+	res := runCLIWithStdoutCapture(t,
+		"install", "foo",
+		"--registry", regURL,
+		"--cache-dir", s.CacheDir,
+		"--manifest", s.ManifestPath,
+		"--scope", "user",
+		"--yes", "--json",
+	)
+	if res.RunErr == nil {
+		t.Fatal("expected error when no platforms detected")
+	}
+}
+
+func TestSelectPlatforms_RequestedSubset(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	enableClaudeCode(t, s)
+	// Cursor also enabled.
+	_ = os.MkdirAll(filepath.Join(s.Home, ".cursor"), 0o755)
+
+	regURL := seedTestRegistry(t, s, []testutil.SkillFixture{
+		{
+			Name: "foo", Version: "1.0.0",
+			Platforms: []string{"claude-code", "cursor"},
+			Files:     testutil.SkillTree{"SKILL.md": sampleSkillMD},
+		},
+	})
+
+	// Requested only cursor → claude-code must not be installed.
+	res := runCLIWithStdoutCapture(t,
+		"install", "foo",
+		"--registry", regURL,
+		"--cache-dir", s.CacheDir,
+		"--manifest", s.ManifestPath,
+		"--platform", "cursor",
+		"--scope", "user",
+		"--yes", "--json",
+	)
+	if res.RunErr != nil {
+		t.Fatalf("run: %v\n%s", res.RunErr, res.Err)
+	}
+	m, _ := manifest.Load(s.ManifestPath)
+	for _, inst := range m.Installations {
+		if inst.Platform == "claude-code" {
+			t.Errorf("claude-code installed despite --platform cursor: %+v", inst)
+		}
+	}
+}

--- a/cli/cmd/humblskills/list_test.go
+++ b/cli/cmd/humblskills/list_test.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jjfantini/humblSKILLS/cli/internal/manifest"
+	"github.com/jjfantini/humblSKILLS/cli/internal/testutil"
+)
+
+func TestList_EmptyManifest_JSON(t *testing.T) {
+	s := testutil.NewSandbox(t)
+
+	res := runCLIWithStdoutCapture(t,
+		"list",
+		"--manifest", s.ManifestPath,
+		"--json",
+	)
+	if res.RunErr != nil {
+		t.Fatalf("run: %v\n%s", res.RunErr, res.Err)
+	}
+	// Output should be JSON with zero installations.
+	idx := strings.Index(res.Out, "{")
+	if idx < 0 {
+		t.Fatalf("no JSON in output:\n%s", res.Out)
+	}
+	var m struct {
+		Installations []any `json:"installations"`
+	}
+	if err := json.Unmarshal([]byte(res.Out[idx:]), &m); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(m.Installations) != 0 {
+		t.Errorf("installations = %d, want 0", len(m.Installations))
+	}
+}
+
+func TestList_PopulatedManifest_JSON(t *testing.T) {
+	s := testutil.NewSandbox(t)
+
+	// Seed a manifest with two installations directly via the manifest
+	// package, avoiding the need to run install for a list test.
+	m := &manifest.Manifest{SchemaVersion: manifest.SchemaVersion}
+	m.Upsert(manifest.Installation{
+		Skill: "alpha", Version: "1.0.0", Platform: "claude-code",
+		Scope: "user", Path: "/tmp/alpha",
+		InstalledAt: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+	})
+	m.Upsert(manifest.Installation{
+		Skill: "beta", Version: "0.9.0", Platform: "cursor-agent",
+		Scope: "project", Path: "/tmp/beta",
+		InstalledAt: time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC),
+	})
+	if err := manifest.Save(s.ManifestPath, m); err != nil {
+		t.Fatal(err)
+	}
+
+	res := runCLIWithStdoutCapture(t,
+		"list",
+		"--manifest", s.ManifestPath,
+		"--json",
+	)
+	if res.RunErr != nil {
+		t.Fatalf("run: %v\n%s", res.RunErr, res.Err)
+	}
+
+	idx := strings.Index(res.Out, "{")
+	var got struct {
+		Installations []struct {
+			Skill    string `json:"skill"`
+			Platform string `json:"platform"`
+		} `json:"installations"`
+	}
+	if err := json.Unmarshal([]byte(res.Out[idx:]), &got); err != nil {
+		t.Fatalf("parse: %v\n%s", err, res.Out)
+	}
+	if len(got.Installations) != 2 {
+		t.Errorf("installations = %d, want 2", len(got.Installations))
+	}
+	names := map[string]string{}
+	for _, i := range got.Installations {
+		names[i.Skill] = i.Platform
+	}
+	if names["alpha"] != "claude-code" {
+		t.Errorf("alpha platform = %q", names["alpha"])
+	}
+	if names["beta"] != "cursor-agent" {
+		t.Errorf("beta platform = %q", names["beta"])
+	}
+}
+
+func TestList_EmptyManifest_TextOutputHint(t *testing.T) {
+	s := testutil.NewSandbox(t)
+
+	// --yes keeps TUI off so we get the plain text output.
+	res := runCLIWithStdoutCapture(t,
+		"list",
+		"--manifest", s.ManifestPath,
+		"--yes",
+	)
+	if res.RunErr != nil {
+		t.Fatalf("run: %v\n%s", res.RunErr, res.Err)
+	}
+	if !strings.Contains(res.Out+res.Err, "no skills installed") {
+		t.Errorf("expected helpful hint, got:\n%s\n---\n%s", res.Out, res.Err)
+	}
+}

--- a/cli/cmd/humblskills/profile_test.go
+++ b/cli/cmd/humblskills/profile_test.go
@@ -1,0 +1,206 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/jjfantini/humblSKILLS/cli/internal/profile"
+	"github.com/jjfantini/humblSKILLS/cli/internal/testutil"
+)
+
+func TestProfileShow_EmptyJSON(t *testing.T) {
+	s := testutil.NewSandbox(t)
+
+	res := runCLIWithStdoutCapture(t,
+		"profile", "show",
+		"--profile", s.ProfilePath,
+		"--json",
+	)
+	if res.RunErr != nil {
+		t.Fatalf("run: %v\n%s", res.RunErr, res.Err)
+	}
+	idx := strings.Index(res.Out, "{")
+	var p struct {
+		SchemaVersion int `json:"schema_version"`
+	}
+	if err := json.Unmarshal([]byte(res.Out[idx:]), &p); err != nil {
+		t.Fatalf("parse: %v\n%s", err, res.Out)
+	}
+	if p.SchemaVersion != profile.SchemaVersion {
+		t.Errorf("schema = %d", p.SchemaVersion)
+	}
+}
+
+func TestProfileSet_ValidScope(t *testing.T) {
+	s := testutil.NewSandbox(t)
+
+	res := runCLIWithStdoutCapture(t,
+		"profile", "set", "scope", "user",
+		"--profile", s.ProfilePath,
+		"--json",
+	)
+	if res.RunErr != nil {
+		t.Fatalf("run: %v", res.RunErr)
+	}
+	p, err := profile.Load(s.ProfilePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.DefaultScope != "user" {
+		t.Errorf("scope = %q", p.DefaultScope)
+	}
+}
+
+func TestProfileSet_InvalidScope(t *testing.T) {
+	s := testutil.NewSandbox(t)
+
+	res := runCLIWithStdoutCapture(t,
+		"profile", "set", "scope", "bogus-value",
+		"--profile", s.ProfilePath,
+	)
+	if res.RunErr == nil {
+		t.Fatal("expected error for invalid scope")
+	}
+}
+
+func TestProfileSet_UnknownKey(t *testing.T) {
+	s := testutil.NewSandbox(t)
+
+	res := runCLIWithStdoutCapture(t,
+		"profile", "set", "bogus-key", "x",
+		"--profile", s.ProfilePath,
+	)
+	if res.RunErr == nil {
+		t.Fatal("expected error for unknown key")
+	}
+	if !strings.Contains(res.RunErr.Error(), "unknown key") {
+		t.Errorf("err = %v", res.RunErr)
+	}
+}
+
+func TestProfileSet_ValidPlatforms(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	res := runCLIWithStdoutCapture(t,
+		"profile", "set", "platforms", "claude-code,cursor",
+		"--profile", s.ProfilePath,
+		"--json",
+	)
+	if res.RunErr != nil {
+		t.Fatalf("run: %v", res.RunErr)
+	}
+	p, _ := profile.Load(s.ProfilePath)
+	if len(p.DefaultPlatforms) != 2 {
+		t.Errorf("platforms = %v", p.DefaultPlatforms)
+	}
+}
+
+func TestProfileSet_UnknownPlatform(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	res := runCLIWithStdoutCapture(t,
+		"profile", "set", "platforms", "claude-code,ghost-platform",
+		"--profile", s.ProfilePath,
+	)
+	if res.RunErr == nil {
+		t.Fatal("expected unknown platform error")
+	}
+}
+
+func TestProfileSet_EmptyPlatformsClears(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	// First set to something.
+	_ = runCLIWithStdoutCapture(t,
+		"profile", "set", "platforms", "claude-code",
+		"--profile", s.ProfilePath, "--json",
+	)
+	// Now clear it.
+	r := runCLIWithStdoutCapture(t,
+		"profile", "set", "platforms", "",
+		"--profile", s.ProfilePath, "--json",
+	)
+	if r.RunErr != nil {
+		t.Fatalf("run: %v", r.RunErr)
+	}
+	p, _ := profile.Load(s.ProfilePath)
+	if len(p.DefaultPlatforms) != 0 {
+		t.Errorf("not cleared: %v", p.DefaultPlatforms)
+	}
+}
+
+func TestProfileReset_RemovesFile(t *testing.T) {
+	s := testutil.NewSandbox(t)
+
+	// Seed a profile.
+	_ = profile.Save(s.ProfilePath, &profile.Profile{DefaultScope: "user"})
+	if _, err := os.Stat(s.ProfilePath); err != nil {
+		t.Fatalf("precondition: profile missing: %v", err)
+	}
+
+	res := runCLIWithStdoutCapture(t,
+		"profile", "reset",
+		"--profile", s.ProfilePath,
+		"--json",
+	)
+	if res.RunErr != nil {
+		t.Fatalf("run: %v", res.RunErr)
+	}
+	if _, err := os.Stat(s.ProfilePath); err == nil {
+		t.Error("profile file should be removed after reset")
+	}
+}
+
+func TestProfilePath_PrintsResolvedPath(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	res := runCLIWithStdoutCapture(t,
+		"profile", "path",
+		"--profile", s.ProfilePath,
+	)
+	if res.RunErr != nil {
+		t.Fatalf("run: %v", res.RunErr)
+	}
+	if !strings.Contains(res.Out, s.ProfilePath) {
+		t.Errorf("expected path in output, got:\n%s", res.Out)
+	}
+}
+
+func TestParseCSV(t *testing.T) {
+	cases := map[string][]string{
+		"":                nil,
+		"   ":             nil,
+		"a":               {"a"},
+		"a,b":             {"a", "b"},
+		"a,  b ,c":        {"a", "b", "c"},
+		", a ,,b ,":       {"a", "b"},
+	}
+	for in, want := range cases {
+		got := parseCSV(in)
+		if len(got) != len(want) {
+			t.Errorf("parseCSV(%q) = %v, want %v", in, got, want)
+			continue
+		}
+		for i := range got {
+			if got[i] != want[i] {
+				t.Errorf("parseCSV(%q)[%d] = %q, want %q", in, i, got[i], want[i])
+			}
+		}
+	}
+}
+
+func TestFormatPlatforms(t *testing.T) {
+	if got := formatPlatforms(nil); got != "(all detected)" {
+		t.Errorf("got %q", got)
+	}
+	if got := formatPlatforms([]string{"a", "b"}); got != "a, b" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestFormatScope(t *testing.T) {
+	if got := formatScope(""); got != "(adapter default)" {
+		t.Errorf("got %q", got)
+	}
+	if got := formatScope("user"); got != "user" {
+		t.Errorf("got %q", got)
+	}
+}

--- a/cli/cmd/humblskills/registry_test.go
+++ b/cli/cmd/humblskills/registry_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/jjfantini/humblSKILLS/cli/internal/testutil"
+)
+
+func TestRegistryRefresh_FileURLReportsFileOrigin(t *testing.T) {
+	s := testutil.NewSandbox(t)
+
+	regURL := seedTestRegistry(t, s, []testutil.SkillFixture{
+		{Name: "foo", Version: "1.0.0",
+			Files: testutil.SkillTree{"SKILL.md": sampleSkillMD}},
+	})
+
+	res := runCLIWithStdoutCapture(t,
+		"registry", "refresh",
+		"--registry", regURL,
+		"--cache-dir", s.CacheDir,
+		"--json",
+	)
+	if res.RunErr != nil {
+		t.Fatalf("run: %v\n%s", res.RunErr, res.Err)
+	}
+	idx := strings.Index(res.Out, "{")
+	if idx < 0 {
+		t.Fatalf("no JSON in output:\n%s", res.Out)
+	}
+	var out struct {
+		URL    string `json:"url"`
+		Source string `json:"source"`
+		Skills int    `json:"skills"`
+	}
+	if err := json.Unmarshal([]byte(res.Out[idx:]), &out); err != nil {
+		t.Fatalf("parse: %v\n%s", err, res.Out)
+	}
+	if out.Source != "file" {
+		t.Errorf("source = %q, want file", out.Source)
+	}
+	if out.Skills != 1 {
+		t.Errorf("skills = %d", out.Skills)
+	}
+}

--- a/cli/cmd/humblskills/root_test.go
+++ b/cli/cmd/humblskills/root_test.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jjfantini/humblSKILLS/cli/internal/testutil"
+)
+
+func TestRoot_QuietAndVerboseMutuallyExclusive(t *testing.T) {
+	testutil.NewSandbox(t)
+
+	res := runCLIWithStdoutCapture(t,
+		"version",
+		"--quiet", "--verbose",
+	)
+	if res.RunErr == nil {
+		t.Fatal("expected error when --quiet and --verbose both set")
+	}
+	if !strings.Contains(res.RunErr.Error(), "mutually exclusive") {
+		t.Errorf("err = %v", res.RunErr)
+	}
+}
+
+func TestRoot_Help_IncludesCommandList(t *testing.T) {
+	testutil.NewSandbox(t)
+
+	res := runCLI(t, "--help")
+	if res.RunErr != nil {
+		t.Fatalf("help returned error: %v", res.RunErr)
+	}
+	// Cobra --help output goes through the Cobra-supplied writer
+	// (captured by runCLI).
+	for _, want := range []string{"install", "update", "list", "search", "doctor", "profile"} {
+		if !strings.Contains(res.Out, want) {
+			t.Errorf("help missing %q:\n%s", want, res.Out)
+		}
+	}
+}
+
+func TestRoot_UnknownCommandErrors(t *testing.T) {
+	testutil.NewSandbox(t)
+	res := runCLI(t, "not-a-command")
+	if res.RunErr == nil {
+		t.Fatal("expected error for unknown command")
+	}
+}
+
+func TestFirstNonEmpty(t *testing.T) {
+	if got := firstNonEmpty("", "", "c", "d"); got != "c" {
+		t.Errorf("got %q", got)
+	}
+	if got := firstNonEmpty("", ""); got != "" {
+		t.Errorf("got %q", got)
+	}
+	if got := firstNonEmpty("a"); got != "a" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestResolveCacheDir_Override(t *testing.T) {
+	got, err := resolveCacheDir("/tmp/override")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "/tmp/override" {
+		t.Errorf("override not honoured: %q", got)
+	}
+}
+
+func TestResolveCacheDir_UsesXDG(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	got, err := resolveCacheDir("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(got, s.XDGCacheHome) {
+		t.Errorf("default cache dir %q not under XDG_CACHE_HOME %q", got, s.XDGCacheHome)
+	}
+}
+
+func TestResolveManifestPath_Override(t *testing.T) {
+	got, err := resolveManifestPath("/tmp/override.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "/tmp/override.json" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestResolveProfilePath_Override(t *testing.T) {
+	got, err := resolveProfilePath("/tmp/profile.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "/tmp/profile.json" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestConfigureApp_SetsCacheManifestProfileFromSandbox(t *testing.T) {
+	s := testutil.NewSandbox(t)
+
+	// Run any real command under the sandbox to trigger configureApp,
+	// then verify the install happened under the sandboxed paths.
+	enableClaudeCode(t, s)
+	regURL := seedTestRegistry(t, s, []testutil.SkillFixture{
+		{Name: "foo", Version: "1.0.0", Platforms: []string{"claude-code"},
+			Files: testutil.SkillTree{"SKILL.md": sampleSkillMD}},
+	})
+	res := runCLIWithStdoutCapture(t,
+		"install", "foo",
+		"--registry", regURL,
+		"--platform", "claude-code", "--scope", "user",
+		"--yes", "--json",
+	)
+	if res.RunErr != nil {
+		t.Fatalf("install: %v\n%s", res.RunErr, res.Err)
+	}
+	// Manifest should have been created under the XDG sandbox,
+	// not the developer's real ~/.local/state.
+	if !strings.HasPrefix(s.ManifestPath, s.XDGStateHome) {
+		t.Fatalf("sandbox manifest path %q not under XDG_STATE_HOME %q",
+			s.ManifestPath, s.XDGStateHome)
+	}
+}

--- a/cli/cmd/humblskills/search_test.go
+++ b/cli/cmd/humblskills/search_test.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/jjfantini/humblSKILLS/cli/internal/testutil"
+)
+
+func TestSearch_NameMatch_JSON(t *testing.T) {
+	s := testutil.NewSandbox(t)
+
+	regURL := seedTestRegistry(t, s, []testutil.SkillFixture{
+		{Name: "foo-helper", Version: "1.0.0", Description: "Help with foo",
+			Files: testutil.SkillTree{"SKILL.md": sampleSkillMD}},
+		{Name: "bar", Version: "1.0.0", Description: "Unrelated",
+			Files: testutil.SkillTree{"SKILL.md": sampleSkillMD}},
+	})
+
+	res := runCLIWithStdoutCapture(t,
+		"search", "foo",
+		"--registry", regURL,
+		"--cache-dir", s.CacheDir,
+		"--json",
+	)
+	if res.RunErr != nil {
+		t.Fatalf("run: %v\n%s", res.RunErr, res.Err)
+	}
+
+	idx := strings.Index(res.Out, "{")
+	var out struct {
+		Query   string `json:"query"`
+		Results []struct {
+			Name string `json:"name"`
+		} `json:"results"`
+	}
+	if err := json.Unmarshal([]byte(res.Out[idx:]), &out); err != nil {
+		t.Fatalf("parse: %v\n%s", err, res.Out)
+	}
+	if len(out.Results) != 1 || out.Results[0].Name != "foo-helper" {
+		t.Errorf("results = %+v", out.Results)
+	}
+}
+
+func TestSearch_TagMatch_JSON(t *testing.T) {
+	s := testutil.NewSandbox(t)
+
+	regURL := seedTestRegistry(t, s, []testutil.SkillFixture{
+		{Name: "alpha", Version: "1.0.0", Tags: []string{"workflow"},
+			Files: testutil.SkillTree{"SKILL.md": sampleSkillMD}},
+		{Name: "beta", Version: "1.0.0",
+			Files: testutil.SkillTree{"SKILL.md": sampleSkillMD}},
+	})
+	res := runCLIWithStdoutCapture(t,
+		"search", "workflow",
+		"--registry", regURL,
+		"--cache-dir", s.CacheDir,
+		"--json",
+	)
+	if res.RunErr != nil {
+		t.Fatalf("run: %v\n%s", res.RunErr, res.Err)
+	}
+	idx := strings.Index(res.Out, "{")
+	var out struct {
+		Results []struct{ Name string } `json:"results"`
+	}
+	_ = json.Unmarshal([]byte(res.Out[idx:]), &out)
+	if len(out.Results) != 1 || out.Results[0].Name != "alpha" {
+		t.Errorf("results = %+v", out.Results)
+	}
+}
+
+func TestSearch_NoResults_JSON(t *testing.T) {
+	s := testutil.NewSandbox(t)
+
+	regURL := seedTestRegistry(t, s, []testutil.SkillFixture{
+		{Name: "alpha", Version: "1.0.0",
+			Files: testutil.SkillTree{"SKILL.md": sampleSkillMD}},
+	})
+	res := runCLIWithStdoutCapture(t,
+		"search", "nomatch",
+		"--registry", regURL,
+		"--cache-dir", s.CacheDir,
+		"--json",
+	)
+	if res.RunErr != nil {
+		t.Fatalf("run: %v\n%s", res.RunErr, res.Err)
+	}
+	idx := strings.Index(res.Out, "{")
+	var out struct {
+		Results []any `json:"results"`
+	}
+	_ = json.Unmarshal([]byte(res.Out[idx:]), &out)
+	if len(out.Results) != 0 {
+		t.Errorf("expected zero results, got %+v", out.Results)
+	}
+}
+
+func TestMatches_NameDescriptionTag(t *testing.T) {
+	// Indirect unit test via the command helper matches().
+	// The function is tested by making sure different fields all hit.
+	// Build fixtures where query only matches one field at a time.
+	s := testutil.NewSandbox(t)
+
+	regURL := seedTestRegistry(t, s, []testutil.SkillFixture{
+		{Name: "alpha", Version: "1.0.0", Description: "marker-desc",
+			Files: testutil.SkillTree{"SKILL.md": sampleSkillMD}},
+		{Name: "marker-name", Version: "1.0.0",
+			Files: testutil.SkillTree{"SKILL.md": sampleSkillMD}},
+		{Name: "gamma", Version: "1.0.0", Tags: []string{"marker-tag"},
+			Files: testutil.SkillTree{"SKILL.md": sampleSkillMD}},
+	})
+
+	search := func(q string) int {
+		r := runCLIWithStdoutCapture(t, "search", q,
+			"--registry", regURL, "--cache-dir", s.CacheDir, "--json")
+		if r.RunErr != nil {
+			t.Fatalf("search %q: %v", q, r.RunErr)
+		}
+		idx := strings.Index(r.Out, "{")
+		var out struct{ Results []any }
+		_ = json.Unmarshal([]byte(r.Out[idx:]), &out)
+		return len(out.Results)
+	}
+	if n := search("marker-name"); n != 1 {
+		t.Errorf("name match: got %d", n)
+	}
+	if n := search("marker-desc"); n != 1 {
+		t.Errorf("desc match: got %d", n)
+	}
+	if n := search("marker-tag"); n != 1 {
+		t.Errorf("tag match: got %d", n)
+	}
+}

--- a/cli/cmd/humblskills/uninstall_test.go
+++ b/cli/cmd/humblskills/uninstall_test.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jjfantini/humblSKILLS/cli/internal/manifest"
+	"github.com/jjfantini/humblSKILLS/cli/internal/testutil"
+)
+
+// installFoo is a small helper for uninstall tests — seeds a registry,
+// runs a successful install, and returns the regURL so callers can
+// drive further CLI runs.
+func installFoo(t *testing.T, s *testutil.Sandbox) string {
+	t.Helper()
+	enableClaudeCode(t, s)
+
+	regURL := seedTestRegistry(t, s, []testutil.SkillFixture{
+		{
+			Name: "foo", Version: "1.0.0",
+			Platforms: []string{"claude-code"},
+			Files:     testutil.SkillTree{"SKILL.md": sampleSkillMD},
+		},
+	})
+	res := runCLIWithStdoutCapture(t,
+		"install", "foo",
+		"--registry", regURL,
+		"--cache-dir", s.CacheDir,
+		"--manifest", s.ManifestPath,
+		"--platform", "claude-code",
+		"--scope", "user",
+		"--yes", "--json",
+	)
+	if res.RunErr != nil {
+		t.Fatalf("install failed: %v\n%s", res.RunErr, res.Err)
+	}
+	return regURL
+}
+
+func TestUninstall_RemovesFilesAndManifestEntry(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	_ = installFoo(t, s)
+
+	// Find install path to confirm it's actually deleted.
+	m, _ := manifest.Load(s.ManifestPath)
+	if len(m.Installations) == 0 {
+		t.Fatal("precondition: expected one install")
+	}
+	installPath := m.Installations[0].Path
+
+	res := runCLIWithStdoutCapture(t,
+		"uninstall", "foo",
+		"--manifest", s.ManifestPath,
+		"--cache-dir", s.CacheDir,
+		"--yes", "--json",
+	)
+	if res.RunErr != nil {
+		t.Fatalf("uninstall: %v\n%s", res.RunErr, res.Err)
+	}
+	if _, err := os.Stat(filepath.Join(installPath, "SKILL.md")); err == nil {
+		t.Error("SKILL.md should be removed after uninstall")
+	}
+	m2, _ := manifest.Load(s.ManifestPath)
+	if len(m2.Installations) != 0 {
+		t.Errorf("manifest still has entries: %+v", m2.Installations)
+	}
+}
+
+func TestUninstall_UnknownSkillWarns(t *testing.T) {
+	s := testutil.NewSandbox(t)
+
+	// Seed an empty manifest.
+	if err := os.MkdirAll(filepath.Dir(s.ManifestPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	_ = manifest.Save(s.ManifestPath, &manifest.Manifest{SchemaVersion: manifest.SchemaVersion})
+
+	res := runCLIWithStdoutCapture(t,
+		"uninstall", "ghost",
+		"--manifest", s.ManifestPath,
+		"--cache-dir", s.CacheDir,
+		"--yes",
+	)
+	if res.RunErr != nil {
+		t.Fatalf("uninstall should not error on unknown skill: %v", res.RunErr)
+	}
+	if !strings.Contains(res.Out+res.Err, "not installed") {
+		t.Errorf("expected 'not installed' warning, got:\n%s", res.Out+res.Err)
+	}
+}
+
+func TestUninstall_PreservesOtherSkills(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	enableClaudeCode(t, s)
+
+	regURL := seedTestRegistry(t, s, []testutil.SkillFixture{
+		{
+			Name: "foo", Version: "1.0.0", Platforms: []string{"claude-code"},
+			Files: testutil.SkillTree{"SKILL.md": sampleSkillMD},
+		},
+		{
+			Name: "bar", Version: "1.0.0", Platforms: []string{"claude-code"},
+			Files: testutil.SkillTree{"SKILL.md": sampleSkillMD},
+		},
+	})
+	for _, name := range []string{"foo", "bar"} {
+		r := runCLIWithStdoutCapture(t,
+			"install", name,
+			"--registry", regURL,
+			"--cache-dir", s.CacheDir,
+			"--manifest", s.ManifestPath,
+			"--platform", "claude-code", "--scope", "user",
+			"--yes", "--json",
+		)
+		if r.RunErr != nil {
+			t.Fatalf("install %s: %v", name, r.RunErr)
+		}
+	}
+
+	r := runCLIWithStdoutCapture(t,
+		"uninstall", "foo",
+		"--manifest", s.ManifestPath,
+		"--cache-dir", s.CacheDir,
+		"--yes", "--json",
+	)
+	if r.RunErr != nil {
+		t.Fatalf("uninstall: %v", r.RunErr)
+	}
+
+	m, _ := manifest.Load(s.ManifestPath)
+	if len(m.Installations) != 1 || m.Installations[0].Skill != "bar" {
+		t.Errorf("expected only bar remaining: %+v", m.Installations)
+	}
+}

--- a/cli/cmd/humblskills/update_test.go
+++ b/cli/cmd/humblskills/update_test.go
@@ -1,0 +1,161 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/jjfantini/humblSKILLS/cli/internal/manifest"
+	"github.com/jjfantini/humblSKILLS/cli/internal/testutil"
+)
+
+// bumpRegistryVersion seeds a new registry where foo has advanced from
+// 1.0.0 to 1.0.1 so the update command has drift to detect.
+func bumpRegistryVersion(t *testing.T, s *testutil.Sandbox, newBody string) string {
+	t.Helper()
+	return seedTestRegistry(t, s, []testutil.SkillFixture{
+		{
+			Name: "foo", Version: "1.0.1", Platforms: []string{"claude-code"},
+			Files: testutil.SkillTree{"SKILL.md": newBody},
+		},
+	})
+}
+
+func TestUpdate_NoInstallsInfoMessage(t *testing.T) {
+	s := testutil.NewSandbox(t)
+
+	res := runCLIWithStdoutCapture(t,
+		"update",
+		"--manifest", s.ManifestPath,
+		"--cache-dir", s.CacheDir,
+		"--registry", "file:///nonexistent/registry.json",
+		"--yes",
+	)
+	if res.RunErr != nil {
+		t.Fatalf("update on empty manifest must not error: %v", res.RunErr)
+	}
+	if !strings.Contains(res.Out+res.Err, "no skills installed") {
+		t.Errorf("expected hint message, got:\n%s\n%s", res.Out, res.Err)
+	}
+}
+
+func TestUpdate_AllUpToDate_InfoMessage(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	regURL := installFoo(t, s)
+
+	// Update against the SAME registry — nothing drifted.
+	res := runCLIWithStdoutCapture(t,
+		"update",
+		"--manifest", s.ManifestPath,
+		"--cache-dir", s.CacheDir,
+		"--registry", regURL,
+		"--yes",
+	)
+	if res.RunErr != nil {
+		t.Fatalf("update: %v", res.RunErr)
+	}
+	if !strings.Contains(res.Out+res.Err, "up-to-date") {
+		t.Errorf("expected up-to-date message, got:\n%s\n%s", res.Out, res.Err)
+	}
+}
+
+func TestUpdate_Check_ReportsDrift(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	_ = installFoo(t, s)
+
+	newBody := strings.Replace(sampleSkillMD, "version: 1.0.0", "version: 1.0.1", 1)
+	regURL := bumpRegistryVersion(t, s, newBody)
+
+	res := runCLIWithStdoutCapture(t,
+		"update", "--check",
+		"--manifest", s.ManifestPath,
+		"--cache-dir", s.CacheDir,
+		"--registry", regURL,
+		"--json",
+	)
+	if res.RunErr != nil {
+		t.Fatalf("update --check: %v", res.RunErr)
+	}
+	idx := strings.Index(res.Out, "{")
+	var out struct {
+		Updates []struct {
+			Skill       string `json:"skill"`
+			FromVersion string `json:"from_version"`
+			ToVersion   string `json:"to_version"`
+		} `json:"updates"`
+	}
+	if err := json.Unmarshal([]byte(res.Out[idx:]), &out); err != nil {
+		t.Fatalf("parse: %v\n%s", err, res.Out)
+	}
+	if len(out.Updates) != 1 || out.Updates[0].Skill != "foo" {
+		t.Errorf("updates = %+v", out.Updates)
+	}
+	if out.Updates[0].FromVersion != "1.0.0" || out.Updates[0].ToVersion != "1.0.1" {
+		t.Errorf("versions = %+v", out.Updates[0])
+	}
+}
+
+func TestUpdate_AppliesDrift(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	_ = installFoo(t, s)
+
+	newBody := strings.Replace(sampleSkillMD, "version: 1.0.0", "version: 1.0.1", 1)
+	regURL := bumpRegistryVersion(t, s, newBody)
+
+	res := runCLIWithStdoutCapture(t,
+		"update",
+		"--manifest", s.ManifestPath,
+		"--cache-dir", s.CacheDir,
+		"--registry", regURL,
+		"--yes", "--all", "--json",
+	)
+	if res.RunErr != nil {
+		t.Fatalf("update: %v\n%s", res.RunErr, res.Err)
+	}
+
+	m, _ := manifest.Load(s.ManifestPath)
+	if len(m.Installations) != 1 {
+		t.Fatalf("installs = %d", len(m.Installations))
+	}
+	if m.Installations[0].Version != "1.0.1" {
+		t.Errorf("version not bumped: %+v", m.Installations[0])
+	}
+}
+
+func TestUpdate_Check_AllUpToDateNonJSON(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	regURL := installFoo(t, s)
+	// Check against same registry.
+	res := runCLIWithStdoutCapture(t,
+		"update", "--check",
+		"--manifest", s.ManifestPath,
+		"--cache-dir", s.CacheDir,
+		"--registry", regURL,
+		"--yes",
+	)
+	if res.RunErr != nil {
+		t.Fatalf("update --check: %v", res.RunErr)
+	}
+	if !strings.Contains(res.Out+res.Err, "up-to-date") {
+		t.Errorf("expected up-to-date, got:\n%s", res.Out+res.Err)
+	}
+}
+
+func TestUpdate_OnlyNamedSkillUpToDate(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	regURL := installFoo(t, s)
+
+	res := runCLIWithStdoutCapture(t,
+		"update", "foo",
+		"--manifest", s.ManifestPath,
+		"--cache-dir", s.CacheDir,
+		"--registry", regURL,
+		"--yes",
+	)
+	if res.RunErr != nil {
+		t.Fatalf("update: %v", res.RunErr)
+	}
+	if !strings.Contains(res.Out+res.Err, "up-to-date") {
+		t.Errorf("expected up-to-date message, got:\n%s", res.Out+res.Err)
+	}
+}

--- a/cli/cmd/humblskills/version_test.go
+++ b/cli/cmd/humblskills/version_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/jjfantini/humblSKILLS/cli/internal/testutil"
+)
+
+func TestVersion_JSONOutputsSchema(t *testing.T) {
+	testutil.NewSandbox(t)
+
+	res := runCLIWithStdoutCapture(t, "version", "--json")
+	if res.RunErr != nil {
+		t.Fatalf("run: %v\nerr: %s", res.RunErr, res.Err)
+	}
+	// Extract just the JSON object (the UI may prefix with other output).
+	out := strings.TrimSpace(res.Out)
+	if !strings.HasPrefix(out, "{") {
+		t.Fatalf("expected JSON object, got:\n%s", out)
+	}
+
+	var v struct {
+		Version string `json:"version"`
+		Commit  string `json:"commit"`
+	}
+	if err := json.Unmarshal([]byte(out), &v); err != nil {
+		t.Fatalf("unmarshal: %v\nbody: %s", err, out)
+	}
+	if v.Version == "" {
+		t.Error("Version field empty")
+	}
+	if v.Commit == "" {
+		t.Error("Commit field empty")
+	}
+}
+
+func TestVersion_TextOutputIncludesBrand(t *testing.T) {
+	testutil.NewSandbox(t)
+
+	// --yes disables TUI mode (see tui.ShouldUseTUI) so we get the plain
+	// pipe-friendly output which is the part tests should lock down.
+	res := runCLIWithStdoutCapture(t, "version", "--yes")
+	if res.RunErr != nil {
+		t.Fatalf("run: %v\nerr: %s", res.RunErr, res.Err)
+	}
+	assertContains(t, res.Out, "humblskills")
+}
+
+func TestResolveVersion_ReturnsDevDefaults(t *testing.T) {
+	info := resolveVersion()
+	// Even in a test binary, Version and Commit are non-empty.
+	if info.Version == "" {
+		t.Error("Version empty")
+	}
+	if info.Commit == "" {
+		t.Error("Commit empty")
+	}
+}
+
+func TestShortCommit(t *testing.T) {
+	cases := map[string]string{
+		"abc":                    "abc",
+		"abcdef1234567":          "abcdef123456",
+		"abcdef1234567890abcdef": "abcdef123456",
+	}
+	for in, want := range cases {
+		if got := shortCommit(in); got != want {
+			t.Errorf("shortCommit(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/cli/internal/adapters/adapters_coverage_test.go
+++ b/cli/internal/adapters/adapters_coverage_test.go
@@ -1,0 +1,250 @@
+package adapters_test
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/jjfantini/humblSKILLS/cli/internal/adapters"
+	"github.com/jjfantini/humblSKILLS/cli/internal/testutil"
+)
+
+func TestExpandPath_TildeAlone(t *testing.T) {
+	// "~" by itself resolves to HOME.
+	s := testutil.NewSandbox(t)
+	got := adapters.ExpandPath("~")
+	if got != s.Home {
+		t.Errorf("ExpandPath(~) = %q, want %q", got, s.Home)
+	}
+}
+
+func TestExpandPath_TildeSlash(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	got := adapters.ExpandPath("~/skills")
+	if got != filepath.Join(s.Home, "skills") {
+		t.Errorf("ExpandPath(~/skills) = %q", got)
+	}
+}
+
+func TestExpandPath_EnvSubstitution(t *testing.T) {
+	t.Setenv("HUMBL_TEST_DIR", "/tmp/xyz")
+	got := adapters.ExpandPath("$HUMBL_TEST_DIR/foo")
+	if got != "/tmp/xyz/foo" {
+		t.Errorf("ExpandPath = %q", got)
+	}
+	got = adapters.ExpandPath("${HUMBL_TEST_DIR}/bar")
+	if got != "/tmp/xyz/bar" {
+		t.Errorf("ExpandPath (braces) = %q", got)
+	}
+}
+
+func TestExpandPath_PlainPath(t *testing.T) {
+	got := adapters.ExpandPath("/absolute/path")
+	if got != "/absolute/path" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestExpandPath_EmptyReturnsEmpty(t *testing.T) {
+	if got := adapters.ExpandPath(""); got != "" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestDetect_AllOfFailsEarly(t *testing.T) {
+	// Build an adapter inline with all_of rules that must fail on the
+	// first missing path, so describeRule is invoked on the failing
+	// rule.
+	ads := []adapters.Adapter{
+		{
+			Name: "t",
+			Detect: adapters.DetectRules{
+				AllOf: []adapters.DetectRule{
+					{PathExists: "/this/does/not/exist"},
+					{Env: "NEVER_SET_XYZZY"},
+				},
+			},
+		},
+	}
+	got := adapters.Detect(ads)
+	if len(got) != 1 {
+		t.Fatalf("got %d results", len(got))
+	}
+	if got[0].Detected {
+		t.Error("expected Detected=false")
+	}
+	if !strings.Contains(got[0].Reason, "all_of failed") {
+		t.Errorf("reason = %q", got[0].Reason)
+	}
+}
+
+func TestDetect_AnyOfMatchesFirst(t *testing.T) {
+	t.Setenv("HUMBL_ANYOF_TEST", "1")
+	ads := []adapters.Adapter{
+		{
+			Name: "t",
+			Detect: adapters.DetectRules{
+				AnyOf: []adapters.DetectRule{
+					{Env: "HUMBL_ANYOF_TEST"},
+					{PathExists: "/nope"},
+				},
+			},
+		},
+	}
+	got := adapters.Detect(ads)
+	if !got[0].Detected {
+		t.Errorf("expected match: %+v", got[0])
+	}
+	if !strings.Contains(got[0].Reason, "matched") {
+		t.Errorf("reason = %q", got[0].Reason)
+	}
+}
+
+func TestDetect_NoRulesReportsEmpty(t *testing.T) {
+	ads := []adapters.Adapter{{Name: "bare"}}
+	got := adapters.Detect(ads)
+	if got[0].Detected {
+		t.Error("empty rules must not detect")
+	}
+	if !strings.Contains(got[0].Reason, "no detect") {
+		t.Errorf("reason = %q", got[0].Reason)
+	}
+}
+
+func TestAdapter_Target_UnknownScope(t *testing.T) {
+	a := adapters.Adapter{
+		Name: "x",
+		InstallTargets: map[string]string{
+			"user": "/tmp/x-user",
+		},
+		DefaultScope: "user",
+	}
+	if _, err := a.Target("project"); err == nil {
+		t.Error("expected error for unknown scope")
+	}
+}
+
+func TestAdapter_Target_EmptyScopeFallsBackToDefault(t *testing.T) {
+	a := adapters.Adapter{
+		Name: "x",
+		InstallTargets: map[string]string{
+			"user": "/tmp/x",
+		},
+		DefaultScope: "user",
+	}
+	tg, err := a.Target("")
+	if err != nil {
+		t.Fatalf("Target: %v", err)
+	}
+	if tg.Scope != "user" {
+		t.Errorf("Scope = %q", tg.Scope)
+	}
+}
+
+func TestAdapter_Targets_ReturnsEveryScopeSorted(t *testing.T) {
+	a := adapters.Adapter{
+		Name: "x",
+		InstallTargets: map[string]string{
+			"user":    "/tmp/u",
+			"project": "./proj",
+		},
+	}
+	ts := a.Targets()
+	if len(ts) != 2 {
+		t.Fatalf("got %d", len(ts))
+	}
+	// Sorted lexically: project < user.
+	if ts[0].Scope != "project" || ts[1].Scope != "user" {
+		t.Errorf("scopes = %v", []string{ts[0].Scope, ts[1].Scope})
+	}
+	// Relative paths get resolved against cwd.
+	if !filepath.IsAbs(ts[0].Path) {
+		t.Errorf("project path not absolute: %q", ts[0].Path)
+	}
+}
+
+func TestNameSet(t *testing.T) {
+	ads := []adapters.Adapter{{Name: "a"}, {Name: "b"}}
+	set := adapters.NameSet(ads)
+	if _, ok := set["a"]; !ok {
+		t.Error("a missing")
+	}
+	if _, ok := set["b"]; !ok {
+		t.Error("b missing")
+	}
+	if _, ok := set["c"]; ok {
+		t.Error("c unexpectedly present")
+	}
+}
+
+func TestTarget_Writable_OnNewPath(t *testing.T) {
+	// A brand-new nested path under a writable tempdir must be
+	// considered writable (isWritable walks up to the first existing
+	// parent and probes it).
+	s := testutil.NewSandbox(t)
+	a := adapters.Adapter{
+		Name: "x",
+		InstallTargets: map[string]string{
+			"user": filepath.Join(s.Root, "new", "nested", "path"),
+		},
+		DefaultScope: "user",
+	}
+	tg, err := a.Target("user")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !tg.Writable {
+		t.Error("expected Writable=true under a tempdir")
+	}
+}
+
+func TestTarget_NotWritable_WhenParentIsFile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission semantics differ on windows")
+	}
+	s := testutil.NewSandbox(t)
+	blocker := filepath.Join(s.Root, "blocker")
+	if err := os.WriteFile(blocker, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	a := adapters.Adapter{
+		Name: "x",
+		InstallTargets: map[string]string{
+			"user": filepath.Join(blocker, "can-not-write"),
+		},
+		DefaultScope: "user",
+	}
+	tg, err := a.Target("user")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tg.Writable {
+		t.Error("expected Writable=false when parent is a file")
+	}
+}
+
+func TestLoad_ReturnsEmbeddedAdapters(t *testing.T) {
+	// Load() reads *.yaml embedded at build time. Every shipped adapter
+	// must parse, expose a non-empty Name, and a valid DefaultScope in
+	// InstallTargets.
+	ads, err := adapters.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(ads) == 0 {
+		t.Fatal("no embedded adapters")
+	}
+	for _, a := range ads {
+		if a.Name == "" {
+			t.Errorf("adapter missing name: %+v", a)
+		}
+		if a.DefaultScope != "" {
+			if _, ok := a.InstallTargets[a.DefaultScope]; !ok {
+				t.Errorf("adapter %q: DefaultScope %q has no install target",
+					a.Name, a.DefaultScope)
+			}
+		}
+	}
+}

--- a/cli/internal/adapters/fuzz_test.go
+++ b/cli/internal/adapters/fuzz_test.go
@@ -1,0 +1,31 @@
+package adapters_test
+
+import (
+	"testing"
+
+	"github.com/jjfantini/humblSKILLS/cli/internal/adapters"
+)
+
+// FuzzExpandPath ensures path expansion never panics on arbitrary
+// input — notably on strings containing null bytes, invalid UTF-8,
+// path traversal sequences, or nested $VAR references.
+func FuzzExpandPath(f *testing.F) {
+	seeds := []string{
+		"",
+		"~",
+		"~/foo",
+		"$HOME/bar",
+		"${HOME}/baz",
+		"/absolute/path",
+		"../escape",
+		"/$HOME/nested/$USER",
+		"~$SHELL", // weird: not a tilde-home pattern
+		"\x00null/bytes",
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+	f.Fuzz(func(t *testing.T, s string) {
+		_ = adapters.ExpandPath(s)
+	})
+}

--- a/cli/internal/env/dotenv_coverage_test.go
+++ b/cli/internal/env/dotenv_coverage_test.go
@@ -1,0 +1,197 @@
+package env_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jjfantini/humblSKILLS/cli/internal/env"
+)
+
+func TestLoadDotEnv_ReturnsZeroWhenNoFileFound(t *testing.T) {
+	// Point at a guaranteed-empty tempdir with no .env and a .git
+	// boundary at the top so the walk terminates quickly.
+	top := t.TempDir()
+	if err := os.Mkdir(filepath.Join(top, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	res, err := env.LoadDotEnv(top)
+	if err != nil {
+		t.Fatalf("LoadDotEnv: %v", err)
+	}
+	if res.Path != "" {
+		t.Errorf("expected empty path, got %q", res.Path)
+	}
+	if len(res.Loaded) != 0 || len(res.Kept) != 0 {
+		t.Errorf("expected nothing loaded: %+v", res)
+	}
+}
+
+func TestLoadDotEnv_EmptyStartDirUsesCwd(t *testing.T) {
+	// Running with startDir="" must fall back to os.Getwd. We don't
+	// necessarily have a .env under the dev's cwd, but the call must
+	// not error.
+	res, err := env.LoadDotEnv("")
+	if err != nil {
+		t.Fatalf("LoadDotEnv(\"\"): %v", err)
+	}
+	_ = res // only asserting no error
+}
+
+func TestLoadDotEnv_KeepsAlreadySetEnvVars(t *testing.T) {
+	root := t.TempDir()
+	if err := os.Mkdir(filepath.Join(root, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	envPath := filepath.Join(root, ".env")
+	if err := os.WriteFile(envPath, []byte("FOO=from_file\nBAR=from_file\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// FOO already set in env → env wins, FOO goes into Kept.
+	t.Setenv("FOO", "from_env")
+	// BAR unset → ends up in Loaded.
+	_ = os.Unsetenv("BAR")
+	t.Cleanup(func() { _ = os.Unsetenv("BAR") })
+
+	res, err := env.LoadDotEnv(root)
+	if err != nil {
+		t.Fatalf("LoadDotEnv: %v", err)
+	}
+	if !containsStr(res.Kept, "FOO") {
+		t.Errorf("FOO not in Kept: %+v", res)
+	}
+	if !containsStr(res.Loaded, "BAR") {
+		t.Errorf("BAR not in Loaded: %+v", res)
+	}
+	if os.Getenv("FOO") != "from_env" {
+		t.Error("FOO was overwritten; env must win")
+	}
+	if os.Getenv("BAR") != "from_file" {
+		t.Errorf("BAR not set to file value; got %q", os.Getenv("BAR"))
+	}
+}
+
+func TestLoadDotEnv_ParsesExportAndQuotesAndComments(t *testing.T) {
+	root := t.TempDir()
+	if err := os.Mkdir(filepath.Join(root, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := strings.Join([]string{
+		"# a comment line",
+		"",
+		"export QUOTED_DOUBLE=\"hello world\"",
+		"export QUOTED_SINGLE='single quoted'",
+		"NO_EQUALS_SIGN_HERE",
+		"=emptykey_should_skip",
+		"PLAIN=plainval",
+	}, "\n")
+	if err := os.WriteFile(filepath.Join(root, ".env"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, k := range []string{"QUOTED_DOUBLE", "QUOTED_SINGLE", "PLAIN"} {
+		_ = os.Unsetenv(k)
+		kk := k
+		t.Cleanup(func() { _ = os.Unsetenv(kk) })
+	}
+	res, err := env.LoadDotEnv(root)
+	if err != nil {
+		t.Fatalf("LoadDotEnv: %v", err)
+	}
+	if os.Getenv("QUOTED_DOUBLE") != "hello world" {
+		t.Errorf("QUOTED_DOUBLE = %q", os.Getenv("QUOTED_DOUBLE"))
+	}
+	if os.Getenv("QUOTED_SINGLE") != "single quoted" {
+		t.Errorf("QUOTED_SINGLE = %q", os.Getenv("QUOTED_SINGLE"))
+	}
+	if os.Getenv("PLAIN") != "plainval" {
+		t.Errorf("PLAIN = %q", os.Getenv("PLAIN"))
+	}
+	// Res.Path set to the .env we wrote.
+	if res.Path != filepath.Join(root, ".env") {
+		t.Errorf("Path = %q", res.Path)
+	}
+}
+
+func TestLoadDotEnv_FindsNearestUpwards(t *testing.T) {
+	root := t.TempDir()
+	// Layout:
+	//   root/ (has .git boundary AND .env)
+	//   root/a/b/c (walk starts here)
+	// Nearest .env is at root.
+	if err := os.Mkdir(filepath.Join(root, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".env"), []byte("UPWARDS=y\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	deep := filepath.Join(root, "a", "b", "c")
+	if err := os.MkdirAll(deep, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	_ = os.Unsetenv("UPWARDS")
+	t.Cleanup(func() { _ = os.Unsetenv("UPWARDS") })
+
+	res, err := env.LoadDotEnv(deep)
+	if err != nil {
+		t.Fatalf("LoadDotEnv: %v", err)
+	}
+	if res.Path != filepath.Join(root, ".env") {
+		t.Errorf("Path = %q, want root .env", res.Path)
+	}
+}
+
+func TestLoadDotEnv_StopsAtGitBoundary(t *testing.T) {
+	// We place a .env OUTSIDE the git boundary; the walk must stop at
+	// .git and not pick it up.
+	outer := t.TempDir()
+	if err := os.WriteFile(filepath.Join(outer, ".env"), []byte("SHOULD_NOT_LOAD=1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	inner := filepath.Join(outer, "repo")
+	if err := os.MkdirAll(filepath.Join(inner, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	_ = os.Unsetenv("SHOULD_NOT_LOAD")
+	res, err := env.LoadDotEnv(inner)
+	if err != nil {
+		t.Fatalf("LoadDotEnv: %v", err)
+	}
+	if res.Path != "" {
+		t.Errorf("git boundary not honored: %q", res.Path)
+	}
+	if got := os.Getenv("SHOULD_NOT_LOAD"); got != "" {
+		t.Errorf("SHOULD_NOT_LOAD leaked: %q", got)
+	}
+}
+
+func TestLoadDotEnv_ScannerErrorPropagatesOnHugeLine(t *testing.T) {
+	root := t.TempDir()
+	if err := os.Mkdir(filepath.Join(root, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// bufio.Scanner default MaxScanTokenSize is ~64K. Writing a single
+	// 128K line without a newline triggers bufio.ErrTooLong, which
+	// parse() must surface.
+	big := strings.Repeat("A=", 1)
+	big += strings.Repeat("x", 128*1024)
+	if err := os.WriteFile(filepath.Join(root, ".env"), []byte(big), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := env.LoadDotEnv(root)
+	if err == nil {
+		t.Fatal("expected scanner error on oversized line")
+	}
+}
+
+func containsStr(ss []string, want string) bool {
+	for _, s := range ss {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}

--- a/cli/internal/env/fuzz_test.go
+++ b/cli/internal/env/fuzz_test.go
@@ -1,0 +1,39 @@
+package env
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// FuzzParseDotEnv ensures the .env parser never panics on arbitrary
+// content. The parser is intentionally lenient — unknown lines are
+// skipped rather than errored — so we only guard the panic contract.
+func FuzzParseDotEnv(f *testing.F) {
+	seeds := []string{
+		"",
+		"FOO=bar\n",
+		"export FOO=\"quoted value\"\n",
+		"FOO='single'\n",
+		"# comment only\n",
+		"FOO\n",
+		"=empty-key\n",
+		"SPACES =  val  \n",
+		"FOO=\n",
+		"FOO=bar\nBAR=baz\n",
+		"weird line with no equals",
+		"\x00\x01\x02",
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+
+	f.Fuzz(func(t *testing.T, body string) {
+		dir := t.TempDir()
+		p := filepath.Join(dir, ".env")
+		if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+			t.Skip()
+		}
+		_, _ = parse(p)
+	})
+}

--- a/cli/internal/eval/brain/brain_coverage_test.go
+++ b/cli/internal/eval/brain/brain_coverage_test.go
@@ -1,0 +1,283 @@
+package brain_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jjfantini/humblSKILLS/cli/internal/eval/brain"
+)
+
+func writeBrainTree(t *testing.T, root string, files map[string]string) {
+	t.Helper()
+	for p, body := range files {
+		full := filepath.Join(root, filepath.FromSlash(p))
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func TestSnapshot_NonSmartSkillIsNoOp(t *testing.T) {
+	skill := t.TempDir()
+	// No references/ directory → not a smart skill.
+	if err := os.WriteFile(filepath.Join(skill, "SKILL.md"), []byte("# x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dst := filepath.Join(t.TempDir(), "snap")
+	if err := brain.Snapshot(skill, dst); err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	if _, err := os.Stat(dst); err == nil {
+		t.Error("snapshot should not create dst for non-smart skill")
+	}
+}
+
+func TestSnapshot_CopiesReferencesTree(t *testing.T) {
+	skill := t.TempDir()
+	writeBrainTree(t, skill, map[string]string{
+		"SKILL.md":                      "# s",
+		"references/patterns.md":        "### p1\nbody\n",
+		"references/wiki/concept/one.md": "# one",
+		"references/raw/note.txt":       "raw",
+	})
+	dst := filepath.Join(t.TempDir(), "snap")
+	if err := brain.Snapshot(skill, dst); err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dst, "patterns.md")); err != nil {
+		t.Error("patterns.md not copied")
+	}
+	if _, err := os.Stat(filepath.Join(dst, "wiki", "concept", "one.md")); err != nil {
+		t.Error("wiki tree not copied")
+	}
+}
+
+func TestRestore_ReplacesReferencesDir(t *testing.T) {
+	// Seed a snapshot with content.
+	snap := t.TempDir()
+	if err := os.WriteFile(filepath.Join(snap, "patterns.md"), []byte("### restored"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Skill with OLD content in references/ that should get replaced.
+	skill := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(skill, "references"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skill, "references", "stale.md"), []byte("OLD"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := brain.Restore(snap, skill); err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(skill, "references", "stale.md")); err == nil {
+		t.Error("stale.md should be gone after Restore")
+	}
+	got, err := os.ReadFile(filepath.Join(skill, "references", "patterns.md"))
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !strings.Contains(string(got), "restored") {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestDeriveFlat_ShapesMetaAndStripsWikiRaw(t *testing.T) {
+	src := t.TempDir()
+	writeBrainTree(t, src, map[string]string{
+		"SKILL.md":                       "# foo\n",
+		"scripts/lint.sh":                "#!/bin/sh",
+		"references/_brain.md":           "brain spec",
+		"references/_template.md":        "template",
+		"references/patterns.md":         "# patterns\n\n---\n\n### entry one\nbody\n",
+		"references/decisions.md":        "# decisions\n\nheader paragraph only\n\n### d1\nbody\n",
+		"references/log.md":              "# log\n\n[RUN 2026-01-01] stuff\n",
+		"references/_index.md":           "index",
+		"references/wiki/concept/one.md": "concept",
+		"references/raw/note.txt":        "raw content",
+	})
+
+	dst := filepath.Join(t.TempDir(), "flat")
+	got, err := brain.DeriveFlat(src, dst)
+	if err != nil {
+		t.Fatalf("DeriveFlat: %v", err)
+	}
+	if got != dst {
+		t.Errorf("got %q, want %q", got, dst)
+	}
+	// SKILL.md + scripts + structural brain files retained.
+	for _, keep := range []string{
+		"SKILL.md", "scripts/lint.sh", "references/_brain.md", "references/_template.md",
+	} {
+		if _, err := os.Stat(filepath.Join(dst, filepath.FromSlash(keep))); err != nil {
+			t.Errorf("missing %s after DeriveFlat", keep)
+		}
+	}
+	// wiki/ and raw/ must be absent.
+	if _, err := os.Stat(filepath.Join(dst, "references", "wiki")); err == nil {
+		t.Error("wiki/ should be stripped")
+	}
+	if _, err := os.Stat(filepath.Join(dst, "references", "raw")); err == nil {
+		t.Error("raw/ should be stripped")
+	}
+	// Shaped meta: patterns.md truncated at `---` and has the flat arm note.
+	if data, err := os.ReadFile(filepath.Join(dst, "references", "patterns.md")); err != nil {
+		t.Fatalf("patterns.md: %v", err)
+	} else if !strings.Contains(string(data), "no entries yet") {
+		t.Errorf("patterns.md not shaped: %q", data)
+	}
+}
+
+func TestSHA_DeterministicAndContentSensitive(t *testing.T) {
+	a := t.TempDir()
+	writeBrainTree(t, a, map[string]string{"a.md": "alpha", "dir/b.md": "beta"})
+	shaA, err := brain.SHA(a)
+	if err != nil {
+		t.Fatalf("SHA: %v", err)
+	}
+
+	b := t.TempDir()
+	writeBrainTree(t, b, map[string]string{"a.md": "alpha", "dir/b.md": "beta"})
+	shaB, err := brain.SHA(b)
+	if err != nil {
+		t.Fatalf("SHA: %v", err)
+	}
+	if shaA != shaB {
+		t.Errorf("identical trees produced different SHAs: %s vs %s", shaA, shaB)
+	}
+
+	c := t.TempDir()
+	writeBrainTree(t, c, map[string]string{"a.md": "ALPHA", "dir/b.md": "beta"})
+	shaC, _ := brain.SHA(c)
+	if shaC == shaA {
+		t.Error("different content produced same SHA")
+	}
+}
+
+func TestComputeGrowth_CountsDeltas(t *testing.T) {
+	before := t.TempDir()
+	writeBrainTree(t, before, map[string]string{
+		"patterns.md":           "### a\n### b\n",
+		"wiki/one.md":           "one",
+	})
+	after := t.TempDir()
+	writeBrainTree(t, after, map[string]string{
+		"patterns.md":           "### a\n### b\n### c\n",
+		"wiki/one.md":           "one",
+		"wiki/two.md":           "two",
+		"raw/note.md":           "raw",
+		"log.md":                "[RUN 2026-01-01] x\n[INGEST 2026-01-02] y\n",
+	})
+	g, err := brain.ComputeGrowth(before, after)
+	if err != nil {
+		t.Fatalf("ComputeGrowth: %v", err)
+	}
+	if g.PatternsEntries.Total != 3 || g.PatternsEntries.Delta != 1 {
+		t.Errorf("PatternsEntries = %+v, want {3,1}", g.PatternsEntries)
+	}
+	if g.WikiConcepts.Total != 2 || g.WikiConcepts.Delta != 1 {
+		t.Errorf("WikiConcepts = %+v", g.WikiConcepts)
+	}
+	if g.RawFiles.Total != 1 || g.RawFiles.Delta != 1 {
+		t.Errorf("RawFiles = %+v", g.RawFiles)
+	}
+	if g.LogEntries.Total != 2 {
+		t.Errorf("LogEntries.Total = %d, want 2", g.LogEntries.Total)
+	}
+}
+
+func TestComputeGrowth_EmptyBeforeIsFreshBrain(t *testing.T) {
+	after := t.TempDir()
+	writeBrainTree(t, after, map[string]string{
+		"wiki/one.md": "one",
+	})
+	g, err := brain.ComputeGrowth("", after)
+	if err != nil {
+		t.Fatalf("ComputeGrowth: %v", err)
+	}
+	if g.WikiConcepts.Total != 1 || g.WikiConcepts.Delta != 1 {
+		t.Errorf("WikiConcepts = %+v", g.WikiConcepts)
+	}
+}
+
+func TestComputeGrowth_NonExistentBeforeDirTreatedAsEmpty(t *testing.T) {
+	after := t.TempDir()
+	writeBrainTree(t, after, map[string]string{"patterns.md": "### a\n"})
+	g, err := brain.ComputeGrowth(filepath.Join(t.TempDir(), "ghost"), after)
+	if err != nil {
+		t.Fatalf("ComputeGrowth: %v", err)
+	}
+	if g.PatternsEntries.Total != 1 {
+		t.Errorf("got %d", g.PatternsEntries.Total)
+	}
+}
+
+func TestReadsFromBrain_CountsReferencesHits(t *testing.T) {
+	transcript := []byte(`
+Read: references/patterns.md
+Invoked tool: Read on references/decisions.md
+write: references/log.md (non-read, should not count)
+Read: somewhere/else (no references, should not count)
+read references/_brain.md
+`)
+	got := brain.ReadsFromBrain(transcript)
+	// Three lines contain both "references/" and "Read"/"read".
+	if got < 3 {
+		t.Errorf("got %d, want >=3", got)
+	}
+}
+
+func TestReadsFromBrain_EmptyTranscript(t *testing.T) {
+	if got := brain.ReadsFromBrain(nil); got != 0 {
+		t.Errorf("got %d", got)
+	}
+	if got := brain.ReadsFromBrain([]byte("")); got != 0 {
+		t.Errorf("got %d", got)
+	}
+}
+
+func TestGrowth_MarshalJSON_RoundTrips(t *testing.T) {
+	g := &brain.Growth{
+		WikiConcepts: brain.Pair{Total: 5, Delta: 1},
+		LogEntries:   brain.Pair{Total: 10, Delta: 2},
+	}
+	data, err := json.Marshal(g)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var round brain.Growth
+	if err := json.Unmarshal(data, &round); err != nil {
+		t.Fatal(err)
+	}
+	if round.WikiConcepts.Total != 5 || round.LogEntries.Delta != 2 {
+		t.Errorf("round-trip lost data: %+v", round)
+	}
+}
+
+func TestShape_Behavior(t *testing.T) {
+	// Direct shape is unexported; exercise it via DeriveFlat on
+	// crafted input that hits each of its three branches.
+	src := t.TempDir()
+	writeBrainTree(t, src, map[string]string{
+		"SKILL.md":              "# s\n",
+		"references/_brain.md":  "x",
+		// Only first paragraph retained (no --- separator).
+		"references/patterns.md": "first para\n\nsecond para should vanish",
+		// Too short to shape — whole body retained.
+		"references/log.md":      "only",
+	})
+	dst := filepath.Join(t.TempDir(), "flat")
+	if _, err := brain.DeriveFlat(src, dst); err != nil {
+		t.Fatalf("DeriveFlat: %v", err)
+	}
+	p, _ := os.ReadFile(filepath.Join(dst, "references", "patterns.md"))
+	if strings.Contains(string(p), "second para") {
+		t.Errorf("second paragraph should be dropped: %q", p)
+	}
+}

--- a/cli/internal/eval/evalruntime/evalruntime_test.go
+++ b/cli/internal/eval/evalruntime/evalruntime_test.go
@@ -1,0 +1,115 @@
+package evalruntime_test
+
+import (
+	"context"
+	"sort"
+	"testing"
+
+	"github.com/jjfantini/humblSKILLS/cli/internal/eval/evalruntime"
+	"github.com/jjfantini/humblSKILLS/cli/internal/secrets"
+	"github.com/jjfantini/humblSKILLS/cli/internal/testutil"
+)
+
+// DefaultRegistry is a small wiring function. These tests protect the
+// contract callers rely on: every runner lines up in a stable order,
+// every name is unique, and lookups / auto-pick fail cleanly when no
+// runner is available (common on headless CI).
+func TestDefaultRegistry_ReturnsSixRunnersInStableOrder(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	testutil.UseFakeKeyring(t)
+
+	store, err := secrets.NewStore(s.SecretsPath)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+
+	reg := evalruntime.DefaultRegistry(store)
+	if reg == nil {
+		t.Fatal("DefaultRegistry returned nil")
+	}
+
+	runners := reg.All()
+	if len(runners) != 6 {
+		t.Fatalf("got %d runners, want 6", len(runners))
+	}
+
+	// Order matters: CLI runners first (lowest friction), then API
+	// runners, then mock. AutoPick walks this list in order.
+	wantOrder := []string{"claudecode", "cursor-agent", "codex", "anthropic-api", "openai-api", "mock"}
+	for i, want := range wantOrder {
+		if got := runners[i].Name(); got != want {
+			t.Errorf("position %d: got %q, want %q", i, got, want)
+		}
+	}
+}
+
+func TestDefaultRegistry_NamesAreUnique(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	testutil.UseFakeKeyring(t)
+	store, _ := secrets.NewStore(s.SecretsPath)
+
+	reg := evalruntime.DefaultRegistry(store)
+	seen := map[string]bool{}
+	for _, r := range reg.All() {
+		if seen[r.Name()] {
+			t.Errorf("duplicate runner name: %q", r.Name())
+		}
+		seen[r.Name()] = true
+	}
+}
+
+func TestDefaultRegistry_NamesReturnsSorted(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	testutil.UseFakeKeyring(t)
+	store, _ := secrets.NewStore(s.SecretsPath)
+
+	reg := evalruntime.DefaultRegistry(store)
+	names := reg.Names()
+	sorted := append([]string(nil), names...)
+	sort.Strings(sorted)
+	for i := range names {
+		if names[i] != sorted[i] {
+			t.Errorf("Names() not sorted: %v", names)
+			break
+		}
+	}
+}
+
+func TestDefaultRegistry_ByNameLookup(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	testutil.UseFakeKeyring(t)
+	store, _ := secrets.NewStore(s.SecretsPath)
+
+	reg := evalruntime.DefaultRegistry(store)
+
+	// The mock runner is always available and has no external deps,
+	// so it's the safe target for a positive lookup test.
+	r, err := reg.ByName("mock")
+	if err != nil {
+		t.Fatalf("ByName(mock): %v", err)
+	}
+	if r.Name() != "mock" {
+		t.Errorf("ByName returned %q", r.Name())
+	}
+
+	if _, err := reg.ByName("nonexistent"); err == nil {
+		t.Error("ByName(nonexistent) should error")
+	}
+}
+
+func TestDefaultRegistry_MockRunnerIsAlwaysAvailable(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	testutil.UseFakeKeyring(t)
+	store, _ := secrets.NewStore(s.SecretsPath)
+
+	reg := evalruntime.DefaultRegistry(store)
+	// Mock needs no external deps - its DoctorCheck must report Available
+	// so CI boxes with no agent tooling can still run evals end-to-end.
+	mock, err := reg.ByName("mock")
+	if err != nil {
+		t.Fatalf("ByName(mock): %v", err)
+	}
+	if !mock.DoctorCheck(context.Background()).Available {
+		t.Error("mock runner DoctorCheck reported Available=false")
+	}
+}

--- a/cli/internal/eval/grader/anthropicjudge/anthropicjudge.go
+++ b/cli/internal/eval/grader/anthropicjudge/anthropicjudge.go
@@ -35,11 +35,18 @@ type Judge struct {
 // New returns a Judge using the given API key. An empty model falls back
 // to DefaultModel.
 func New(apiKey, model string) *Judge {
+	return NewWithOptions(model, option.WithAPIKey(apiKey))
+}
+
+// NewWithOptions builds a Judge with arbitrary SDK options. Useful in
+// tests that want to pin the base URL at an httptest.Server or inject
+// a custom http.Client with timeout semantics.
+func NewWithOptions(model string, opts ...option.RequestOption) *Judge {
 	if model == "" {
 		model = DefaultModel
 	}
 	return &Judge{
-		client: anthropic.NewClient(option.WithAPIKey(apiKey)),
+		client: anthropic.NewClient(opts...),
 		model:  model,
 	}
 }

--- a/cli/internal/eval/grader/anthropicjudge/anthropicjudge_test.go
+++ b/cli/internal/eval/grader/anthropicjudge/anthropicjudge_test.go
@@ -1,17 +1,317 @@
 package anthropicjudge
 
-import "testing"
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/anthropics/anthropic-sdk-go/option"
+
+	"github.com/jjfantini/humblSKILLS/cli/internal/eval/scenarios"
+)
 
 func TestExtractJSONObject(t *testing.T) {
-	tests := []struct{ in, want string }{
-		{`{"a":1}`, `{"a":1}`},
-		{"```json\n{\"a\":1}\n```", `{"a":1}`},
-		{"some preamble {\"a\":1} trailing", `{"a":1}`},
-		{"{\"outer\":{\"inner\":1}}", `{"outer":{"inner":1}}`},
+	tests := []struct {
+		name, in, want string
+	}{
+		{"plain", `{"a":1}`, `{"a":1}`},
+		{"fenced_json", "```json\n{\"a\":1}\n```", `{"a":1}`},
+		{"preamble", "some preamble {\"a\":1} trailing", `{"a":1}`},
+		{"nested", `{"outer":{"inner":1}}`, `{"outer":{"inner":1}}`},
+		{"only_fence_no_brace", "```json```", ""},
+		{"empty_after_trim", "", ""},
+		{"whitespace_only", "   ", ""},
+		{"multiline_preamble_and_trailing_prose",
+			"Here is the result:\n{\n  \"expectations\": [1,2]\n}\nHope this helps.",
+			"{\n  \"expectations\": [1,2]\n}",
+		},
+		{"nothing_braced_passes_through", "not json at all", "not json at all"},
 	}
 	for _, tc := range tests {
-		if got := extractJSONObject(tc.in); got != tc.want {
-			t.Errorf("extractJSONObject(%q) = %q, want %q", tc.in, got, tc.want)
-		}
+		t.Run(tc.name, func(t *testing.T) {
+			if got := extractJSONObject(tc.in); got != tc.want {
+				t.Errorf("extractJSONObject(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestTruncate(t *testing.T) {
+	if got := truncate("hello", 10); got != "hello" {
+		t.Errorf("short string truncated: %q", got)
+	}
+	if got := truncate("hello world", 5); got != "hello..." {
+		t.Errorf("long truncate = %q", got)
+	}
+	if got := truncate("", 5); got != "" {
+		t.Errorf("empty truncate = %q", got)
+	}
+}
+
+func TestNew_DefaultsToDefaultModelWhenEmpty(t *testing.T) {
+	j := New("sk-unused", "")
+	if j.model != DefaultModel {
+		t.Errorf("model = %q, want %q", j.model, DefaultModel)
+	}
+
+	j2 := New("sk-unused", "claude-haiku-4-5")
+	if j2.model != "claude-haiku-4-5" {
+		t.Errorf("model = %q, want override", j2.model)
+	}
+}
+
+func TestGrade_EmptyAssertionsSkipsAPICall(t *testing.T) {
+	// No server set up — an API call would hang. Grade must short-circuit.
+	j := New("sk-unused", "")
+	got, err := j.Grade(context.Background(), "prompt", []byte("transcript"), "outputs", nil)
+	if err != nil {
+		t.Errorf("err = %v", err)
+	}
+	if got != nil {
+		t.Errorf("result = %v, want nil", got)
+	}
+}
+
+// ---- mock-server-backed tests ---------------------------------------------
+
+// messagesServer is a tiny Anthropic Messages API mock. It captures the
+// last request for assertions and returns whatever body the test set.
+type messagesServer struct {
+	t *testing.T
+
+	mu   sync.Mutex
+	body string
+	code int
+
+	lastRequest []byte
+}
+
+func newMessagesServer(t *testing.T) (*messagesServer, *httptest.Server) {
+	t.Helper()
+	m := &messagesServer{t: t, code: 200}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		buf, _ := io.ReadAll(r.Body)
+		m.mu.Lock()
+		m.lastRequest = buf
+		body := m.body
+		code := m.code
+		m.mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(code)
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+	return m, srv
+}
+
+func (m *messagesServer) reply(body string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.body = body
+	m.code = 200
+}
+
+func (m *messagesServer) replyStatus(code int, body string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.body = body
+	m.code = code
+}
+
+func (m *messagesServer) lastSent() []byte {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]byte(nil), m.lastRequest...)
+}
+
+// okResponse builds a minimal Messages API response whose text content
+// is `text`. The SDK parses any valid Messages shape; this is the
+// smallest one that exercises the "text block" branch in Grade.
+func okResponse(text string) string {
+	resp := map[string]any{
+		"id":            "msg_test_0001",
+		"type":          "message",
+		"role":          "assistant",
+		"model":         "claude-opus-4-5",
+		"stop_reason":   "end_turn",
+		"stop_sequence": nil,
+		"usage":         map[string]int{"input_tokens": 1, "output_tokens": 1},
+		"content": []map[string]any{
+			{"type": "text", "text": text},
+		},
+	}
+	b, _ := json.Marshal(resp)
+	return string(b)
+}
+
+func newTestJudge(t *testing.T, baseURL string) *Judge {
+	t.Helper()
+	return NewWithOptions("claude-test-model",
+		option.WithAPIKey("sk-test"),
+		option.WithBaseURL(baseURL),
+	)
+}
+
+func TestGrade_HappyPath_ParsesJSONAndPreservesOrder(t *testing.T) {
+	m, srv := newMessagesServer(t)
+	j := newTestJudge(t, srv.URL)
+
+	assertions := []scenarios.Assertion{
+		{Text: "The agent explained the bug"},
+		{Text: "The agent proposed a fix"},
+	}
+	// Model paraphrases the text; Grade must overwrite with the
+	// original assertion text so downstream aggregation still keys
+	// cleanly.
+	judgeReply := `{"expectations":[
+		{"text":"paraphrased version of bug claim","passed":true,"evidence":"quoted: 'root cause is a nil deref'"},
+		{"text":"paraphrased fix claim","passed":false,"evidence":"no fix shown"}
+	]}`
+	m.reply(okResponse(judgeReply))
+
+	got, err := j.Grade(context.Background(), "explain the bug", []byte("transcript body"), "outputs body", assertions)
+	if err != nil {
+		t.Fatalf("Grade: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("results = %d", len(got))
+	}
+	if got[0].Text != assertions[0].Text || got[1].Text != assertions[1].Text {
+		t.Errorf("text not restored to original: got [%q, %q]", got[0].Text, got[1].Text)
+	}
+	if !got[0].Passed || got[1].Passed {
+		t.Errorf("passed flags wrong: %+v", got)
+	}
+	if got[0].Evidence == "" || got[1].Evidence == "" {
+		t.Errorf("evidence empty: %+v", got)
+	}
+
+	// Verify request shape: contains assertion numbering and the eval prompt.
+	req := string(m.lastSent())
+	if !strings.Contains(req, `"model":"claude-test-model"`) {
+		t.Errorf("request missing model field: %s", truncate(req, 200))
+	}
+	if !strings.Contains(req, "1. The agent explained the bug") {
+		t.Errorf("request missing first assertion: %s", truncate(req, 300))
+	}
+	if !strings.Contains(req, "2. The agent proposed a fix") {
+		t.Errorf("request missing second assertion")
+	}
+	if !strings.Contains(req, "explain the bug") {
+		t.Errorf("request missing eval prompt")
+	}
+}
+
+func TestGrade_CountMismatchErrors(t *testing.T) {
+	m, srv := newMessagesServer(t)
+	j := newTestJudge(t, srv.URL)
+
+	m.reply(okResponse(`{"expectations":[{"text":"a","passed":true,"evidence":"x"}]}`))
+
+	assertions := []scenarios.Assertion{
+		{Text: "first"},
+		{Text: "second"},
+	}
+	_, err := j.Grade(context.Background(), "p", []byte("t"), "o", assertions)
+	if err == nil {
+		t.Fatal("expected error when judge returns wrong expectation count")
+	}
+	if !strings.Contains(err.Error(), "returned 1 expectations, want 2") {
+		t.Errorf("err = %v", err)
+	}
+}
+
+func TestGrade_MalformedJSONSurfaceTruncatedReply(t *testing.T) {
+	m, srv := newMessagesServer(t)
+	j := newTestJudge(t, srv.URL)
+
+	// Content block has text that is not valid JSON at all.
+	m.reply(okResponse("this is not JSON and has no braces"))
+
+	_, err := j.Grade(context.Background(), "p", []byte("t"), "o",
+		[]scenarios.Assertion{{Text: "a"}})
+	if err == nil {
+		t.Fatal("expected parse error")
+	}
+	if !strings.Contains(err.Error(), "parse judge reply") {
+		t.Errorf("err doesn't mention parsing: %v", err)
+	}
+}
+
+func TestGrade_FencedReplyIsUnwrapped(t *testing.T) {
+	m, srv := newMessagesServer(t)
+	j := newTestJudge(t, srv.URL)
+
+	wrapped := "```json\n" +
+		`{"expectations":[{"text":"a","passed":true,"evidence":"e"}]}` +
+		"\n```"
+	m.reply(okResponse(wrapped))
+
+	got, err := j.Grade(context.Background(), "p", []byte("t"), "o",
+		[]scenarios.Assertion{{Text: "a"}})
+	if err != nil {
+		t.Fatalf("Grade: %v", err)
+	}
+	if len(got) != 1 || !got[0].Passed {
+		t.Errorf("result = %+v", got)
+	}
+}
+
+func TestGrade_TranscriptAndOutputsAreTruncated(t *testing.T) {
+	m, srv := newMessagesServer(t)
+	j := newTestJudge(t, srv.URL)
+
+	m.reply(okResponse(`{"expectations":[{"text":"a","passed":true,"evidence":"e"}]}`))
+
+	big := strings.Repeat("A", 60*1024)     // 60 KiB, well above the 40 KiB cap
+	bigOut := strings.Repeat("B", 60*1024)
+
+	_, err := j.Grade(context.Background(), "p", []byte(big), bigOut,
+		[]scenarios.Assertion{{Text: "a"}})
+	if err != nil {
+		t.Fatalf("Grade: %v", err)
+	}
+	req := m.lastSent()
+	// Transcript payload capped by the 40 KiB limit + truncation marker.
+	if !strings.Contains(string(req), "transcript truncated") {
+		t.Errorf("transcript not truncated in request")
+	}
+	if !strings.Contains(string(req), "outputs truncated") {
+		t.Errorf("outputs not truncated in request")
+	}
+}
+
+func TestGrade_APIErrorPropagates(t *testing.T) {
+	m, srv := newMessagesServer(t)
+	j := newTestJudge(t, srv.URL)
+
+	m.replyStatus(500, `{"type":"error","error":{"type":"api_error","message":"boom"}}`)
+
+	_, err := j.Grade(context.Background(), "p", []byte("t"), "o",
+		[]scenarios.Assertion{{Text: "a"}})
+	if err == nil {
+		t.Fatal("expected API error to propagate")
+	}
+	if !strings.Contains(err.Error(), "grader.messages.new") {
+		t.Errorf("err missing context: %v", err)
+	}
+}
+
+func TestGrade_ContextCancellationPropagates(t *testing.T) {
+	_, srv := newMessagesServer(t)
+	j := newTestJudge(t, srv.URL)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already done before Grade is called
+
+	_, err := j.Grade(ctx, "p", []byte("t"), "o",
+		[]scenarios.Assertion{{Text: "a"}})
+	if err == nil {
+		t.Fatal("expected error from cancelled context")
 	}
 }

--- a/cli/internal/eval/runner/anthropicapi/anthropicapi.go
+++ b/cli/internal/eval/runner/anthropicapi/anthropicapi.go
@@ -37,11 +37,21 @@ var defaultPricing = &runner.Pricing{
 // Runner is the anthropic-api backend.
 type Runner struct {
 	Store secrets.Store
+	// extraOptions is appended to the SDK client options after the API
+	// key is resolved. Tests can inject option.WithBaseURL to point at
+	// an httptest server; production callers leave it empty.
+	extraOptions []option.RequestOption
 }
 
 // New returns a Runner. Caller passes the secrets store (the CLI always
 // hands over the same one; tests can substitute an in-memory stub).
 func New(store secrets.Store) *Runner { return &Runner{Store: store} }
+
+// NewWithOptions returns a Runner with extra SDK options (e.g. base URL
+// override for tests). Production code should use New.
+func NewWithOptions(store secrets.Store, opts ...option.RequestOption) *Runner {
+	return &Runner{Store: store, extraOptions: opts}
+}
 
 func (r *Runner) Name() string { return "anthropic-api" }
 
@@ -87,7 +97,8 @@ func (r *Runner) Execute(ctx context.Context, req runner.Request) (*runner.Resul
 	if err != nil || key == "" {
 		return &runner.Result{Err: fmt.Errorf("no API key")}, fmt.Errorf("no API key")
 	}
-	client := anthropic.NewClient(option.WithAPIKey(key))
+	opts := append([]option.RequestOption{option.WithAPIKey(key)}, r.extraOptions...)
+	client := anthropic.NewClient(opts...)
 
 	scratch, err := os.MkdirTemp(filepath.Dir(req.OutputDir), "scratch-")
 	if err != nil {

--- a/cli/internal/eval/runner/anthropicapi/anthropicapi.go
+++ b/cli/internal/eval/runner/anthropicapi/anthropicapi.go
@@ -282,8 +282,10 @@ func collectIntoOutput(scratch, outDir string) ([]string, error) {
 			return err
 		}
 		// Skip the inputs/ subtree - that's what we staged in.
+		// ToSlash normalises path separators so this works on Windows
+		// where filepath.Rel returns "inputs\x.txt".
 		rel, _ := filepath.Rel(scratch, p)
-		if strings.HasPrefix(rel, "inputs/") {
+		if strings.HasPrefix(filepath.ToSlash(rel), "inputs/") {
 			return nil
 		}
 		dst := filepath.Join(outDir, rel)

--- a/cli/internal/eval/runner/anthropicapi/anthropicapi_test.go
+++ b/cli/internal/eval/runner/anthropicapi/anthropicapi_test.go
@@ -1,0 +1,322 @@
+package anthropicapi
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/anthropics/anthropic-sdk-go/option"
+
+	"github.com/jjfantini/humblSKILLS/cli/internal/eval/runner"
+	"github.com/jjfantini/humblSKILLS/cli/internal/secrets"
+	"github.com/jjfantini/humblSKILLS/cli/internal/testutil"
+)
+
+// fakeStore is a minimal in-memory secrets.Store.
+type fakeStore struct {
+	keys   map[string]string
+	absent bool
+}
+
+func (f *fakeStore) Get(p string) (string, secrets.Source, error) {
+	if f.absent {
+		return "", secrets.SourceAbsent, nil
+	}
+	v, ok := f.keys[p]
+	if !ok || v == "" {
+		return "", secrets.SourceAbsent, nil
+	}
+	return v, secrets.SourceEnv, nil
+}
+func (f *fakeStore) Set(p, v string) (secrets.Source, error) {
+	if f.keys == nil {
+		f.keys = map[string]string{}
+	}
+	f.keys[p] = v
+	return secrets.SourceEnv, nil
+}
+func (f *fakeStore) Delete(p string) error { delete(f.keys, p); return nil }
+
+func TestName_AndCapabilities(t *testing.T) {
+	r := New(&fakeStore{keys: map[string]string{"anthropic": "sk"}})
+	if r.Name() != "anthropic-api" {
+		t.Errorf("Name = %q", r.Name())
+	}
+	caps := r.Capabilities()
+	if caps.DefaultModel != DefaultModel {
+		t.Errorf("DefaultModel = %q", caps.DefaultModel)
+	}
+	if caps.Pricing == nil {
+		t.Error("Pricing nil")
+	}
+}
+
+func TestDoctorCheck_NilStore(t *testing.T) {
+	r := New(nil)
+	got := r.DoctorCheck(context.Background())
+	if got.Available {
+		t.Error("expected Available=false with nil store")
+	}
+}
+
+func TestDoctorCheck_AbsentKey(t *testing.T) {
+	r := New(&fakeStore{absent: true})
+	got := r.DoctorCheck(context.Background())
+	if got.Available {
+		t.Error("expected Available=false when key absent")
+	}
+	if !strings.Contains(got.Reason, "ANTHROPIC_API_KEY") {
+		t.Errorf("Reason = %q", got.Reason)
+	}
+}
+
+func TestDoctorCheck_KeyPresent(t *testing.T) {
+	r := New(&fakeStore{keys: map[string]string{"anthropic": "sk-test"}})
+	got := r.DoctorCheck(context.Background())
+	if !got.Available {
+		t.Error("expected Available=true with key set")
+	}
+}
+
+func TestExecute_WithoutAPIKey(t *testing.T) {
+	r := New(&fakeStore{absent: true})
+	_, err := r.Execute(context.Background(), runner.Request{
+		Prompt: "p", OutputDir: t.TempDir(),
+	})
+	if err == nil {
+		t.Fatal("expected error when key absent")
+	}
+}
+
+// messagesServer is a scriptable /messages endpoint.
+type messagesServer struct {
+	mu       sync.Mutex
+	responses []string
+	nextIdx  int
+	calls    int
+}
+
+func (m *messagesServer) handle(w http.ResponseWriter, r *http.Request) {
+	_, _ = io.ReadAll(r.Body)
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.calls++
+	idx := m.nextIdx
+	if idx >= len(m.responses) {
+		idx = len(m.responses) - 1
+	}
+	m.nextIdx++
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = w.Write([]byte(m.responses[idx]))
+}
+
+func endTurnResponse(text string) string {
+	resp := map[string]any{
+		"id": "msg_1", "type": "message", "role": "assistant",
+		"model": "claude-test", "stop_reason": "end_turn",
+		"usage":   map[string]int{"input_tokens": 10, "output_tokens": 5},
+		"content": []map[string]any{{"type": "text", "text": text}},
+	}
+	b, _ := json.Marshal(resp)
+	return string(b)
+}
+
+func toolUseResponse(toolName, toolID string, args map[string]any) string {
+	argBytes, _ := json.Marshal(args)
+	resp := map[string]any{
+		"id": "msg_tu", "type": "message", "role": "assistant",
+		"model": "claude-test", "stop_reason": "tool_use",
+		"usage": map[string]int{"input_tokens": 12, "output_tokens": 3},
+		"content": []map[string]any{
+			{"type": "tool_use", "id": toolID, "name": toolName, "input": json.RawMessage(argBytes)},
+		},
+	}
+	b, _ := json.Marshal(resp)
+	return string(b)
+}
+
+func TestExecute_HappyPath_EndsOnEndTurn(t *testing.T) {
+	testutil.NewSandbox(t)
+
+	ms := &messagesServer{
+		responses: []string{endTurnResponse("hello from the model")},
+	}
+	srv := httptest.NewServer(http.HandlerFunc(ms.handle))
+	defer srv.Close()
+
+	r := NewWithOptions(&fakeStore{keys: map[string]string{"anthropic": "sk-test"}},
+		option.WithBaseURL(srv.URL))
+
+	outDir := filepath.Join(t.TempDir(), "out")
+	res, err := r.Execute(context.Background(), runner.Request{
+		Prompt: "hi", OutputDir: outDir,
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.Contains(string(res.Transcript), "hello from the model") {
+		t.Errorf("transcript missing text:\n%s", res.Transcript)
+	}
+	if res.PromptTokens != 10 || res.CompletionTokens != 5 {
+		t.Errorf("tokens: %+v", res)
+	}
+	if ms.calls != 1 {
+		t.Errorf("calls = %d, want 1", ms.calls)
+	}
+}
+
+func TestExecute_ToolLoop(t *testing.T) {
+	testutil.NewSandbox(t)
+
+	// Response 1: tool_use Read foo.txt. Response 2: end_turn with summary.
+	ms := &messagesServer{
+		responses: []string{
+			toolUseResponse("Read", "t_1", map[string]any{"path": "hello.txt"}),
+			endTurnResponse("read complete"),
+		},
+	}
+	srv := httptest.NewServer(http.HandlerFunc(ms.handle))
+	defer srv.Close()
+
+	// Pre-create the file the model will "read" inside the sandbox that
+	// Execute creates. Since we can't inject the scratch path, stage the
+	// file via InputFiles so it lands at scratch/inputs/hello.txt.
+	// Instead, write our tool_use with the correct path.
+	ms.responses[0] = toolUseResponse("Read", "t_1", map[string]any{"path": "inputs/hello.txt"})
+
+	workDir := t.TempDir()
+	input := filepath.Join(workDir, "hello.txt")
+	if err := os.WriteFile(input, []byte("hello content"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	r := NewWithOptions(&fakeStore{keys: map[string]string{"anthropic": "sk-test"}},
+		option.WithBaseURL(srv.URL))
+
+	outDir := filepath.Join(t.TempDir(), "out")
+	res, err := r.Execute(context.Background(), runner.Request{
+		Prompt:     "read the file",
+		OutputDir:  outDir,
+		InputFiles: []string{input},
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if ms.calls != 2 {
+		t.Errorf("calls = %d, want 2 (tool + end_turn)", ms.calls)
+	}
+	if res.ToolCalls["Read"] != 1 {
+		t.Errorf("Read tool count = %d", res.ToolCalls["Read"])
+	}
+	// Sum of tokens across both rounds.
+	if res.PromptTokens != 22 || res.CompletionTokens != 8 {
+		t.Errorf("tokens = (%d, %d)", res.PromptTokens, res.CompletionTokens)
+	}
+}
+
+func TestExecute_ApiErrorSurfacedOnResultErr(t *testing.T) {
+	testutil.NewSandbox(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(500)
+		_, _ = io.WriteString(w, `{"type":"error","error":{"type":"api_error","message":"boom"}}`)
+	}))
+	defer srv.Close()
+
+	r := NewWithOptions(&fakeStore{keys: map[string]string{"anthropic": "sk-test"}},
+		option.WithBaseURL(srv.URL))
+
+	res, err := r.Execute(context.Background(), runner.Request{
+		Prompt: "p", OutputDir: filepath.Join(t.TempDir(), "out"),
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if res.Err == nil {
+		t.Error("expected res.Err on API failure")
+	}
+}
+
+func TestBuildSystem_PrependsSkillBody(t *testing.T) {
+	skill := t.TempDir()
+	if err := os.WriteFile(filepath.Join(skill, "SKILL.md"), []byte("# spec"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	blocks := buildSystem(runner.Request{SkillDir: skill})
+	if len(blocks) != 1 {
+		t.Fatalf("got %d blocks", len(blocks))
+	}
+	if !strings.Contains(blocks[0].Text, "# spec") {
+		t.Errorf("skill body not included:\n%s", blocks[0].Text)
+	}
+}
+
+func TestBuildSystem_ReturnsNilWhenNothing(t *testing.T) {
+	blocks := buildSystem(runner.Request{})
+	if blocks != nil {
+		t.Errorf("got %+v, want nil", blocks)
+	}
+}
+
+func TestBuildSystem_SystemPromptTakesPrecedenceOverMissingSkill(t *testing.T) {
+	blocks := buildSystem(runner.Request{SystemPrompt: "be terse"})
+	if len(blocks) != 1 || blocks[0].Text != "be terse" {
+		t.Errorf("got %+v", blocks)
+	}
+}
+
+func TestToolDefs_ReturnsFive(t *testing.T) {
+	defs := toolDefs()
+	if len(defs) != 5 {
+		t.Errorf("got %d, want 5", len(defs))
+	}
+}
+
+func TestOneLine_Truncates(t *testing.T) {
+	long := strings.Repeat("a", 200)
+	if got := oneLine(long, 20); len(got) > 30 || !strings.HasSuffix(got, "...") {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestStageInputs_CopiesFiles(t *testing.T) {
+	work := t.TempDir()
+	src := filepath.Join(work, "in.txt")
+	if err := os.WriteFile(src, []byte("hi"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	scratch := t.TempDir()
+	err := stageInputs(runner.Request{InputFiles: []string{src}}, scratch)
+	if err != nil {
+		t.Fatalf("stageInputs: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(scratch, "inputs", "in.txt")); err != nil {
+		t.Errorf("file not staged: %v", err)
+	}
+}
+
+func TestCollectIntoOutput_SkipsInputs(t *testing.T) {
+	scratch := t.TempDir()
+	_ = os.MkdirAll(filepath.Join(scratch, "inputs"), 0o755)
+	_ = os.WriteFile(filepath.Join(scratch, "inputs", "x.txt"), []byte("x"), 0o644)
+	_ = os.WriteFile(filepath.Join(scratch, "out.md"), []byte("body"), 0o644)
+
+	out := t.TempDir()
+	files, err := collectIntoOutput(scratch, out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) != 1 || files[0] != "out.md" {
+		t.Errorf("got %v", files)
+	}
+	if _, err := os.Stat(filepath.Join(out, "inputs", "x.txt")); err == nil {
+		t.Error("inputs/ should not be copied to output")
+	}
+}

--- a/cli/internal/eval/runner/claudecode/claudecode_test.go
+++ b/cli/internal/eval/runner/claudecode/claudecode_test.go
@@ -1,0 +1,130 @@
+package claudecode
+
+import (
+	"os"
+	"testing"
+
+	"github.com/jjfantini/humblSKILLS/cli/internal/eval/runner"
+)
+
+func TestNew_ReturnsClaudecodeRunner(t *testing.T) {
+	r := New()
+	if r.Name() != "claudecode" {
+		t.Errorf("Name = %q", r.Name())
+	}
+	if r.Capabilities().DefaultModel != "claude-opus-4-7" {
+		t.Errorf("DefaultModel = %q", r.Capabilities().DefaultModel)
+	}
+}
+
+func TestArgs_IncludesPromptAndOutputFormat(t *testing.T) {
+	r := New()
+	args := r.D.Args(runner.Request{Prompt: "do a thing"}, "/scratch", "/scratch/prompt.txt")
+	haveP, haveFormat := false, false
+	for i, a := range args {
+		if a == "-p" && i+1 < len(args) && args[i+1] == "do a thing" {
+			haveP = true
+		}
+		if a == "--output-format" && i+1 < len(args) && args[i+1] == "stream-json" {
+			haveFormat = true
+		}
+	}
+	if !haveP {
+		t.Errorf("missing -p: %v", args)
+	}
+	if !haveFormat {
+		t.Errorf("missing --output-format stream-json: %v", args)
+	}
+}
+
+func TestArgs_SkillDirAddsSkillFlag(t *testing.T) {
+	r := New()
+	args := r.D.Args(runner.Request{Prompt: "p", SkillDir: "/x"}, "/s", "/s/p")
+	hasSkill := false
+	for i, a := range args {
+		if a == "--skill-dir" && i+1 < len(args) && args[i+1] == "skill" {
+			hasSkill = true
+		}
+	}
+	if !hasSkill {
+		t.Errorf("missing --skill-dir: %v", args)
+	}
+}
+
+func TestArgs_ModelFlag(t *testing.T) {
+	r := New()
+	args := r.D.Args(runner.Request{Prompt: "p", Model: "claude-sonnet-4-6"}, "/s", "/s/p")
+	has := false
+	for i, a := range args {
+		if a == "--model" && i+1 < len(args) && args[i+1] == "claude-sonnet-4-6" {
+			has = true
+		}
+	}
+	if !has {
+		t.Errorf("missing --model: %v", args)
+	}
+}
+
+func TestArgs_ExtraArgsFromEnv(t *testing.T) {
+	t.Setenv("CLAUDE_CODE_EXTRA_ARGS", "--foo bar --baz")
+	defer os.Unsetenv("CLAUDE_CODE_EXTRA_ARGS")
+
+	r := New()
+	args := r.D.Args(runner.Request{Prompt: "p"}, "/s", "/s/p")
+	found := 0
+	for _, a := range args {
+		if a == "--foo" || a == "bar" || a == "--baz" {
+			found++
+		}
+	}
+	if found != 3 {
+		t.Errorf("extra args missing: got %v", args)
+	}
+}
+
+func TestParseEvent_ToolUse(t *testing.T) {
+	ev := parseEvent([]byte(`{"type":"tool_use","name":"Read"}`))
+	if ev.ToolName != "Read" {
+		t.Errorf("ToolName = %q", ev.ToolName)
+	}
+}
+
+func TestParseEvent_Usage(t *testing.T) {
+	ev := parseEvent([]byte(`{"type":"result","usage":{"input_tokens":123,"output_tokens":456}}`))
+	if ev.PromptTokensDelta != 123 {
+		t.Errorf("PromptTokensDelta = %d", ev.PromptTokensDelta)
+	}
+	if ev.CompletionTokensDelta != 456 {
+		t.Errorf("CompletionTokensDelta = %d", ev.CompletionTokensDelta)
+	}
+}
+
+func TestParseEvent_IgnoresNonJSON(t *testing.T) {
+	ev := parseEvent([]byte("garbage line"))
+	if ev.ToolName != "" || ev.PromptTokensDelta != 0 {
+		t.Errorf("non-JSON produced event: %+v", ev)
+	}
+}
+
+func TestParseEvent_IgnoresUnknownType(t *testing.T) {
+	// type="user_input" isn't recognized — event stays zero.
+	ev := parseEvent([]byte(`{"type":"user_input","text":"hi"}`))
+	if ev.ToolName != "" {
+		t.Errorf("unexpected ToolName: %q", ev.ToolName)
+	}
+}
+
+func TestIntField_HandlesFloatAndInt(t *testing.T) {
+	if got := intField(map[string]any{"x": float64(42)}, "x"); got != 42 {
+		t.Errorf("float64: got %d", got)
+	}
+	if got := intField(map[string]any{"x": 7}, "x"); got != 7 {
+		t.Errorf("int: got %d", got)
+	}
+	if got := intField(map[string]any{}, "missing"); got != 0 {
+		t.Errorf("missing: got %d", got)
+	}
+	if got := intField(map[string]any{"x": "bogus"}, "x"); got != 0 {
+		t.Errorf("non-numeric: got %d", got)
+	}
+}

--- a/cli/internal/eval/runner/clitool/clitool_test.go
+++ b/cli/internal/eval/runner/clitool/clitool_test.go
@@ -1,0 +1,320 @@
+package clitool_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jjfantini/humblSKILLS/cli/internal/eval/runner"
+	"github.com/jjfantini/humblSKILLS/cli/internal/eval/runner/clitool"
+)
+
+// installStubBinary writes a POSIX shell script to a fresh temp dir,
+// prepends that dir to $PATH, and returns the binary name. Tests use
+// this to exercise Execute without needing a real agent CLI.
+func installStubBinary(t *testing.T, name, body string) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("stub binary uses POSIX shell")
+	}
+	dir := t.TempDir()
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, []byte("#!/bin/sh\n"+body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	old := os.Getenv("PATH")
+	_ = os.Setenv("PATH", dir+string(os.PathListSeparator)+old)
+	t.Cleanup(func() { _ = os.Setenv("PATH", old) })
+}
+
+func TestParseJSONEvent_SkipsNonJSON(t *testing.T) {
+	got, err := clitool.ParseJSONEvent([]byte("not json"))
+	if err != nil {
+		t.Errorf("should return nil err on non-json, got %v", err)
+	}
+	if got != nil {
+		t.Errorf("should return nil map, got %v", got)
+	}
+}
+
+func TestParseJSONEvent_Empty(t *testing.T) {
+	got, err := clitool.ParseJSONEvent([]byte("  "))
+	if err != nil || got != nil {
+		t.Errorf("empty line returned got=%v err=%v", got, err)
+	}
+}
+
+func TestParseJSONEvent_ParsesObject(t *testing.T) {
+	got, err := clitool.ParseJSONEvent([]byte(`{"k":"v"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got["k"] != "v" {
+		t.Errorf("got %v", got)
+	}
+}
+
+func TestParseJSONEvent_MalformedObject(t *testing.T) {
+	_, err := clitool.ParseJSONEvent([]byte("{bad json"))
+	if err == nil {
+		t.Error("expected error for malformed JSON")
+	}
+}
+
+func TestRunner_NameAndCapabilities(t *testing.T) {
+	r := clitool.New(clitool.Driver{
+		Name:         "test-cli",
+		Binary:       "nonexistent-binary",
+		DefaultModel: "model-x",
+	})
+	if r.Name() != "test-cli" {
+		t.Errorf("Name = %q", r.Name())
+	}
+	caps := r.Capabilities()
+	if caps.DefaultModel != "model-x" {
+		t.Errorf("DefaultModel = %q", caps.DefaultModel)
+	}
+	if len(caps.SupportsTools) == 0 {
+		t.Error("SupportsTools empty")
+	}
+}
+
+func TestDoctorCheck_BinaryMissing(t *testing.T) {
+	r := clitool.New(clitool.Driver{
+		Name:        "test-cli",
+		Binary:      "definitely-not-a-real-binary-xyz123",
+		RequiresKey: "anthropic",
+	})
+	got := r.DoctorCheck(context.Background())
+	if got.Available {
+		t.Error("expected Available=false")
+	}
+	if !strings.Contains(got.Reason, "PATH") {
+		t.Errorf("Reason = %q", got.Reason)
+	}
+	if got.RequiresKey != "anthropic" {
+		t.Errorf("RequiresKey = %q", got.RequiresKey)
+	}
+}
+
+func TestDoctorCheck_BinaryPresent(t *testing.T) {
+	installStubBinary(t, "fake-cli", "echo 'fake-cli 1.2.3'\n")
+	r := clitool.New(clitool.Driver{
+		Name:        "test-cli",
+		Binary:      "fake-cli",
+		VersionArgs: []string{"--version"},
+	})
+	got := r.DoctorCheck(context.Background())
+	if !got.Available {
+		t.Error("expected Available=true")
+	}
+	if !strings.Contains(got.Version, "fake-cli") {
+		t.Errorf("Version = %q", got.Version)
+	}
+}
+
+func TestExecute_StreamsJSONAndCapturesTokens(t *testing.T) {
+	// Stub emits two JSON lines — a tool_use then a usage event. The
+	// Driver's ParseEvent extracts token counts from the latter.
+	installStubBinary(t, "stub-agent", `
+cat <<'JSON'
+{"type":"tool_use","name":"Read"}
+{"type":"result","usage":{"input_tokens":10,"output_tokens":20}}
+JSON
+`)
+
+	r := clitool.New(clitool.Driver{
+		Name:   "stub-agent",
+		Binary: "stub-agent",
+		Args:   func(req runner.Request, scratchDir, promptPath string) []string { return []string{} },
+		ParseEvent: func(line []byte) clitool.Event {
+			m, _ := clitool.ParseJSONEvent(line)
+			if m == nil {
+				return clitool.Event{}
+			}
+			var ev clitool.Event
+			if t, _ := m["type"].(string); t == "tool_use" {
+				ev.ToolName, _ = m["name"].(string)
+			}
+			if usage, ok := m["usage"].(map[string]any); ok {
+				if pt, ok := usage["input_tokens"].(float64); ok {
+					ev.PromptTokensDelta = int(pt)
+				}
+				if ct, ok := usage["output_tokens"].(float64); ok {
+					ev.CompletionTokensDelta = int(ct)
+				}
+			}
+			return ev
+		},
+	})
+
+	outDir := filepath.Join(t.TempDir(), "out")
+	res, err := r.Execute(context.Background(), runner.Request{
+		Prompt:    "do a thing",
+		OutputDir: outDir,
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if res.PromptTokens != 10 || res.CompletionTokens != 20 {
+		t.Errorf("tokens = (%d, %d)", res.PromptTokens, res.CompletionTokens)
+	}
+	if res.TotalTokens != 30 {
+		t.Errorf("total tokens = %d, want 30", res.TotalTokens)
+	}
+	if res.ToolCalls["Read"] != 1 {
+		t.Errorf("Read count = %d", res.ToolCalls["Read"])
+	}
+	if res.DurationMs < 0 {
+		t.Errorf("DurationMs = %d", res.DurationMs)
+	}
+	if !strings.Contains(string(res.Transcript), "tool_use") {
+		t.Errorf("transcript missing events:\n%s", res.Transcript)
+	}
+}
+
+func TestExecute_BinaryFailureSurfacesOnResultErr(t *testing.T) {
+	installStubBinary(t, "stub-fail", "echo 'boom' >&2; exit 1\n")
+	r := clitool.New(clitool.Driver{
+		Name:   "stub-fail",
+		Binary: "stub-fail",
+		Args:   func(req runner.Request, _, _ string) []string { return []string{} },
+	})
+	res, err := r.Execute(context.Background(), runner.Request{
+		Prompt:    "p",
+		OutputDir: t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("Execute should not return infra error on binary failure: %v", err)
+	}
+	if res.Err == nil {
+		t.Error("expected res.Err to be set when binary exits non-zero")
+	}
+	if res.Err != nil && !strings.Contains(res.Err.Error(), "boom") {
+		t.Errorf("err missing stderr: %v", res.Err)
+	}
+}
+
+func TestExecute_StdinFedToBinary(t *testing.T) {
+	// Stub echoes stdin back. Driver supplies a Stdin function; the
+	// Result.Transcript should contain that text.
+	installStubBinary(t, "stub-stdin", "cat\n")
+	r := clitool.New(clitool.Driver{
+		Name:   "stub-stdin",
+		Binary: "stub-stdin",
+		Args:   func(req runner.Request, _, _ string) []string { return []string{} },
+		Stdin:  func(req runner.Request) []byte { return []byte("piped-content\n") },
+	})
+	res, err := r.Execute(context.Background(), runner.Request{
+		Prompt:    "p",
+		OutputDir: t.TempDir(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(res.Transcript), "piped-content") {
+		t.Errorf("transcript missing stdin echo:\n%s", res.Transcript)
+	}
+}
+
+func TestExecute_InputFilesStagedIntoScratch(t *testing.T) {
+	// Stub writes every file it sees in inputs/ into outputs/.
+	installStubBinary(t, "stub-inputs", `
+mkdir -p outputs
+for f in inputs/*; do
+  cp "$f" "outputs/seen-$(basename "$f")"
+done
+`)
+
+	workDir := t.TempDir()
+	in := filepath.Join(workDir, "data.txt")
+	if err := os.WriteFile(in, []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	r := clitool.New(clitool.Driver{
+		Name:   "stub-inputs",
+		Binary: "stub-inputs",
+		Args:   func(req runner.Request, _, _ string) []string { return []string{} },
+	})
+	outDir := filepath.Join(t.TempDir(), "outputs")
+	res, err := r.Execute(context.Background(), runner.Request{
+		Prompt:     "p",
+		InputFiles: []string{in},
+		OutputDir:  outDir,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// outputs/seen-data.txt was produced — clitool flattens outputs/
+	// into OutputDir.
+	found := false
+	for _, f := range res.OutputFiles {
+		if strings.HasSuffix(f, "seen-data.txt") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("input was not staged; OutputFiles=%v", res.OutputFiles)
+	}
+}
+
+func TestExecute_TimeoutHonored(t *testing.T) {
+	// exec -c's `sleep` runs as a child of the shell; on some platforms
+	// SIGKILL to the shell doesn't cascade to sleep, so we use an
+	// `exec sleep` pattern so the process-group receives the signal.
+	installStubBinary(t, "stub-sleep", "exec sleep 10\n")
+	r := clitool.New(clitool.Driver{
+		Name:   "stub-sleep",
+		Binary: "stub-sleep",
+		Args:   func(req runner.Request, _, _ string) []string { return []string{} },
+	})
+	start := time.Now()
+	_, err := r.Execute(context.Background(), runner.Request{
+		Prompt:    "p",
+		OutputDir: t.TempDir(),
+		Timeout:   300 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("Execute err: %v", err)
+	}
+	// Must be well under the 10s sleep to prove the timeout fired.
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Errorf("Timeout not honored, took %v", elapsed)
+	}
+}
+
+func TestExecute_SkillDirStagedAndBrainSyncedBack(t *testing.T) {
+	// Seed a skill with references/log.md that the "agent" will append
+	// to. Verify the persistent skillDir has the appended content.
+	skillDir := t.TempDir()
+	refs := filepath.Join(skillDir, "references")
+	_ = os.MkdirAll(refs, 0o755)
+	logPath := filepath.Join(refs, "log.md")
+	_ = os.WriteFile(logPath, []byte("initial\n"), 0o644)
+
+	installStubBinary(t, "stub-brain", `
+echo "agent-added" >> skill/references/log.md
+`)
+
+	r := clitool.New(clitool.Driver{
+		Name:   "stub-brain",
+		Binary: "stub-brain",
+		Args:   func(req runner.Request, _, _ string) []string { return []string{} },
+	})
+	if _, err := r.Execute(context.Background(), runner.Request{
+		Prompt:    "p",
+		SkillDir:  skillDir,
+		OutputDir: t.TempDir(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := os.ReadFile(logPath)
+	if !strings.Contains(string(got), "agent-added") {
+		t.Errorf("brain sync failed; log.md = %q", got)
+	}
+}

--- a/cli/internal/eval/runner/codex/codex_test.go
+++ b/cli/internal/eval/runner/codex/codex_test.go
@@ -1,0 +1,116 @@
+package codex
+
+import (
+	"os"
+	"testing"
+
+	"github.com/jjfantini/humblSKILLS/cli/internal/eval/runner"
+)
+
+func TestNew(t *testing.T) {
+	r := New()
+	if r.Name() != "codex" {
+		t.Errorf("Name = %q", r.Name())
+	}
+	if r.Capabilities().DefaultModel != "gpt-5-codex" {
+		t.Errorf("DefaultModel = %q", r.Capabilities().DefaultModel)
+	}
+}
+
+func TestArgs_ExecAndJSONFlag(t *testing.T) {
+	r := New()
+	args := r.D.Args(runner.Request{Prompt: "do a thing"}, "/s", "/s/p")
+	if len(args) < 3 {
+		t.Fatalf("args too short: %v", args)
+	}
+	if args[0] != "exec" {
+		t.Errorf("first arg = %q, want exec", args[0])
+	}
+	if args[1] != "do a thing" {
+		t.Errorf("second arg = %q", args[1])
+	}
+	hasJSON := false
+	for _, a := range args {
+		if a == "--json" {
+			hasJSON = true
+		}
+	}
+	if !hasJSON {
+		t.Errorf("missing --json: %v", args)
+	}
+}
+
+func TestArgs_ModelFlag(t *testing.T) {
+	r := New()
+	args := r.D.Args(runner.Request{Prompt: "p", Model: "gpt-5"}, "/s", "/s/p")
+	has := false
+	for i, a := range args {
+		if a == "--model" && i+1 < len(args) && args[i+1] == "gpt-5" {
+			has = true
+		}
+	}
+	if !has {
+		t.Errorf("missing --model: %v", args)
+	}
+}
+
+func TestArgs_ExtraArgsFromEnv(t *testing.T) {
+	t.Setenv("CODEX_EXTRA_ARGS", "--zap")
+	defer os.Unsetenv("CODEX_EXTRA_ARGS")
+
+	r := New()
+	args := r.D.Args(runner.Request{Prompt: "p"}, "/s", "/s/p")
+	has := false
+	for _, a := range args {
+		if a == "--zap" {
+			has = true
+		}
+	}
+	if !has {
+		t.Errorf("missing --zap: %v", args)
+	}
+}
+
+func TestParseEvent_ToolCall(t *testing.T) {
+	// Codex emits "response.output_item.added" with `type` containing "tool_call".
+	ev := parseEvent([]byte(`{"type":"response.tool_call.delta","name":"Read"}`))
+	if ev.ToolName != "Read" {
+		t.Errorf("got %q", ev.ToolName)
+	}
+}
+
+func TestParseEvent_Usage(t *testing.T) {
+	ev := parseEvent([]byte(`{"usage":{"input_tokens":11,"output_tokens":22,"total_tokens":33}}`))
+	if ev.PromptTokensDelta != 11 {
+		t.Errorf("PromptTokensDelta = %d", ev.PromptTokensDelta)
+	}
+	if ev.CompletionTokensDelta != 22 {
+		t.Errorf("CompletionTokensDelta = %d", ev.CompletionTokensDelta)
+	}
+	if ev.TotalTokensDelta != 33 {
+		t.Errorf("TotalTokensDelta = %d", ev.TotalTokensDelta)
+	}
+}
+
+func TestParseEvent_NonJSONIgnored(t *testing.T) {
+	ev := parseEvent([]byte("not json"))
+	if ev.ToolName != "" || ev.PromptTokensDelta != 0 {
+		t.Errorf("non-json produced: %+v", ev)
+	}
+}
+
+func TestIntField(t *testing.T) {
+	m := map[string]any{"a": float64(5), "b": 3, "c": "bogus"}
+	if got := intField(m, "a"); got != 5 {
+		t.Errorf("a = %d", got)
+	}
+	if got := intField(m, "b"); got != 3 {
+		t.Errorf("b = %d", got)
+	}
+	if got := intField(m, "c"); got != 0 {
+		t.Errorf("c = %d", got)
+	}
+	if got := intField(m, "missing"); got != 0 {
+		t.Errorf("missing = %d", got)
+	}
+}

--- a/cli/internal/eval/runner/cursor/cursor_test.go
+++ b/cli/internal/eval/runner/cursor/cursor_test.go
@@ -1,0 +1,138 @@
+package cursor
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/jjfantini/humblSKILLS/cli/internal/eval/runner"
+)
+
+func TestNew(t *testing.T) {
+	r := New()
+	if r.Name() != "cursor-agent" {
+		t.Errorf("Name = %q", r.Name())
+	}
+	if r.Capabilities().DefaultModel != "sonnet-4" {
+		t.Errorf("DefaultModel = %q", r.Capabilities().DefaultModel)
+	}
+}
+
+func TestArgs_Contains_P_F_OutputFormat(t *testing.T) {
+	r := New()
+	args := r.D.Args(runner.Request{Prompt: "hi"}, "/s", "/s/p")
+	hasP, hasF, hasFormat := false, false, false
+	for _, a := range args {
+		switch a {
+		case "-p":
+			hasP = true
+		case "-f":
+			hasF = true
+		case "stream-json":
+			hasFormat = true
+		}
+	}
+	if !hasP || !hasF || !hasFormat {
+		t.Errorf("missing flag(s): %v", args)
+	}
+}
+
+func TestBuildPrompt_PrependsSkillPreamble(t *testing.T) {
+	got := buildPrompt(runner.Request{Prompt: "base", SkillDir: "/x"})
+	if !strings.Contains(got, "./skill/SKILL.md") {
+		t.Errorf("missing skill preamble:\n%s", got)
+	}
+	if !strings.HasSuffix(got, "base") {
+		t.Errorf("base prompt missing/relocated:\n%s", got)
+	}
+}
+
+func TestBuildPrompt_NoPreambleWithoutSkill(t *testing.T) {
+	got := buildPrompt(runner.Request{Prompt: "base"})
+	if strings.Contains(got, "SKILL.md") {
+		t.Errorf("unexpected preamble:\n%s", got)
+	}
+}
+
+func TestBuildPrompt_MentionsInputsWhenPresent(t *testing.T) {
+	got := buildPrompt(runner.Request{Prompt: "p", InputFiles: []string{"/a", "/b"}})
+	if !strings.Contains(got, "./inputs/") {
+		t.Errorf("missing inputs mention:\n%s", got)
+	}
+}
+
+func TestArgs_ModelFlag(t *testing.T) {
+	r := New()
+	args := r.D.Args(runner.Request{Prompt: "p", Model: "gpt-5"}, "/s", "/s/p")
+	has := false
+	for i, a := range args {
+		if a == "--model" && i+1 < len(args) && args[i+1] == "gpt-5" {
+			has = true
+		}
+	}
+	if !has {
+		t.Errorf("missing --model: %v", args)
+	}
+}
+
+func TestArgs_ExtraArgsFromEnv(t *testing.T) {
+	t.Setenv("CURSOR_AGENT_EXTRA_ARGS", "--vendor-flag")
+	defer os.Unsetenv("CURSOR_AGENT_EXTRA_ARGS")
+
+	r := New()
+	args := r.D.Args(runner.Request{Prompt: "p"}, "/s", "/s/p")
+	has := false
+	for _, a := range args {
+		if a == "--vendor-flag" {
+			has = true
+		}
+	}
+	if !has {
+		t.Errorf("missing extra arg: %v", args)
+	}
+}
+
+func TestParseEvent_ToolCallWithToolKey(t *testing.T) {
+	ev := parseEvent([]byte(`{"type":"tool_call","tool":"Read"}`))
+	if ev.ToolName != "Read" {
+		t.Errorf("got %q", ev.ToolName)
+	}
+}
+
+func TestParseEvent_ToolCallWithNameKey(t *testing.T) {
+	ev := parseEvent([]byte(`{"type":"tool_use","name":"Write"}`))
+	if ev.ToolName != "Write" {
+		t.Errorf("got %q", ev.ToolName)
+	}
+}
+
+func TestParseEvent_CamelCaseUsage(t *testing.T) {
+	ev := parseEvent([]byte(`{"usage":{"inputTokens":10,"outputTokens":20,"totalTokens":30}}`))
+	if ev.PromptTokensDelta != 10 || ev.CompletionTokensDelta != 20 || ev.TotalTokensDelta != 30 {
+		t.Errorf("camelCase not parsed: %+v", ev)
+	}
+}
+
+func TestParseEvent_SnakeCaseUsage(t *testing.T) {
+	ev := parseEvent([]byte(`{"usage":{"input_tokens":5,"output_tokens":6,"total_tokens":11}}`))
+	if ev.PromptTokensDelta != 5 || ev.CompletionTokensDelta != 6 || ev.TotalTokensDelta != 11 {
+		t.Errorf("snake_case not parsed: %+v", ev)
+	}
+}
+
+func TestParseEvent_IgnoresGarbage(t *testing.T) {
+	ev := parseEvent([]byte("not json"))
+	if ev.ToolName != "" || ev.PromptTokensDelta != 0 {
+		t.Errorf("garbage produced event: %+v", ev)
+	}
+}
+
+func TestFirstNonZeroInt(t *testing.T) {
+	m := map[string]any{"a": float64(0), "b": float64(5), "c": float64(0)}
+	if got := firstNonZeroInt(m, "a", "b", "c"); got != 5 {
+		t.Errorf("got %d", got)
+	}
+	if got := firstNonZeroInt(m, "a", "c"); got != 0 {
+		t.Errorf("all-zero: got %d", got)
+	}
+}

--- a/cli/internal/eval/runner/mock/mock_test.go
+++ b/cli/internal/eval/runner/mock/mock_test.go
@@ -1,0 +1,143 @@
+package mock_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jjfantini/humblSKILLS/cli/internal/eval/runner"
+	"github.com/jjfantini/humblSKILLS/cli/internal/eval/runner/mock"
+)
+
+func TestName(t *testing.T) {
+	if got := mock.New().Name(); got != "mock" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestCapabilities_ReportsDefaultModel(t *testing.T) {
+	caps := mock.New().Capabilities()
+	if caps.DefaultModel == "" {
+		t.Error("DefaultModel empty")
+	}
+	if len(caps.SupportsTools) == 0 {
+		t.Error("SupportsTools empty")
+	}
+	if !caps.SupportsParallel {
+		t.Error("SupportsParallel should be true")
+	}
+}
+
+func TestDoctorCheck_AlwaysAvailable(t *testing.T) {
+	got := mock.New().DoctorCheck(context.Background())
+	if !got.Available {
+		t.Error("mock should always be available")
+	}
+}
+
+func TestExecute_WritesStubOutputAndTranscript(t *testing.T) {
+	outDir := t.TempDir()
+	r := mock.New()
+	req := runner.Request{
+		Prompt:    "hello world",
+		OutputDir: outDir,
+	}
+	res, err := r.Execute(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if res.TotalTokens <= 0 {
+		t.Errorf("TotalTokens = %d", res.TotalTokens)
+	}
+	if len(res.Transcript) == 0 {
+		t.Error("empty transcript")
+	}
+	if len(res.OutputFiles) != 1 || res.OutputFiles[0] != "mock-output.txt" {
+		t.Errorf("OutputFiles = %v", res.OutputFiles)
+	}
+	// File written to OutputDir.
+	body, err := os.ReadFile(filepath.Join(outDir, "mock-output.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(body), "hello world") {
+		t.Errorf("output body missing prompt: %s", body)
+	}
+	// ToolCalls populated.
+	if res.ToolCalls["Write"] != 1 {
+		t.Errorf("Write tool count = %d", res.ToolCalls["Write"])
+	}
+	if res.ToolCalls["Bash"] != 1 {
+		t.Errorf("Bash tool count = %d", res.ToolCalls["Bash"])
+	}
+	// metrics.json sidecar written.
+	if _, err := os.Stat(filepath.Join(outDir, "metrics.json")); err != nil {
+		t.Errorf("metrics.json missing: %v", err)
+	}
+}
+
+func TestExecute_InputFilesBumpReadCount(t *testing.T) {
+	workDir := t.TempDir()
+	file1 := filepath.Join(workDir, "in1.md")
+	file2 := filepath.Join(workDir, "in2.md")
+	for _, p := range []string{file1, file2} {
+		_ = os.WriteFile(p, []byte("content"), 0o644)
+	}
+
+	r := mock.New()
+	res, err := r.Execute(context.Background(), runner.Request{
+		Prompt:     "p",
+		OutputDir:  t.TempDir(),
+		InputFiles: []string{file1, file2},
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if res.ToolCalls["Read"] != 2 {
+		t.Errorf("Read tool count = %d, want 2", res.ToolCalls["Read"])
+	}
+}
+
+func TestExecute_SmartSkillBoostsBrainReadsAndReducesCompletion(t *testing.T) {
+	skillDir := t.TempDir()
+	refsDir := filepath.Join(skillDir, "references")
+	if err := os.MkdirAll(refsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Give mock all four brain files so it reports max brain_reads.
+	for _, name := range []string{"_index.md", "patterns.md", "decisions.md", "log.md"} {
+		_ = os.WriteFile(filepath.Join(refsDir, name), []byte("x"), 0o644)
+	}
+
+	withSkill, err := mock.New().Execute(context.Background(), runner.Request{
+		Prompt:    "p",
+		SkillDir:  skillDir,
+		OutputDir: t.TempDir(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	withoutSkill, err := mock.New().Execute(context.Background(), runner.Request{
+		Prompt:    "p",
+		OutputDir: t.TempDir(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// With brain: prompt tokens larger, completion tokens smaller.
+	if withSkill.PromptTokens <= withoutSkill.PromptTokens {
+		t.Errorf("smart skill should use more prompt tokens: with=%d without=%d",
+			withSkill.PromptTokens, withoutSkill.PromptTokens)
+	}
+	if withSkill.CompletionTokens >= withoutSkill.CompletionTokens {
+		t.Errorf("smart skill should use fewer completion tokens: with=%d without=%d",
+			withSkill.CompletionTokens, withoutSkill.CompletionTokens)
+	}
+	// Read tool count must include brain reads.
+	if withSkill.ToolCalls["Read"] < 4 {
+		t.Errorf("Read count %d doesn't include brain reads", withSkill.ToolCalls["Read"])
+	}
+}

--- a/cli/internal/eval/runner/openaiapi/openaiapi.go
+++ b/cli/internal/eval/runner/openaiapi/openaiapi.go
@@ -32,11 +32,18 @@ var defaultPricing = &runner.Pricing{
 
 // Runner is the openai-api backend.
 type Runner struct {
-	Store secrets.Store
+	Store        secrets.Store
+	extraOptions []option.RequestOption
 }
 
 // New returns a Runner.
 func New(store secrets.Store) *Runner { return &Runner{Store: store} }
+
+// NewWithOptions returns a Runner with extra SDK options (tests inject
+// option.WithBaseURL to point at an httptest server).
+func NewWithOptions(store secrets.Store, opts ...option.RequestOption) *Runner {
+	return &Runner{Store: store, extraOptions: opts}
+}
 
 func (r *Runner) Name() string { return "openai-api" }
 
@@ -80,7 +87,8 @@ func (r *Runner) Execute(ctx context.Context, req runner.Request) (*runner.Resul
 	if err != nil || key == "" {
 		return &runner.Result{Err: fmt.Errorf("no API key")}, fmt.Errorf("no API key")
 	}
-	client := openai.NewClient(option.WithAPIKey(key))
+	opts := append([]option.RequestOption{option.WithAPIKey(key)}, r.extraOptions...)
+	client := openai.NewClient(opts...)
 
 	scratch, err := os.MkdirTemp(filepath.Dir(req.OutputDir), "scratch-")
 	if err != nil {

--- a/cli/internal/eval/runner/openaiapi/openaiapi.go
+++ b/cli/internal/eval/runner/openaiapi/openaiapi.go
@@ -234,7 +234,9 @@ func collectIntoOutput(scratch, outDir string) ([]string, error) {
 			return err
 		}
 		rel, _ := filepath.Rel(scratch, p)
-		if strings.HasPrefix(rel, "inputs/") {
+		// ToSlash makes the prefix check work on Windows, where
+		// filepath.Rel returns paths with backslashes.
+		if strings.HasPrefix(filepath.ToSlash(rel), "inputs/") {
 			return nil
 		}
 		dst := filepath.Join(outDir, rel)

--- a/cli/internal/eval/runner/openaiapi/openaiapi_test.go
+++ b/cli/internal/eval/runner/openaiapi/openaiapi_test.go
@@ -1,0 +1,283 @@
+package openaiapi
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/openai/openai-go/option"
+
+	"github.com/jjfantini/humblSKILLS/cli/internal/eval/runner"
+	"github.com/jjfantini/humblSKILLS/cli/internal/secrets"
+	"github.com/jjfantini/humblSKILLS/cli/internal/testutil"
+)
+
+type fakeStore struct {
+	keys   map[string]string
+	absent bool
+}
+
+func (f *fakeStore) Get(p string) (string, secrets.Source, error) {
+	if f.absent {
+		return "", secrets.SourceAbsent, nil
+	}
+	v, ok := f.keys[p]
+	if !ok || v == "" {
+		return "", secrets.SourceAbsent, nil
+	}
+	return v, secrets.SourceEnv, nil
+}
+func (f *fakeStore) Set(p, v string) (secrets.Source, error) {
+	if f.keys == nil {
+		f.keys = map[string]string{}
+	}
+	f.keys[p] = v
+	return secrets.SourceEnv, nil
+}
+func (f *fakeStore) Delete(p string) error { delete(f.keys, p); return nil }
+
+func TestName_AndCapabilities(t *testing.T) {
+	r := New(&fakeStore{keys: map[string]string{"openai": "sk"}})
+	if r.Name() != "openai-api" {
+		t.Errorf("Name = %q", r.Name())
+	}
+	if r.Capabilities().DefaultModel != DefaultModel {
+		t.Errorf("DefaultModel = %q", r.Capabilities().DefaultModel)
+	}
+}
+
+func TestDoctorCheck_NilStore(t *testing.T) {
+	r := New(nil)
+	if r.DoctorCheck(context.Background()).Available {
+		t.Error("expected Available=false for nil store")
+	}
+}
+
+func TestDoctorCheck_AbsentKey(t *testing.T) {
+	r := New(&fakeStore{absent: true})
+	got := r.DoctorCheck(context.Background())
+	if got.Available {
+		t.Error("expected Available=false")
+	}
+	if !strings.Contains(got.Reason, "OPENAI_API_KEY") {
+		t.Errorf("Reason = %q", got.Reason)
+	}
+}
+
+func TestDoctorCheck_KeyPresent(t *testing.T) {
+	r := New(&fakeStore{keys: map[string]string{"openai": "sk"}})
+	if !r.DoctorCheck(context.Background()).Available {
+		t.Error("expected Available=true")
+	}
+}
+
+func TestExecute_NoKeyErrors(t *testing.T) {
+	r := New(&fakeStore{absent: true})
+	_, err := r.Execute(context.Background(), runner.Request{
+		Prompt: "p", OutputDir: t.TempDir(),
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+// ---- httptest-based tests ------------------------------------------------
+
+type chatServer struct {
+	mu        sync.Mutex
+	responses []string
+	nextIdx   int
+	calls     int
+}
+
+func (c *chatServer) handle(w http.ResponseWriter, r *http.Request) {
+	_, _ = io.ReadAll(r.Body)
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.calls++
+	idx := c.nextIdx
+	if idx >= len(c.responses) {
+		idx = len(c.responses) - 1
+	}
+	c.nextIdx++
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = w.Write([]byte(c.responses[idx]))
+}
+
+func chatResponse(content string, toolCalls []map[string]any) string {
+	msg := map[string]any{"role": "assistant"}
+	if content != "" {
+		msg["content"] = content
+	}
+	if len(toolCalls) > 0 {
+		msg["tool_calls"] = toolCalls
+	}
+	resp := map[string]any{
+		"id":      "cmpl_1",
+		"object":  "chat.completion",
+		"created": 1,
+		"model":   "gpt-test",
+		"choices": []map[string]any{
+			{"index": 0, "message": msg, "finish_reason": "stop"},
+		},
+		"usage": map[string]int{"prompt_tokens": 7, "completion_tokens": 3, "total_tokens": 10},
+	}
+	b, _ := json.Marshal(resp)
+	return string(b)
+}
+
+func TestExecute_EndsOnStop(t *testing.T) {
+	testutil.NewSandbox(t)
+
+	cs := &chatServer{responses: []string{chatResponse("done!", nil)}}
+	srv := httptest.NewServer(http.HandlerFunc(cs.handle))
+	defer srv.Close()
+
+	r := NewWithOptions(&fakeStore{keys: map[string]string{"openai": "sk"}},
+		option.WithBaseURL(srv.URL))
+
+	res, err := r.Execute(context.Background(), runner.Request{
+		Prompt: "p", OutputDir: filepath.Join(t.TempDir(), "out"),
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if cs.calls != 1 {
+		t.Errorf("calls = %d", cs.calls)
+	}
+	if !strings.Contains(string(res.Transcript), "done!") {
+		t.Errorf("transcript missing content:\n%s", res.Transcript)
+	}
+	if res.PromptTokens != 7 || res.CompletionTokens != 3 {
+		t.Errorf("tokens: %+v", res)
+	}
+}
+
+func TestExecute_ToolLoop(t *testing.T) {
+	testutil.NewSandbox(t)
+
+	workDir := t.TempDir()
+	input := filepath.Join(workDir, "hello.txt")
+	_ = os.WriteFile(input, []byte("content"), 0o644)
+
+	toolCall := []map[string]any{
+		{
+			"id":   "call_1",
+			"type": "function",
+			"function": map[string]any{
+				"name":      "Read",
+				"arguments": `{"path":"inputs/hello.txt"}`,
+			},
+		},
+	}
+	cs := &chatServer{
+		responses: []string{
+			chatResponse("", toolCall),
+			chatResponse("summary", nil),
+		},
+	}
+	srv := httptest.NewServer(http.HandlerFunc(cs.handle))
+	defer srv.Close()
+
+	r := NewWithOptions(&fakeStore{keys: map[string]string{"openai": "sk"}},
+		option.WithBaseURL(srv.URL))
+
+	res, err := r.Execute(context.Background(), runner.Request{
+		Prompt: "read the file", OutputDir: filepath.Join(t.TempDir(), "out"),
+		InputFiles: []string{input},
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if cs.calls != 2 {
+		t.Errorf("calls = %d, want 2", cs.calls)
+	}
+	if res.ToolCalls["Read"] != 1 {
+		t.Errorf("Read tool count = %d", res.ToolCalls["Read"])
+	}
+}
+
+func TestExecute_APIErrorOnResultErr(t *testing.T) {
+	testutil.NewSandbox(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(500)
+		_, _ = io.WriteString(w, `{"error":{"message":"boom"}}`)
+	}))
+	defer srv.Close()
+
+	r := NewWithOptions(&fakeStore{keys: map[string]string{"openai": "sk"}},
+		option.WithBaseURL(srv.URL))
+
+	res, err := r.Execute(context.Background(), runner.Request{
+		Prompt: "p", OutputDir: filepath.Join(t.TempDir(), "out"),
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if res.Err == nil {
+		t.Error("expected res.Err on API failure")
+	}
+}
+
+func TestBuildSystem_WithAndWithoutSkill(t *testing.T) {
+	skill := t.TempDir()
+	_ = os.WriteFile(filepath.Join(skill, "SKILL.md"), []byte("# s"), 0o644)
+	if got := buildSystem(runner.Request{SkillDir: skill}); !strings.Contains(got, "# s") {
+		t.Errorf("skill body missing: %q", got)
+	}
+	if got := buildSystem(runner.Request{}); got != "" {
+		t.Errorf("empty: got %q", got)
+	}
+	if got := buildSystem(runner.Request{SystemPrompt: "be nice"}); !strings.Contains(got, "be nice") {
+		t.Errorf("system prompt missing: %q", got)
+	}
+}
+
+func TestToolDefs(t *testing.T) {
+	if len(toolDefs()) != 5 {
+		t.Errorf("expected 5 tool defs")
+	}
+}
+
+func TestStageInputs_CopiesFiles(t *testing.T) {
+	work := t.TempDir()
+	src := filepath.Join(work, "in.txt")
+	_ = os.WriteFile(src, []byte("x"), 0o644)
+	scratch := t.TempDir()
+	if err := stageInputs(runner.Request{InputFiles: []string{src}}, scratch); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(scratch, "inputs", "in.txt")); err != nil {
+		t.Errorf("not staged: %v", err)
+	}
+}
+
+func TestCollectIntoOutput_SkipsInputs(t *testing.T) {
+	scratch := t.TempDir()
+	_ = os.MkdirAll(filepath.Join(scratch, "inputs"), 0o755)
+	_ = os.WriteFile(filepath.Join(scratch, "inputs", "x.txt"), []byte("x"), 0o644)
+	_ = os.WriteFile(filepath.Join(scratch, "out.md"), []byte("body"), 0o644)
+
+	out := t.TempDir()
+	files, err := collectIntoOutput(scratch, out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) != 1 || files[0] != "out.md" {
+		t.Errorf("got %v", files)
+	}
+}
+
+func TestOneLine(t *testing.T) {
+	if got := oneLine(strings.Repeat("a", 100), 10); !strings.HasSuffix(got, "...") {
+		t.Errorf("got %q", got)
+	}
+}

--- a/cli/internal/eval/runner/toolbox/toolbox_coverage_test.go
+++ b/cli/internal/eval/runner/toolbox/toolbox_coverage_test.go
@@ -1,0 +1,263 @@
+package toolbox_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jjfantini/humblSKILLS/cli/internal/eval/runner/toolbox"
+)
+
+func newBox(t *testing.T) *toolbox.Sandbox {
+	t.Helper()
+	sb, err := toolbox.NewSandbox(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	sb.ExecTimeout = 5 * time.Second
+	return sb
+}
+
+func TestDefaultTools_ReturnsFive(t *testing.T) {
+	tools := toolbox.DefaultTools()
+	if len(tools) != 5 {
+		t.Fatalf("tools = %d, want 5", len(tools))
+	}
+	want := map[string]bool{"Read": true, "Write": true, "Bash": true, "Glob": true, "Grep": true}
+	for _, tl := range tools {
+		if !want[tl.Name] {
+			t.Errorf("unexpected tool %q", tl.Name)
+		}
+		if tl.Description == "" {
+			t.Errorf("tool %q missing description", tl.Name)
+		}
+		if tl.Schema == nil {
+			t.Errorf("tool %q missing schema", tl.Name)
+		}
+	}
+}
+
+func TestCall_Read(t *testing.T) {
+	sb := newBox(t)
+	if err := os.WriteFile(filepath.Join(sb.Root, "x.txt"), []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := sb.Call(context.Background(), "Read", map[string]any{"path": "x.txt"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "hello" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestCall_Write_ThenRead(t *testing.T) {
+	sb := newBox(t)
+	_, err := sb.Call(context.Background(), "Write", map[string]any{
+		"path": "nested/a.txt", "content": "hi",
+	})
+	if err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	got, _ := sb.Call(context.Background(), "Read", map[string]any{"path": "nested/a.txt"})
+	if got != "hi" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestCall_Bash(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("bash tool uses sh -c; skipping on windows")
+	}
+	sb := newBox(t)
+	got, err := sb.Call(context.Background(), "Bash", map[string]any{"command": "echo ok"})
+	if err != nil {
+		t.Fatalf("Bash: %v", err)
+	}
+	if !strings.Contains(got, "ok") {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestBash_NonZeroExitSurfacesError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip()
+	}
+	sb := newBox(t)
+	out, err := sb.Bash(context.Background(), "exit 3")
+	if err == nil {
+		t.Fatal("expected non-zero exit error")
+	}
+	// Output can still contain anything the command emitted before dying.
+	_ = out
+}
+
+func TestBash_EmptyCommand(t *testing.T) {
+	sb := newBox(t)
+	if _, err := sb.Bash(context.Background(), "   "); err == nil {
+		t.Error("expected error for empty command")
+	}
+}
+
+func TestBash_Timeout(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip()
+	}
+	sb := newBox(t)
+	sb.ExecTimeout = 100 * time.Millisecond
+	start := time.Now()
+	_, _ = sb.Bash(context.Background(), "sleep 5")
+	if time.Since(start) > 2*time.Second {
+		t.Error("Bash did not honor timeout")
+	}
+}
+
+func TestCall_Glob_MatchesBasenameAndRelative(t *testing.T) {
+	sb := newBox(t)
+	_ = os.MkdirAll(filepath.Join(sb.Root, "sub"), 0o755)
+	_ = os.WriteFile(filepath.Join(sb.Root, "a.md"), []byte("a"), 0o644)
+	_ = os.WriteFile(filepath.Join(sb.Root, "sub", "b.md"), []byte("b"), 0o644)
+
+	got, err := sb.Call(context.Background(), "Glob", map[string]any{"pattern": "*.md"})
+	if err != nil {
+		t.Fatalf("Glob: %v", err)
+	}
+	if !strings.Contains(got, "a.md") || !strings.Contains(got, "b.md") {
+		t.Errorf("glob missing matches: %q", got)
+	}
+}
+
+func TestGlob_EmptyPatternErrors(t *testing.T) {
+	sb := newBox(t)
+	if _, err := sb.Glob(""); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestGlob_NoMatches(t *testing.T) {
+	sb := newBox(t)
+	got, err := sb.Glob("nothing-matches-this")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(got, "no matches") {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestCall_Grep_ReturnsMatchLocation(t *testing.T) {
+	sb := newBox(t)
+	_ = os.WriteFile(filepath.Join(sb.Root, "haystack.md"), []byte("line one\nneedle here\nthird line\n"), 0o644)
+
+	got, err := sb.Call(context.Background(), "Grep", map[string]any{"pattern": "needle"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(got, "haystack.md:2") {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestGrep_InvalidRegex(t *testing.T) {
+	sb := newBox(t)
+	if _, err := sb.Grep("[invalid", ""); err == nil {
+		t.Fatal("expected regex error")
+	}
+}
+
+func TestGrep_PathScoped(t *testing.T) {
+	sb := newBox(t)
+	_ = os.MkdirAll(filepath.Join(sb.Root, "a"), 0o755)
+	_ = os.MkdirAll(filepath.Join(sb.Root, "b"), 0o755)
+	_ = os.WriteFile(filepath.Join(sb.Root, "a", "f.txt"), []byte("match_a"), 0o644)
+	_ = os.WriteFile(filepath.Join(sb.Root, "b", "f.txt"), []byte("match_b"), 0o644)
+
+	got, err := sb.Grep("match", "a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(got, "f.txt") || strings.Contains(got, "match_b") {
+		t.Errorf("path scope broken: %q", got)
+	}
+}
+
+func TestGrep_NoMatches(t *testing.T) {
+	sb := newBox(t)
+	got, _ := sb.Grep("never-here", "")
+	if !strings.Contains(got, "no matches") {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestCall_UnknownTool(t *testing.T) {
+	sb := newBox(t)
+	if _, err := sb.Call(context.Background(), "Bogus", nil); err == nil {
+		t.Fatal("expected unknown tool error")
+	}
+}
+
+func TestResolve_RejectsEscape(t *testing.T) {
+	sb := newBox(t)
+	// Reading ".." should error rather than succeeding.
+	if _, err := sb.Read("../../etc/passwd"); err == nil {
+		t.Error("expected escape rejection")
+	}
+}
+
+func TestResolve_AbsolutePathOutsideSandboxRejected(t *testing.T) {
+	sb := newBox(t)
+	if _, err := sb.Read("/etc/passwd"); err == nil {
+		t.Error("expected abs-outside rejection")
+	}
+}
+
+func TestResolve_AbsolutePathInsideSandboxAllowed(t *testing.T) {
+	sb := newBox(t)
+	abs := filepath.Join(sb.Root, "z.txt")
+	if err := os.WriteFile(abs, []byte("ok"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := sb.Read(abs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "ok" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestRead_LargeFileTruncated(t *testing.T) {
+	sb := newBox(t)
+	big := strings.Repeat("x", 512*1024) // 512 KiB
+	if err := os.WriteFile(filepath.Join(sb.Root, "big"), []byte(big), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := sb.Read("big")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(got, "truncated") {
+		t.Errorf("missing truncation marker: len=%d", len(got))
+	}
+}
+
+func TestRead_MissingFile(t *testing.T) {
+	sb := newBox(t)
+	if _, err := sb.Read("nope"); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestStringArg_Missing(t *testing.T) {
+	// Indirectly via Call with missing args.
+	sb := newBox(t)
+	_, err := sb.Call(context.Background(), "Read", nil)
+	// Read("") hits os.ReadFile which errors on an empty path.
+	if err == nil {
+		t.Error("expected error on missing path arg")
+	}
+}

--- a/cli/internal/eval/runner/toolbox/toolbox_coverage_test.go
+++ b/cli/internal/eval/runner/toolbox/toolbox_coverage_test.go
@@ -108,11 +108,17 @@ func TestBash_Timeout(t *testing.T) {
 		t.Skip()
 	}
 	sb := newBox(t)
-	sb.ExecTimeout = 100 * time.Millisecond
+	sb.ExecTimeout = 300 * time.Millisecond
 	start := time.Now()
-	_, _ = sb.Bash(context.Background(), "sleep 5")
-	if time.Since(start) > 2*time.Second {
-		t.Error("Bash did not honor timeout")
+	// `exec` replaces the shell with sleep so SIGKILL to the process
+	// cascades. Without `exec`, Linux leaves the orphaned sleep holding
+	// the stdout pipe and CombinedOutput blocks until the full 5s.
+	_, _ = sb.Bash(context.Background(), "exec sleep 10")
+	elapsed := time.Since(start)
+	// Generous cap: deadline-driven kill should return well under the
+	// 10s sleep, but CI runners are occasionally slow.
+	if elapsed > 5*time.Second {
+		t.Errorf("Bash did not honor timeout, took %v", elapsed)
 	}
 }
 

--- a/cli/internal/eval/scenarios/scenarios_coverage_test.go
+++ b/cli/internal/eval/scenarios/scenarios_coverage_test.go
@@ -1,0 +1,343 @@
+package scenarios_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jjfantini/humblSKILLS/cli/internal/eval/scenarios"
+)
+
+func writeJSON(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestLoad_MissingDirErrors(t *testing.T) {
+	if _, err := scenarios.Load(filepath.Join(t.TempDir(), "evals")); err == nil {
+		t.Fatal("expected error for missing evals dir")
+	}
+}
+
+func TestLoad_PrefersScenariosOverEvals(t *testing.T) {
+	dir := t.TempDir()
+	writeJSON(t, filepath.Join(dir, "scenarios.json"), `{
+		"skill_name": "foo",
+		"schema_version": 1,
+		"scenarios": [
+			{"id":"s1","sessions":[{"n":1,"prompt":"hi","assertions":[{"text":"t1"}]}]}
+		]
+	}`)
+	// evals.json exists but should be ignored.
+	writeJSON(t, filepath.Join(dir, "evals.json"), `{"skill_name":"foo","evals":[]}`)
+
+	f, err := scenarios.Load(dir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if f.Scenarios[0].ID != "s1" {
+		t.Errorf("got %q", f.Scenarios[0].ID)
+	}
+}
+
+func TestLoad_LegacyEvalsJSONLifted(t *testing.T) {
+	dir := t.TempDir()
+	writeJSON(t, filepath.Join(dir, "evals.json"), `{
+		"skill_name":"foo",
+		"evals":[
+			{"id":1,"prompt":"do a","assertions":[{"text":"t"}]},
+			{"id":2,"prompt":"do b"}
+		]
+	}`)
+	f, err := scenarios.Load(dir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(f.Scenarios) != 2 {
+		t.Fatalf("scenarios = %d", len(f.Scenarios))
+	}
+	if f.Scenarios[0].ID != "eval-1" || f.Scenarios[0].Family != "generic" {
+		t.Errorf("lift mismatch: %+v", f.Scenarios[0])
+	}
+	// applyDefaults fills in configurations.
+	if len(f.Configurations) != 3 {
+		t.Errorf("configurations = %v", f.Configurations)
+	}
+	if f.RunsPerConfiguration != 1 {
+		t.Errorf("RunsPerConfiguration = %d", f.RunsPerConfiguration)
+	}
+}
+
+func TestLoad_MalformedScenariosJSON(t *testing.T) {
+	dir := t.TempDir()
+	writeJSON(t, filepath.Join(dir, "scenarios.json"), "{not json")
+	if _, err := scenarios.Load(dir); err == nil {
+		t.Fatal("expected parse error")
+	}
+}
+
+func TestLoad_MalformedEvalsJSON(t *testing.T) {
+	dir := t.TempDir()
+	writeJSON(t, filepath.Join(dir, "evals.json"), "{not json")
+	if _, err := scenarios.Load(dir); err == nil {
+		t.Fatal("expected parse error")
+	}
+}
+
+func TestLoadFromSkill_ResolvesEvalsSubdir(t *testing.T) {
+	skill := t.TempDir()
+	writeJSON(t, filepath.Join(skill, "evals", "evals.json"), `{
+		"skill_name":"x",
+		"evals":[{"id":1,"prompt":"hi"}]
+	}`)
+	f, err := scenarios.LoadFromSkill(skill)
+	if err != nil {
+		t.Fatalf("LoadFromSkill: %v", err)
+	}
+	if len(f.Scenarios) != 1 {
+		t.Error("scenario not lifted")
+	}
+}
+
+func TestValidate_RejectsUnknownSchemaVersion(t *testing.T) {
+	f := &scenarios.File{SchemaVersion: 42, SkillName: "x"}
+	if err := scenarios.Validate(f); err == nil {
+		t.Fatal("expected schema version error")
+	}
+}
+
+func TestValidate_MissingSkillName(t *testing.T) {
+	f := &scenarios.File{SchemaVersion: scenarios.SchemaVersion}
+	if err := scenarios.Validate(f); err == nil {
+		t.Fatal("expected skill_name error")
+	}
+}
+
+func TestValidate_UnknownConfiguration(t *testing.T) {
+	f := &scenarios.File{
+		SchemaVersion:  scenarios.SchemaVersion,
+		SkillName:      "x",
+		Configurations: []string{"bogus"},
+	}
+	if err := scenarios.Validate(f); err == nil {
+		t.Fatal("expected unknown configuration error")
+	}
+}
+
+func TestValidate_DuplicateScenarioID(t *testing.T) {
+	f := &scenarios.File{
+		SchemaVersion: scenarios.SchemaVersion,
+		SkillName:     "x",
+		Scenarios: []scenarios.Scenario{
+			{ID: "dup", Sessions: []scenarios.Session{{N: 1, Prompt: "p"}}},
+			{ID: "dup", Sessions: []scenarios.Session{{N: 1, Prompt: "p"}}},
+		},
+	}
+	if err := scenarios.Validate(f); err == nil {
+		t.Fatal("expected duplicate ID error")
+	}
+}
+
+func TestValidate_MissingScenarioID(t *testing.T) {
+	f := &scenarios.File{
+		SchemaVersion: scenarios.SchemaVersion,
+		SkillName:     "x",
+		Scenarios:     []scenarios.Scenario{{Sessions: []scenarios.Session{{N: 1, Prompt: "p"}}}},
+	}
+	if err := scenarios.Validate(f); err == nil {
+		t.Fatal("expected id required error")
+	}
+}
+
+func TestValidate_ZeroSessions(t *testing.T) {
+	f := &scenarios.File{
+		SchemaVersion: scenarios.SchemaVersion,
+		SkillName:     "x",
+		Scenarios:     []scenarios.Scenario{{ID: "s1"}},
+	}
+	if err := scenarios.Validate(f); err == nil {
+		t.Fatal("expected at least one session error")
+	}
+}
+
+func TestValidate_SessionNOutOfOrder(t *testing.T) {
+	f := &scenarios.File{
+		SchemaVersion: scenarios.SchemaVersion,
+		SkillName:     "x",
+		Scenarios: []scenarios.Scenario{{
+			ID: "s1",
+			Sessions: []scenarios.Session{
+				{N: 1, Prompt: "p"},
+				{N: 3, Prompt: "p"}, // should be 2
+			},
+		}},
+	}
+	if err := scenarios.Validate(f); err == nil {
+		t.Fatal("expected session numbering error")
+	}
+}
+
+func TestValidate_SessionWithEmptyPrompt(t *testing.T) {
+	f := &scenarios.File{
+		SchemaVersion: scenarios.SchemaVersion,
+		SkillName:     "x",
+		Scenarios: []scenarios.Scenario{{
+			ID:       "s1",
+			Sessions: []scenarios.Session{{N: 1, Prompt: "   "}},
+		}},
+	}
+	if err := scenarios.Validate(f); err == nil {
+		t.Fatal("expected empty prompt error")
+	}
+}
+
+func TestValidate_AssertionWithEmptyText(t *testing.T) {
+	f := &scenarios.File{
+		SchemaVersion: scenarios.SchemaVersion,
+		SkillName:     "x",
+		Scenarios: []scenarios.Scenario{{
+			ID: "s1",
+			Sessions: []scenarios.Session{{
+				N: 1, Prompt: "p",
+				Assertions: []scenarios.Assertion{{Text: "", Check: "llm"}},
+			}},
+		}},
+	}
+	if err := scenarios.Validate(f); err == nil {
+		t.Fatal("expected empty assertion text error")
+	}
+}
+
+func TestValidate_UnknownAssertionKind(t *testing.T) {
+	f := &scenarios.File{
+		SchemaVersion: scenarios.SchemaVersion,
+		SkillName:     "x",
+		Scenarios: []scenarios.Scenario{{
+			ID: "s1",
+			Sessions: []scenarios.Session{{
+				N: 1, Prompt: "p",
+				Assertions: []scenarios.Assertion{{Text: "t", Check: "bogus-kind"}},
+			}},
+		}},
+	}
+	err := scenarios.Validate(f)
+	if err == nil {
+		t.Fatal("expected unknown kind error")
+	}
+	if !strings.Contains(err.Error(), "unknown assertion kind") {
+		t.Errorf("err = %v", err)
+	}
+}
+
+func TestValidate_TransferFromUnknownScenario(t *testing.T) {
+	f := &scenarios.File{
+		SchemaVersion: scenarios.SchemaVersion,
+		SkillName:     "x",
+		Scenarios: []scenarios.Scenario{
+			{
+				ID: "s1", TransferFrom: []string{"ghost"},
+				Sessions: []scenarios.Session{{N: 1, Prompt: "p"}},
+			},
+		},
+	}
+	if err := scenarios.Validate(f); err == nil {
+		t.Fatal("expected transfer_from error")
+	}
+}
+
+func TestValidate_Nil(t *testing.T) {
+	if err := scenarios.Validate(nil); err == nil {
+		t.Fatal("expected nil error")
+	}
+}
+
+func TestValidate_StampsMissingSessionN(t *testing.T) {
+	// Session N=0 with correct position is auto-stamped rather than rejected.
+	f := &scenarios.File{
+		SchemaVersion: scenarios.SchemaVersion,
+		SkillName:     "x",
+		Scenarios: []scenarios.Scenario{{
+			ID: "s1",
+			Sessions: []scenarios.Session{
+				{N: 0, Prompt: "first"},
+				{N: 0, Prompt: "second"},
+			},
+		}},
+	}
+	if err := scenarios.Validate(f); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if f.Scenarios[0].Sessions[0].N != 1 || f.Scenarios[0].Sessions[1].N != 2 {
+		t.Errorf("N not stamped: %+v", f.Scenarios[0].Sessions)
+	}
+}
+
+func TestParseCheck_AllKinds(t *testing.T) {
+	cases := []struct {
+		in       string
+		kind     scenarios.CheckKind
+		arg      string
+	}{
+		{"", scenarios.CheckLLM, ""},
+		{"llm", scenarios.CheckLLM, ""},
+		{"path_exists:foo/bar", scenarios.CheckPathExists, "foo/bar"},
+		{"regex:out.md:^H", scenarios.CheckRegex, "out.md:^H"},
+		{"exec:go test", scenarios.CheckExec, "go test"},
+		{"script:check.sh", scenarios.CheckScript, "check.sh"},
+		{"json_valid:out.json", scenarios.CheckJSONValid, "out.json"},
+	}
+	for _, tc := range cases {
+		k, a := scenarios.ParseCheck(tc.in)
+		if k != tc.kind || a != tc.arg {
+			t.Errorf("ParseCheck(%q) = (%q,%q), want (%q,%q)", tc.in, k, a, tc.kind, tc.arg)
+		}
+	}
+}
+
+func TestTotalSessions(t *testing.T) {
+	f := &scenarios.File{
+		Scenarios: []scenarios.Scenario{
+			{Sessions: []scenarios.Session{{}, {}}},
+			{Sessions: []scenarios.Session{{}}},
+		},
+	}
+	if got := f.TotalSessions(); got != 3 {
+		t.Errorf("got %d", got)
+	}
+}
+
+func TestFindScenario(t *testing.T) {
+	f := &scenarios.File{Scenarios: []scenarios.Scenario{{ID: "a"}, {ID: "b"}}}
+	if got := f.FindScenario("a"); got == nil || got.ID != "a" {
+		t.Error("FindScenario(a) miss")
+	}
+	if got := f.FindScenario("z"); got != nil {
+		t.Error("FindScenario(z) unexpectedly hit")
+	}
+}
+
+func TestApplyDefaults_SessionTimeoutConvertedOnLoad(t *testing.T) {
+	// Load exercises applyDefaults, which converts TimeoutSec to
+	// Session.Timeout.
+	dir := t.TempDir()
+	writeJSON(t, filepath.Join(dir, "scenarios.json"), `{
+		"skill_name":"x","schema_version":1,
+		"scenarios":[{
+			"id":"s1",
+			"sessions":[{"n":1,"prompt":"p","timeout_seconds":30}]
+		}]
+	}`)
+	f, err := scenarios.Load(dir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if f.Scenarios[0].Sessions[0].Timeout.Seconds() != 30 {
+		t.Errorf("Timeout = %v, want 30s", f.Scenarios[0].Sessions[0].Timeout)
+	}
+}

--- a/cli/internal/eval/workspace/workspace_coverage_test.go
+++ b/cli/internal/eval/workspace/workspace_coverage_test.go
@@ -1,0 +1,335 @@
+package workspace_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jjfantini/humblSKILLS/cli/internal/eval/workspace"
+	"github.com/jjfantini/humblSKILLS/cli/internal/testutil"
+)
+
+func TestResolver_PrefersFlagOverEnvOverProfile(t *testing.T) {
+	r := workspace.Resolver{
+		FlagOverride:   "/flag",
+		EnvOverride:    "/env",
+		ProfileDefault: "/profile",
+	}
+	got, err := r.Root()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "/flag" {
+		t.Errorf("got %q, want /flag", got)
+	}
+}
+
+func TestResolver_FallsBackToEnvThenProfile(t *testing.T) {
+	r := workspace.Resolver{EnvOverride: "/env", ProfileDefault: "/profile"}
+	got, _ := r.Root()
+	if got != "/env" {
+		t.Errorf("got %q, want /env", got)
+	}
+
+	r = workspace.Resolver{ProfileDefault: "/profile"}
+	got, _ = r.Root()
+	if got != "/profile" {
+		t.Errorf("got %q, want /profile", got)
+	}
+}
+
+func TestResolver_FallsBackToDefaultRoot(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	got, err := workspace.Resolver{}.Root()
+	if err != nil {
+		t.Fatalf("Root: %v", err)
+	}
+	if !strings.HasPrefix(got, s.XDGStateHome) {
+		t.Errorf("default root %q not under XDG_STATE_HOME %q", got, s.XDGStateHome)
+	}
+}
+
+func TestDefaultRoot_UsesXDGStateHome(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	got, err := workspace.DefaultRoot()
+	if err != nil {
+		t.Fatalf("DefaultRoot: %v", err)
+	}
+	if !strings.HasPrefix(got, s.XDGStateHome) {
+		t.Errorf("DefaultRoot = %q", got)
+	}
+}
+
+func TestSkillDir_AndRegistryPath(t *testing.T) {
+	if got := workspace.SkillDir("/r", "foo"); got != "/r/foo" {
+		t.Errorf("SkillDir = %q", got)
+	}
+	if got := workspace.RegistryPath("/r", "foo"); got != "/r/foo/iterations.json" {
+		t.Errorf("RegistryPath = %q", got)
+	}
+	if got := workspace.IterationDir("/r", "foo", 3); got != "/r/foo/iteration-3" {
+		t.Errorf("IterationDir = %q", got)
+	}
+}
+
+func TestLoadRegistry_MissingReturnsEmpty(t *testing.T) {
+	root := t.TempDir()
+	r, err := workspace.LoadRegistry(root, "foo")
+	if err != nil {
+		t.Fatalf("LoadRegistry: %v", err)
+	}
+	if r == nil || r.SchemaVersion != workspace.SchemaVersion {
+		t.Errorf("unexpected: %+v", r)
+	}
+}
+
+func TestLoadRegistry_UnsupportedSchema(t *testing.T) {
+	root := t.TempDir()
+	path := workspace.RegistryPath(root, "foo")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(`{"schema_version": 999}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := workspace.LoadRegistry(root, "foo"); err == nil {
+		t.Fatal("expected unsupported schema_version error")
+	}
+}
+
+func TestLoadRegistry_CorruptJSON(t *testing.T) {
+	root := t.TempDir()
+	path := workspace.RegistryPath(root, "foo")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("{not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := workspace.LoadRegistry(root, "foo"); err == nil {
+		t.Fatal("expected parse error")
+	}
+}
+
+func TestSaveRegistry_NilReturnsError(t *testing.T) {
+	if err := workspace.SaveRegistry(t.TempDir(), "x", nil); err == nil {
+		t.Fatal("expected error for nil registry")
+	}
+}
+
+func TestBeginIteration_AllocatesAndRecords(t *testing.T) {
+	root := t.TempDir()
+	n, dir, err := workspace.BeginIteration(root, "foo", "mock", []string{"smart_skill", "no_skill"}, []string{"s1"})
+	if err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("n = %d, want 1", n)
+	}
+	if _, err := os.Stat(dir); err != nil {
+		t.Errorf("iteration dir missing: %v", err)
+	}
+	reg, _ := workspace.LoadRegistry(root, "foo")
+	if len(reg.Iterations) != 1 {
+		t.Fatalf("iterations = %d", len(reg.Iterations))
+	}
+	if reg.Iterations[0].Status != workspace.StatusRunning {
+		t.Errorf("status = %q", reg.Iterations[0].Status)
+	}
+}
+
+func TestBeginIteration_MonotonicAcrossCalls(t *testing.T) {
+	root := t.TempDir()
+	n1, _, _ := workspace.BeginIteration(root, "foo", "mock", nil, nil)
+	n2, _, _ := workspace.BeginIteration(root, "foo", "mock", nil, nil)
+	if n2 != n1+1 {
+		t.Errorf("expected n2=%d, got %d", n1+1, n2)
+	}
+}
+
+func TestCompleteIteration_StampsAndRecordsStats(t *testing.T) {
+	root := t.TempDir()
+	n, _, _ := workspace.BeginIteration(root, "foo", "mock", nil, nil)
+	err := workspace.CompleteIteration(root, "foo", n,
+		map[string]float64{"smart_skill": 0.9},
+		map[string]int{"total": 1000},
+	)
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	reg, _ := workspace.LoadRegistry(root, "foo")
+	it := reg.Iterations[0]
+	if it.Status != workspace.StatusComplete {
+		t.Errorf("status = %q", it.Status)
+	}
+	if it.CompletedAt == nil {
+		t.Error("CompletedAt not set")
+	}
+	if it.HeadlinePassRt["smart_skill"] != 0.9 {
+		t.Errorf("pass rate = %v", it.HeadlinePassRt)
+	}
+}
+
+func TestCompleteIteration_UnknownN(t *testing.T) {
+	root := t.TempDir()
+	if err := workspace.CompleteIteration(root, "foo", 99, nil, nil); err == nil {
+		t.Fatal("expected error for unknown iteration")
+	}
+}
+
+func TestMarkIteration_UpdatesStatus(t *testing.T) {
+	root := t.TempDir()
+	n, _, _ := workspace.BeginIteration(root, "foo", "mock", nil, nil)
+	if err := workspace.MarkIteration(root, "foo", n, workspace.StatusFailed); err != nil {
+		t.Fatalf("Mark: %v", err)
+	}
+	reg, _ := workspace.LoadRegistry(root, "foo")
+	if reg.Iterations[0].Status != workspace.StatusFailed {
+		t.Errorf("status = %q", reg.Iterations[0].Status)
+	}
+}
+
+func TestMarkIteration_UnknownN(t *testing.T) {
+	if err := workspace.MarkIteration(t.TempDir(), "x", 1, workspace.StatusFailed); err == nil {
+		t.Fatal("expected error for unknown iteration")
+	}
+}
+
+func TestListSkills_IgnoresHiddenAndFiles(t *testing.T) {
+	root := t.TempDir()
+	_ = os.MkdirAll(filepath.Join(root, "alpha"), 0o755)
+	_ = os.MkdirAll(filepath.Join(root, "beta"), 0o755)
+	_ = os.MkdirAll(filepath.Join(root, ".hidden"), 0o755)
+	_ = os.WriteFile(filepath.Join(root, "regular_file"), []byte("x"), 0o644)
+
+	got, err := workspace.ListSkills(root)
+	if err != nil {
+		t.Fatalf("ListSkills: %v", err)
+	}
+	if len(got) != 2 || got[0] != "alpha" || got[1] != "beta" {
+		t.Errorf("got %v", got)
+	}
+}
+
+func TestListSkills_MissingRootIsEmpty(t *testing.T) {
+	got, err := workspace.ListSkills(filepath.Join(t.TempDir(), "ghost"))
+	if err != nil {
+		t.Fatalf("ListSkills: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("got %v, want empty", got)
+	}
+}
+
+func TestSizeBytes_SumsTreeAndHandlesMissing(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "a"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "a", "x.txt"), []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "y.txt"), []byte("hi"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := workspace.SizeBytes(dir)
+	if err != nil {
+		t.Fatalf("SizeBytes: %v", err)
+	}
+	if got != 7 {
+		t.Errorf("got %d, want 7", got)
+	}
+
+	// Missing path returns 0 without error.
+	got, err = workspace.SizeBytes(filepath.Join(t.TempDir(), "nope"))
+	if err != nil {
+		t.Fatalf("missing path: %v", err)
+	}
+	if got != 0 {
+		t.Errorf("got %d, want 0", got)
+	}
+}
+
+func TestPrune_KeepLast(t *testing.T) {
+	root := t.TempDir()
+	for i := 0; i < 3; i++ {
+		_, _, _ = workspace.BeginIteration(root, "foo", "mock", nil, nil)
+	}
+	res, err := workspace.Prune(root, "foo", workspace.PruneOpts{KeepLast: 1})
+	if err != nil {
+		t.Fatalf("Prune: %v", err)
+	}
+	if len(res.Removed) != 2 {
+		t.Errorf("Removed = %v", res.Removed)
+	}
+	reg, _ := workspace.LoadRegistry(root, "foo")
+	if len(reg.Iterations) != 1 {
+		t.Errorf("remaining = %d", len(reg.Iterations))
+	}
+}
+
+func TestPrune_OlderThan(t *testing.T) {
+	root := t.TempDir()
+	_, _, _ = workspace.BeginIteration(root, "foo", "mock", nil, nil)
+
+	// Rewrite registry to backdate the single iteration far enough
+	// that OlderThan matches.
+	reg, _ := workspace.LoadRegistry(root, "foo")
+	reg.Iterations[0].StartedAt = time.Now().Add(-48 * time.Hour)
+	_ = workspace.SaveRegistry(root, "foo", reg)
+
+	res, err := workspace.Prune(root, "foo", workspace.PruneOpts{OlderThan: 24 * time.Hour})
+	if err != nil {
+		t.Fatalf("Prune: %v", err)
+	}
+	if len(res.Removed) != 1 {
+		t.Errorf("expected 1 removed, got %v", res.Removed)
+	}
+}
+
+func TestPrune_AllDropsEverything(t *testing.T) {
+	root := t.TempDir()
+	_, _, _ = workspace.BeginIteration(root, "foo", "mock", nil, nil)
+	_, _, _ = workspace.BeginIteration(root, "foo", "mock", nil, nil)
+
+	res, err := workspace.Prune(root, "foo", workspace.PruneOpts{All: true})
+	if err != nil {
+		t.Fatalf("Prune: %v", err)
+	}
+	if len(res.Removed) != 2 {
+		t.Errorf("Removed = %v", res.Removed)
+	}
+}
+
+func TestPrune_DryRunKeepsFiles(t *testing.T) {
+	root := t.TempDir()
+	_, dir, _ := workspace.BeginIteration(root, "foo", "mock", nil, nil)
+
+	res, err := workspace.Prune(root, "foo", workspace.PruneOpts{All: true, DryRun: true})
+	if err != nil {
+		t.Fatalf("Prune: %v", err)
+	}
+	if len(res.Removed) != 1 {
+		t.Errorf("Removed report = %v", res.Removed)
+	}
+	if _, err := os.Stat(dir); err != nil {
+		t.Error("DryRun must not delete files")
+	}
+}
+
+func TestHumanSize(t *testing.T) {
+	cases := map[int64]string{
+		0:                  "0 B",
+		512:                "512 B",
+		1024:               "1.0 KiB",
+		1024 * 1024:        "1.0 MiB",
+		int64(1024*1024*3): "3.0 MiB",
+	}
+	for in, want := range cases {
+		if got := workspace.HumanSize(in); got != want {
+			t.Errorf("HumanSize(%d) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/cli/internal/eval/workspace/workspace_coverage_test.go
+++ b/cli/internal/eval/workspace/workspace_coverage_test.go
@@ -11,6 +11,18 @@ import (
 	"github.com/jjfantini/humblSKILLS/cli/internal/testutil"
 )
 
+// abs turns a forward-slashed test path into a platform-specific
+// absolute path so assertions hold on Windows (where filepath.Abs
+// returns drive-letter-prefixed strings).
+func abs(t *testing.T, p string) string {
+	t.Helper()
+	got, err := filepath.Abs(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return got
+}
+
 func TestResolver_PrefersFlagOverEnvOverProfile(t *testing.T) {
 	r := workspace.Resolver{
 		FlagOverride:   "/flag",
@@ -21,22 +33,22 @@ func TestResolver_PrefersFlagOverEnvOverProfile(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got != "/flag" {
-		t.Errorf("got %q, want /flag", got)
+	if got != abs(t, "/flag") {
+		t.Errorf("got %q, want %q", got, abs(t, "/flag"))
 	}
 }
 
 func TestResolver_FallsBackToEnvThenProfile(t *testing.T) {
 	r := workspace.Resolver{EnvOverride: "/env", ProfileDefault: "/profile"}
 	got, _ := r.Root()
-	if got != "/env" {
-		t.Errorf("got %q, want /env", got)
+	if got != abs(t, "/env") {
+		t.Errorf("got %q, want %q", got, abs(t, "/env"))
 	}
 
 	r = workspace.Resolver{ProfileDefault: "/profile"}
 	got, _ = r.Root()
-	if got != "/profile" {
-		t.Errorf("got %q, want /profile", got)
+	if got != abs(t, "/profile") {
+		t.Errorf("got %q, want %q", got, abs(t, "/profile"))
 	}
 }
 
@@ -63,14 +75,19 @@ func TestDefaultRoot_UsesXDGStateHome(t *testing.T) {
 }
 
 func TestSkillDir_AndRegistryPath(t *testing.T) {
-	if got := workspace.SkillDir("/r", "foo"); got != "/r/foo" {
-		t.Errorf("SkillDir = %q", got)
+	// filepath.Join uses OS-native separators; use filepath.Join in
+	// the expectations so assertions hold cross-platform.
+	want := filepath.Join("/r", "foo")
+	if got := workspace.SkillDir("/r", "foo"); got != want {
+		t.Errorf("SkillDir = %q, want %q", got, want)
 	}
-	if got := workspace.RegistryPath("/r", "foo"); got != "/r/foo/iterations.json" {
-		t.Errorf("RegistryPath = %q", got)
+	want = filepath.Join("/r", "foo", "iterations.json")
+	if got := workspace.RegistryPath("/r", "foo"); got != want {
+		t.Errorf("RegistryPath = %q, want %q", got, want)
 	}
-	if got := workspace.IterationDir("/r", "foo", 3); got != "/r/foo/iteration-3" {
-		t.Errorf("IterationDir = %q", got)
+	want = filepath.Join("/r", "foo", "iteration-3")
+	if got := workspace.IterationDir("/r", "foo", 3); got != want {
+		t.Errorf("IterationDir = %q, want %q", got, want)
 	}
 }
 

--- a/cli/internal/fetch/fetch_coverage_test.go
+++ b/cli/internal/fetch/fetch_coverage_test.go
@@ -1,0 +1,250 @@
+package fetch_test
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jjfantini/humblSKILLS/cli/internal/fetch"
+)
+
+// tarballBytes returns a gzipped tar with one top-level directory and
+// the given files underneath. Shared across the coverage-lift tests.
+func tarballBytes(t *testing.T, prefix string, files map[string]string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	_ = tw.WriteHeader(&tar.Header{Name: prefix + "/", Typeflag: tar.TypeDir, Mode: 0o755})
+	for name, body := range files {
+		_ = tw.WriteHeader(&tar.Header{
+			Name:     prefix + "/" + name,
+			Typeflag: tar.TypeReg,
+			Mode:     0o644,
+			Size:     int64(len(body)),
+		})
+		if _, err := tw.Write([]byte(body)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	_ = tw.Close()
+	_ = gz.Close()
+	return buf.Bytes()
+}
+
+// fetcherWithMockHTTP builds a Fetcher whose HTTP client is redirected
+// to srv regardless of URL. We intercept all outbound requests via a
+// RoundTripper shim because production code hard-codes codeload URLs.
+func fetcherWithMockHTTP(cacheDir string, srv *httptest.Server) *fetch.Fetcher {
+	f := fetch.NewFetcher(cacheDir)
+	f.HTTP = &http.Client{
+		Timeout: 5 * time.Second,
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			// Rewrite to point at the httptest server.
+			u := *req.URL
+			u.Scheme = "http"
+			u.Host = srv.Listener.Addr().String()
+			req.URL = &u
+			req.Host = u.Host
+			return http.DefaultTransport.RoundTrip(req)
+		}),
+	}
+	return f
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+func TestFetch_WritesTarballIntoCache(t *testing.T) {
+	body := tarballBytes(t, "o-r-abcd", map[string]string{
+		"skills/foo/SKILL.md": "# foo",
+	})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/tar.gz/") {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/gzip")
+		_, _ = w.Write(body)
+	}))
+	defer srv.Close()
+
+	cache := t.TempDir()
+	f := fetcherWithMockHTTP(cache, srv)
+
+	path, err := f.Fetch("owner/repo", "deadbeef0000")
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if !strings.HasPrefix(path, cache) {
+		t.Errorf("path %q not under cache %q", path, cache)
+	}
+	// Second Fetch must be a cache hit (no network).
+	srv.Close()
+	path2, err := f.Fetch("owner/repo", "deadbeef0000")
+	if err != nil {
+		t.Fatalf("Fetch (cache hit): %v", err)
+	}
+	if path != path2 {
+		t.Errorf("cache hit path differs: %q vs %q", path, path2)
+	}
+}
+
+func TestFetch_EmptySHA(t *testing.T) {
+	f := fetch.NewFetcher(t.TempDir())
+	if _, err := f.Fetch("o/r", ""); err == nil {
+		t.Fatal("expected error for empty sha")
+	}
+}
+
+func TestFetch_InvalidRepo(t *testing.T) {
+	f := fetch.NewFetcher(t.TempDir())
+	if _, err := f.Fetch("not-a-repo", "abc"); err == nil {
+		t.Fatal("expected error for malformed repo")
+	}
+}
+
+func TestFetch_HTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(503)
+	}))
+	defer srv.Close()
+
+	f := fetcherWithMockHTTP(t.TempDir(), srv)
+	_, err := f.Fetch("owner/repo", "deadbeef0000")
+	if err == nil {
+		t.Fatal("expected HTTP error to surface")
+	}
+	if !strings.Contains(err.Error(), "503") {
+		t.Errorf("err missing status: %v", err)
+	}
+}
+
+func TestFetch_NetworkFailure(t *testing.T) {
+	srv := httptest.NewServer(nil)
+	addr := srv.Listener.Addr().String()
+	srv.Close() // kill it immediately
+
+	f := fetch.NewFetcher(t.TempDir())
+	f.HTTP = &http.Client{
+		Timeout: 500 * time.Millisecond,
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			u := *req.URL
+			u.Scheme = "http"
+			u.Host = addr
+			req.URL = &u
+			return http.DefaultTransport.RoundTrip(req)
+		}),
+	}
+
+	if _, err := f.Fetch("owner/repo", "sha"); err == nil {
+		t.Fatal("expected network error")
+	}
+}
+
+func TestExtract_EmptySkillPath(t *testing.T) {
+	body := tarballBytes(t, "pfx", map[string]string{"file.md": "x"})
+	tarPath := filepath.Join(t.TempDir(), "a.tar.gz")
+	if err := os.WriteFile(tarPath, body, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := fetch.Extract(tarPath, "", t.TempDir()); err == nil {
+		t.Fatal("expected error for empty skill path")
+	}
+	if err := fetch.Extract(tarPath, ".", t.TempDir()); err == nil {
+		t.Fatal("expected error for '.' skill path")
+	}
+}
+
+func TestExtract_MissingTarball(t *testing.T) {
+	if err := fetch.Extract(filepath.Join(t.TempDir(), "nope.tar.gz"), "skills/foo", t.TempDir()); err == nil {
+		t.Fatal("expected error for missing tarball")
+	}
+}
+
+func TestExtract_NotGzip(t *testing.T) {
+	tarPath := filepath.Join(t.TempDir(), "plain.tar.gz")
+	if err := os.WriteFile(tarPath, []byte("not gzip"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := fetch.Extract(tarPath, "skills/foo", t.TempDir()); err == nil {
+		t.Fatal("expected gzip error")
+	}
+}
+
+func TestExtract_RejectsDotDotEntry(t *testing.T) {
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	_ = tw.WriteHeader(&tar.Header{Name: "pfx/", Typeflag: tar.TypeDir, Mode: 0o755})
+	_ = tw.WriteHeader(&tar.Header{
+		Name:     "../escape",
+		Typeflag: tar.TypeReg,
+		Mode:     0o644,
+		Size:     3,
+	})
+	_, _ = tw.Write([]byte("pwn"))
+	_ = tw.Close()
+	_ = gz.Close()
+
+	tarPath := filepath.Join(t.TempDir(), "evil.tar.gz")
+	if err := os.WriteFile(tarPath, buf.Bytes(), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := fetch.Extract(tarPath, "skills/foo", t.TempDir()); err == nil {
+		t.Fatal("expected ../ rejection")
+	}
+}
+
+func TestExtract_DirectoryEntriesAreCreated(t *testing.T) {
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	_ = tw.WriteHeader(&tar.Header{Name: "pfx/", Typeflag: tar.TypeDir, Mode: 0o755})
+	_ = tw.WriteHeader(&tar.Header{Name: "pfx/skills/foo/", Typeflag: tar.TypeDir, Mode: 0o755})
+	_ = tw.WriteHeader(&tar.Header{Name: "pfx/skills/foo/sub/", Typeflag: tar.TypeDir, Mode: 0o755})
+	body := "hi"
+	_ = tw.WriteHeader(&tar.Header{
+		Name: "pfx/skills/foo/sub/README.md", Typeflag: tar.TypeReg, Mode: 0o644, Size: int64(len(body)),
+	})
+	_, _ = tw.Write([]byte(body))
+	_ = tw.Close()
+	_ = gz.Close()
+
+	tarPath := filepath.Join(t.TempDir(), "dirs.tar.gz")
+	if err := os.WriteFile(tarPath, buf.Bytes(), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dest := filepath.Join(t.TempDir(), "out")
+	if err := fetch.Extract(tarPath, "skills/foo", dest); err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	info, err := os.Stat(filepath.Join(dest, "sub"))
+	if err != nil {
+		t.Fatalf("stat sub: %v", err)
+	}
+	if !info.IsDir() {
+		t.Error("sub not a directory")
+	}
+}
+
+func TestNewFetcher_Defaults(t *testing.T) {
+	f := fetch.NewFetcher("/tmp/cache")
+	if f.CacheDir != "/tmp/cache" {
+		t.Errorf("CacheDir = %q", f.CacheDir)
+	}
+	if f.HTTP == nil {
+		t.Error("HTTP should be non-nil")
+	}
+	if f.HTTP.Timeout != fetch.DefaultHTTPTimeout {
+		t.Errorf("Timeout = %v, want %v", f.HTTP.Timeout, fetch.DefaultHTTPTimeout)
+	}
+}

--- a/cli/internal/frontmatter/benchmark_test.go
+++ b/cli/internal/frontmatter/benchmark_test.go
@@ -1,0 +1,48 @@
+package frontmatter_test
+
+import (
+	"testing"
+
+	"github.com/jjfantini/humblSKILLS/cli/internal/frontmatter"
+)
+
+var benchFrontmatter = []byte(`---
+name: bench-skill
+description: A skill used in benchmarks; description is long enough to satisfy
+version: 1.2.3
+metadata:
+  tags: [a, b, c, d, e]
+  requires:
+    - foo@1.0.0
+    - bar@>=2.0.0
+    - baz
+  platforms: [claude-code, cursor]
+  preserve:
+    - data/log.md
+    - notes/
+---
+
+# Bench skill body
+
+Some body content that simulates a realistic SKILL.md. Lorem ipsum dolor sit
+amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore
+et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation.
+`)
+
+func BenchmarkParse(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		if _, _, err := frontmatter.Parse(benchFrontmatter); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkParseDep(b *testing.B) {
+	cases := []string{"foo", "foo@1.0.0", "foo@>=1.0.0", "some-skill@2.1.0"}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _, c := range cases {
+			_, _ = frontmatter.ParseDep(c)
+		}
+	}
+}

--- a/cli/internal/frontmatter/fuzz_test.go
+++ b/cli/internal/frontmatter/fuzz_test.go
@@ -1,0 +1,63 @@
+package frontmatter_test
+
+import (
+	"testing"
+
+	"github.com/jjfantini/humblSKILLS/cli/internal/frontmatter"
+)
+
+// FuzzParse ensures the frontmatter parser never panics on arbitrary
+// input. Correctness (valid vs invalid) is decided by Parse's returned
+// error; the fuzz target only guards the panic contract.
+func FuzzParse(f *testing.F) {
+	// Seed with examples covering the main branches.
+	seeds := []string{
+		"",
+		"---\n---\n\n# body\n",
+		"---\nname: foo\nversion: 1.0.0\ndescription: desc\n---\n",
+		"--- not frontmatter",
+		"\n\n\n",
+		"---\nname: x\n",   // unterminated
+		"---\n\t\t\t---\n", // tabs in YAML (invalid)
+		"---\nname: [array, not, scalar]\n---\n",
+		"---\nversion: 1.2\n---\n", // non-semver
+		"---\nrequires:\n  - foo@1.0.0\n  - bar\n---\n",
+	}
+	for _, s := range seeds {
+		f.Add([]byte(s))
+	}
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		_, _, _ = frontmatter.Parse(data)
+	})
+}
+
+// FuzzParseDep ensures version-constraint parsing never panics.
+func FuzzParseDep(f *testing.F) {
+	seeds := []string{
+		"",
+		"foo",
+		"foo@1.0.0",
+		"foo@>=1.0.0",
+		"foo@~1.0.0",
+		"@malformed",
+		"foo@",
+		"foo@1",
+		"foo@1.2",
+		"foo@abc",
+		"foo@>=", // incomplete constraint
+		"@@@",
+		"with spaces@1.0.0",
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+	f.Fuzz(func(t *testing.T, s string) {
+		dep, err := frontmatter.ParseDep(s)
+		if err == nil {
+			// If parse succeeded, Satisfies must not panic either.
+			_ = dep.Satisfies("1.0.0")
+			_ = dep.Satisfies("malformed")
+		}
+	})
+}

--- a/cli/internal/manifest/benchmark_test.go
+++ b/cli/internal/manifest/benchmark_test.go
@@ -1,0 +1,53 @@
+package manifest_test
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/jjfantini/humblSKILLS/cli/internal/manifest"
+)
+
+// seedBench returns a manifest populated with 500 installations so
+// Load/Save exercise realistic JSON volumes.
+func seedBench() *manifest.Manifest {
+	m := &manifest.Manifest{SchemaVersion: manifest.SchemaVersion}
+	for i := 0; i < 500; i++ {
+		m.Upsert(manifest.Installation{
+			Skill: fmt.Sprintf("skill-%d", i), Version: "1.0.0",
+			Platform:    "claude-code",
+			Scope:       "user",
+			Path:        fmt.Sprintf("/tmp/skill-%d", i),
+			InstalledAt: time.Now().UTC(),
+			SourceSHA:   "deadbeef",
+			RegistryRef: fmt.Sprintf("ref-%d", i),
+		})
+	}
+	return m
+}
+
+func BenchmarkManifestSave(b *testing.B) {
+	m := seedBench()
+	path := filepath.Join(b.TempDir(), "manifest.json")
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := manifest.Save(path, m); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkManifestLoad(b *testing.B) {
+	m := seedBench()
+	path := filepath.Join(b.TempDir(), "manifest.json")
+	if err := manifest.Save(path, m); err != nil {
+		b.Fatal(err)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := manifest.Load(path); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/cli/internal/manifest/manifest_coverage_test.go
+++ b/cli/internal/manifest/manifest_coverage_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -92,6 +93,9 @@ func TestSave_NilManifestRejected(t *testing.T) {
 }
 
 func TestSave_FailsWhenParentUnwritable(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("chmod 0500 does not prevent write on windows")
+	}
 	s := testutil.NewSandbox(t)
 	parent := filepath.Join(s.Root, "ro")
 	if err := os.MkdirAll(parent, 0o755); err != nil {

--- a/cli/internal/manifest/manifest_coverage_test.go
+++ b/cli/internal/manifest/manifest_coverage_test.go
@@ -1,0 +1,248 @@
+package manifest_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jjfantini/humblSKILLS/cli/internal/manifest"
+	"github.com/jjfantini/humblSKILLS/cli/internal/testutil"
+)
+
+func sampleInstall(skill, platform, scope string) manifest.Installation {
+	return manifest.Installation{
+		Skill:       skill,
+		Version:     "1.0.0",
+		Platform:    platform,
+		Scope:       scope,
+		Path:        "/tmp/" + skill,
+		InstalledAt: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		SourceSHA:   "abc",
+		RegistryRef: "sha-" + skill,
+	}
+}
+
+func TestDefaultPath_ResolvesUnderSandboxedXDG(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	p, err := manifest.DefaultPath()
+	if err != nil {
+		t.Fatalf("DefaultPath: %v", err)
+	}
+	if !strings.HasPrefix(p, s.XDGStateHome) {
+		t.Errorf("DefaultPath %q not under XDG_STATE_HOME %q", p, s.XDGStateHome)
+	}
+	if filepath.Base(p) != "manifest.json" {
+		t.Errorf("basename = %q", filepath.Base(p))
+	}
+}
+
+func TestLoad_RejectsUnsupportedSchemaVersion(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	body := `{"schema_version": 42, "installations": []}` + "\n"
+	if err := os.MkdirAll(filepath.Dir(s.ManifestPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(s.ManifestPath, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manifest.Load(s.ManifestPath); err == nil {
+		t.Fatal("expected error for unsupported schema_version")
+	}
+}
+
+func TestLoad_RejectsCorruptJSON(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	if err := os.MkdirAll(filepath.Dir(s.ManifestPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(s.ManifestPath, []byte("{not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manifest.Load(s.ManifestPath); err == nil {
+		t.Fatal("expected parse error")
+	}
+}
+
+func TestLoad_UpgradesLegacyZeroSchemaVersion(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	body := `{"installations":[]}` + "\n"
+	if err := os.MkdirAll(filepath.Dir(s.ManifestPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(s.ManifestPath, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	m, err := manifest.Load(s.ManifestPath)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if m.SchemaVersion != manifest.SchemaVersion {
+		t.Errorf("SchemaVersion not upgraded: %d", m.SchemaVersion)
+	}
+}
+
+func TestSave_NilManifestRejected(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	if err := manifest.Save(s.ManifestPath, nil); err == nil {
+		t.Fatal("expected error for nil manifest")
+	}
+}
+
+func TestSave_FailsWhenParentUnwritable(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	parent := filepath.Join(s.Root, "ro")
+	if err := os.MkdirAll(parent, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(parent, 0o500); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(parent, 0o755) })
+
+	target := filepath.Join(parent, "nested", "manifest.json")
+	if err := manifest.Save(target, &manifest.Manifest{}); err == nil {
+		t.Fatal("expected Save to fail with unwritable parent")
+	}
+}
+
+func TestSave_StampsSchemaVersion(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	m := &manifest.Manifest{} // zero schema_version
+	if err := manifest.Save(s.ManifestPath, m); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	data, err := os.ReadFile(s.ManifestPath)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	var raw struct {
+		SchemaVersion int `json:"schema_version"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatal(err)
+	}
+	if raw.SchemaVersion != manifest.SchemaVersion {
+		t.Errorf("schema_version = %d, want %d", raw.SchemaVersion, manifest.SchemaVersion)
+	}
+}
+
+func TestFind_ReturnsFirstMatch(t *testing.T) {
+	m := &manifest.Manifest{SchemaVersion: manifest.SchemaVersion}
+	m.Upsert(sampleInstall("foo", "claude-code", "user"))
+	m.Upsert(sampleInstall("foo", "cursor-agent", "project"))
+
+	got := m.Find("foo")
+	if got == nil {
+		t.Fatal("Find returned nil")
+	}
+	// Order is insertion order — first install wins.
+	if got.Platform != "claude-code" {
+		t.Errorf("platform = %q", got.Platform)
+	}
+	if m.Find("absent") != nil {
+		t.Error("Find returned non-nil for absent skill")
+	}
+}
+
+func TestFindAll_ReturnsEveryMatch(t *testing.T) {
+	m := &manifest.Manifest{SchemaVersion: manifest.SchemaVersion}
+	m.Upsert(sampleInstall("foo", "claude-code", "user"))
+	m.Upsert(sampleInstall("foo", "cursor-agent", "project"))
+	m.Upsert(sampleInstall("bar", "claude-code", "user"))
+
+	got := m.FindAll("foo")
+	if len(got) != 2 {
+		t.Errorf("len = %d, want 2", len(got))
+	}
+}
+
+func TestFindOne_PrecisionMatch(t *testing.T) {
+	m := &manifest.Manifest{SchemaVersion: manifest.SchemaVersion}
+	m.Upsert(sampleInstall("foo", "claude-code", "user"))
+	if got := m.FindOne("foo", "claude-code", "user"); got == nil {
+		t.Error("FindOne should hit")
+	}
+	if got := m.FindOne("foo", "claude-code", "project"); got != nil {
+		t.Error("FindOne should miss on wrong scope")
+	}
+	if got := m.FindOne("foo", "cursor-agent", "user"); got != nil {
+		t.Error("FindOne should miss on wrong platform")
+	}
+	if got := m.FindOne("bar", "claude-code", "user"); got != nil {
+		t.Error("FindOne should miss on wrong skill")
+	}
+}
+
+func TestUpsert_ReplacesOnSameKey(t *testing.T) {
+	m := &manifest.Manifest{SchemaVersion: manifest.SchemaVersion}
+	m.Upsert(sampleInstall("foo", "claude-code", "user"))
+	upgraded := sampleInstall("foo", "claude-code", "user")
+	upgraded.Version = "2.0.0"
+	m.Upsert(upgraded)
+	if len(m.Installations) != 1 {
+		t.Fatalf("len = %d, want 1", len(m.Installations))
+	}
+	if m.Installations[0].Version != "2.0.0" {
+		t.Errorf("version = %q", m.Installations[0].Version)
+	}
+}
+
+func TestRemove_DropsEveryMatchAndReturnsCount(t *testing.T) {
+	m := &manifest.Manifest{SchemaVersion: manifest.SchemaVersion}
+	m.Upsert(sampleInstall("foo", "claude-code", "user"))
+	m.Upsert(sampleInstall("foo", "cursor-agent", "project"))
+	m.Upsert(sampleInstall("bar", "claude-code", "user"))
+
+	n := m.Remove("foo")
+	if n != 2 {
+		t.Errorf("Remove returned %d, want 2", n)
+	}
+	if len(m.Installations) != 1 || m.Installations[0].Skill != "bar" {
+		t.Errorf("unexpected remaining: %+v", m.Installations)
+	}
+	if n := m.Remove("ghost"); n != 0 {
+		t.Errorf("Remove ghost returned %d", n)
+	}
+}
+
+func TestRemoveOne_ExactMatchOnly(t *testing.T) {
+	m := &manifest.Manifest{SchemaVersion: manifest.SchemaVersion}
+	m.Upsert(sampleInstall("foo", "claude-code", "user"))
+	m.Upsert(sampleInstall("foo", "cursor-agent", "project"))
+
+	if !m.RemoveOne("foo", "claude-code", "user") {
+		t.Error("RemoveOne should return true on hit")
+	}
+	if len(m.Installations) != 1 {
+		t.Errorf("len = %d, want 1", len(m.Installations))
+	}
+	if m.RemoveOne("foo", "claude-code", "user") {
+		t.Error("second RemoveOne on same key should return false")
+	}
+}
+
+func TestSaveLoad_RoundTripPreservesEveryField(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	m := &manifest.Manifest{SchemaVersion: manifest.SchemaVersion}
+	m.Upsert(sampleInstall("foo", "claude-code", "user"))
+	m.Upsert(sampleInstall("bar", "cursor-agent", "project"))
+
+	if err := manifest.Save(s.ManifestPath, m); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	got, err := manifest.Load(s.ManifestPath)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(got.Installations) != 2 {
+		t.Fatalf("installs = %d", len(got.Installations))
+	}
+	for i, want := range m.Installations {
+		if got.Installations[i] != want {
+			t.Errorf("install[%d] mismatch:\n got=%+v\nwant=%+v", i, got.Installations[i], want)
+		}
+	}
+}

--- a/cli/internal/profile/profile_test.go
+++ b/cli/internal/profile/profile_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -198,6 +199,9 @@ func TestFilterKnownPlatforms(t *testing.T) {
 }
 
 func TestSave_FailsWhenParentUnwritable(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("chmod 0500 does not prevent write on windows")
+	}
 	s := testutil.NewSandbox(t)
 	// Create a readonly parent directory and target a file inside it.
 	parent := filepath.Join(s.Root, "ro")

--- a/cli/internal/profile/profile_test.go
+++ b/cli/internal/profile/profile_test.go
@@ -1,0 +1,249 @@
+package profile_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jjfantini/humblSKILLS/cli/internal/profile"
+	"github.com/jjfantini/humblSKILLS/cli/internal/testutil"
+)
+
+func TestLoad_MissingFileReturnsEmptyProfile(t *testing.T) {
+	s := testutil.NewSandbox(t)
+
+	p, err := profile.Load(s.ProfilePath)
+	if err != nil {
+		t.Fatalf("Load on missing file returned error: %v", err)
+	}
+	if p == nil {
+		t.Fatal("Load returned nil profile")
+	}
+	if p.SchemaVersion != profile.SchemaVersion {
+		t.Errorf("SchemaVersion = %d, want %d", p.SchemaVersion, profile.SchemaVersion)
+	}
+	if len(p.DefaultPlatforms) != 0 || p.DefaultScope != "" || p.Eval != nil {
+		t.Errorf("fresh profile has non-zero fields: %+v", p)
+	}
+}
+
+func TestSave_WritesAtomicallyAndRoundTrips(t *testing.T) {
+	s := testutil.NewSandbox(t)
+
+	in := &profile.Profile{
+		DefaultPlatforms: []string{"claude-code", "cursor"},
+		DefaultScope:     "project",
+		Eval: &profile.EvalProfile{
+			Runner:                 "anthropic-api",
+			ExecutorModel:          "claude-sonnet-4-6",
+			GraderModel:            "claude-opus-4-7",
+			RunsPerConfiguration:   3,
+			Parallel:               2,
+			DefaultWorkspace:       "/tmp/ws",
+			IncludeBlindComparator: true,
+		},
+	}
+	if err := profile.Save(s.ProfilePath, in); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	// The .tmp file must not linger after a successful rename.
+	if _, err := os.Stat(s.ProfilePath + ".tmp"); err == nil {
+		t.Error("tmp file leaked after successful Save")
+	}
+
+	out, err := profile.Load(s.ProfilePath)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if out.DefaultScope != "project" {
+		t.Errorf("DefaultScope = %q", out.DefaultScope)
+	}
+	if got := strings.Join(out.DefaultPlatforms, ","); got != "claude-code,cursor" {
+		t.Errorf("DefaultPlatforms = %q", got)
+	}
+	if out.Eval == nil || out.Eval.Runner != "anthropic-api" {
+		t.Errorf("Eval lost in round-trip: %+v", out.Eval)
+	}
+	if !out.Eval.IncludeBlindComparator {
+		t.Error("IncludeBlindComparator not round-tripped")
+	}
+}
+
+func TestSave_StampsSchemaVersionWhenZero(t *testing.T) {
+	s := testutil.NewSandbox(t)
+
+	// Caller didn't set SchemaVersion — Save must stamp the current one.
+	in := &profile.Profile{DefaultScope: "user"}
+	if err := profile.Save(s.ProfilePath, in); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	data, err := os.ReadFile(s.ProfilePath)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	var raw struct {
+		SchemaVersion int `json:"schema_version"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if raw.SchemaVersion != profile.SchemaVersion {
+		t.Errorf("on-disk schema_version = %d, want %d", raw.SchemaVersion, profile.SchemaVersion)
+	}
+}
+
+func TestSave_NilProfileErrors(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	if err := profile.Save(s.ProfilePath, nil); err == nil {
+		t.Fatal("expected error for nil profile")
+	}
+}
+
+func TestLoad_RejectsUnknownSchemaVersion(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	body := `{"schema_version": 999, "default_scope": "user"}` + "\n"
+	if err := os.MkdirAll(filepath.Dir(s.ProfilePath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(s.ProfilePath, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := profile.Load(s.ProfilePath); err == nil {
+		t.Fatal("expected error for unsupported schema_version")
+	}
+}
+
+func TestLoad_RejectsCorruptJSON(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	if err := os.MkdirAll(filepath.Dir(s.ProfilePath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(s.ProfilePath, []byte("{not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := profile.Load(s.ProfilePath); err == nil {
+		t.Fatal("expected parse error for corrupt profile")
+	}
+}
+
+func TestLoad_UpgradesLegacyZeroSchemaVersion(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	// Hand-written / legacy profile with no schema_version at all.
+	body := `{"default_scope": "user"}` + "\n"
+	if err := os.MkdirAll(filepath.Dir(s.ProfilePath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(s.ProfilePath, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	p, err := profile.Load(s.ProfilePath)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if p.SchemaVersion != profile.SchemaVersion {
+		t.Errorf("SchemaVersion not upgraded: got %d", p.SchemaVersion)
+	}
+	if p.DefaultScope != "user" {
+		t.Errorf("DefaultScope = %q", p.DefaultScope)
+	}
+}
+
+func TestDelete_RemovesFile_AndToleratesMissing(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	if err := profile.Save(s.ProfilePath, &profile.Profile{DefaultScope: "user"}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if err := profile.Delete(s.ProfilePath); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, err := os.Stat(s.ProfilePath); err == nil {
+		t.Error("profile file still exists after Delete")
+	}
+	// Deleting a missing file must be a no-op, not an error.
+	if err := profile.Delete(s.ProfilePath); err != nil {
+		t.Errorf("Delete on missing file: %v", err)
+	}
+}
+
+func TestDefaultPath_ResolvesUnderSandboxedXDG(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	got, err := profile.DefaultPath()
+	if err != nil {
+		t.Fatalf("DefaultPath: %v", err)
+	}
+	if !strings.HasPrefix(got, s.XDGConfigHome) {
+		t.Errorf("DefaultPath = %q, want under %q", got, s.XDGConfigHome)
+	}
+	if filepath.Base(got) != "config.json" {
+		t.Errorf("DefaultPath basename = %q, want config.json", filepath.Base(got))
+	}
+}
+
+func TestFilterKnownPlatforms(t *testing.T) {
+	known := map[string]struct{}{"claude-code": {}, "cursor": {}}
+	kept, dropped := profile.FilterKnownPlatforms(
+		[]string{"claude-code", "vscode", "cursor", "emacs"},
+		known,
+	)
+	if strings.Join(kept, ",") != "claude-code,cursor" {
+		t.Errorf("kept = %v", kept)
+	}
+	if strings.Join(dropped, ",") != "vscode,emacs" {
+		t.Errorf("dropped = %v", dropped)
+	}
+}
+
+func TestSave_FailsWhenParentUnwritable(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	// Create a readonly parent directory and target a file inside it.
+	parent := filepath.Join(s.Root, "ro")
+	if err := os.MkdirAll(parent, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(parent, 0o500); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(parent, 0o755) })
+
+	target := filepath.Join(parent, "nested", "config.json")
+	if err := profile.Save(target, &profile.Profile{DefaultScope: "user"}); err == nil {
+		t.Fatal("expected Save to fail when parent is unwritable")
+	}
+}
+
+func TestDelete_ReturnsErrorWhenPathIsDirectory(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	// A directory at the profile path makes os.Remove fail with a
+	// non-ErrNotExist error, which Delete should surface.
+	if err := os.MkdirAll(s.ProfilePath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Put a sentinel inside so os.Remove fails even on permissive OSes
+	// (darwin/linux allow removing an empty dir with os.Remove).
+	if err := os.WriteFile(filepath.Join(s.ProfilePath, "guard"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := profile.Delete(s.ProfilePath); err == nil {
+		t.Fatal("expected error removing non-empty directory at profile path")
+	}
+}
+
+func TestIsValidScope(t *testing.T) {
+	cases := map[string]bool{
+		"":        true,
+		"user":    true,
+		"project": true,
+		"global":  false,
+		"USER":    false,
+		" user":   false,
+	}
+	for in, want := range cases {
+		if got := profile.IsValidScope(in); got != want {
+			t.Errorf("IsValidScope(%q) = %v, want %v", in, got, want)
+		}
+	}
+}

--- a/cli/internal/registry/benchmark_test.go
+++ b/cli/internal/registry/benchmark_test.go
@@ -1,0 +1,60 @@
+package registry_test
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/jjfantini/humblSKILLS/cli/internal/registry"
+)
+
+// buildBenchTree materialises a representative skill tree for DirSHA
+// benchmarking. N files across M subdirs approximates a medium skill
+// (SKILL.md + references/ + scripts/).
+func buildBenchTree(b *testing.B, root string, files int) {
+	b.Helper()
+	for i := 0; i < files; i++ {
+		sub := filepath.Join(root, "dir"+strconv.Itoa(i%5))
+		if err := os.MkdirAll(sub, 0o755); err != nil {
+			b.Fatal(err)
+		}
+		body := "file " + strconv.Itoa(i) + " content with some padding for realism."
+		if err := os.WriteFile(filepath.Join(sub, "f"+strconv.Itoa(i)+".md"), []byte(body), 0o644); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkDirSHA_SmallTree(b *testing.B) {
+	dir := b.TempDir()
+	buildBenchTree(b, dir, 10)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := registry.DirSHA(dir); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkDirSHA_MediumTree(b *testing.B) {
+	dir := b.TempDir()
+	buildBenchTree(b, dir, 100)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := registry.DirSHA(dir); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkDirSHA_LargeTree(b *testing.B) {
+	dir := b.TempDir()
+	buildBenchTree(b, dir, 500)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := registry.DirSHA(dir); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/cli/internal/registry/fetcher_coverage_test.go
+++ b/cli/internal/registry/fetcher_coverage_test.go
@@ -1,0 +1,227 @@
+package registry_test
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jjfantini/humblSKILLS/cli/internal/registry"
+)
+
+func TestInspect_AfterLoad_ReportsExistsAndAge(t *testing.T) {
+	body := `{"schema_version":1,"skills":[]}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, body)
+	}))
+	defer srv.Close()
+
+	cache := t.TempDir()
+	clock := time.Now()
+	f := registry.NewFetcher(srv.URL, cache)
+	f.Now = func() time.Time { return clock }
+
+	if _, _, err := f.Load(); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	clock = clock.Add(2 * time.Minute)
+	info := f.Inspect()
+	if !info.Exists {
+		t.Error("Inspect reports Exists=false after Load")
+	}
+	if info.Age < 2*time.Minute {
+		t.Errorf("Age = %v, want >= 2m", info.Age)
+	}
+	if info.URL != srv.URL {
+		t.Errorf("URL = %q", info.URL)
+	}
+}
+
+func TestInspect_LocalPath_ReturnsLocalURLAndNoAge(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "registry.json")
+	_ = os.WriteFile(path, []byte(`{"schema_version":1}`), 0o644)
+
+	f := registry.NewFetcher("file://"+path, t.TempDir())
+	info := f.Inspect()
+	if info.Exists {
+		t.Errorf("local URL Inspect should report Exists=false, got %+v", info)
+	}
+}
+
+func TestLoad_BareFilesystemPath(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "registry.json")
+	if err := os.WriteFile(path, []byte(`{"schema_version":1,"skills":[]}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// No file:// prefix — bare path should route through loadLocal.
+	f := registry.NewFetcher(path, t.TempDir())
+	_, src, err := f.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if src != registry.OriginFile {
+		t.Errorf("source = %q, want file", src)
+	}
+}
+
+func TestRefresh_LocalRoute(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "registry.json")
+	if err := os.WriteFile(path, []byte(`{"schema_version":1,"skills":[]}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	f := registry.NewFetcher("file://"+path, t.TempDir())
+	_, src, err := f.Refresh()
+	if err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+	if src != registry.OriginFile {
+		t.Errorf("Refresh(file) source = %q", src)
+	}
+}
+
+func TestRefresh_HTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(500)
+	}))
+	defer srv.Close()
+
+	f := registry.NewFetcher(srv.URL, t.TempDir())
+	if _, _, err := f.Refresh(); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestLoad_LocalFileMissing(t *testing.T) {
+	f := registry.NewFetcher("file:///definitely/not/a/real/path/registry.json", t.TempDir())
+	if _, _, err := f.Load(); err == nil {
+		t.Fatal("expected error for missing local registry")
+	}
+}
+
+func TestLoad_MalformedJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "{not json")
+	}))
+	defer srv.Close()
+	f := registry.NewFetcher(srv.URL, t.TempDir())
+	_, _, err := f.Load()
+	if err == nil {
+		t.Fatal("expected parse error")
+	}
+	if !strings.Contains(err.Error(), "parse") {
+		t.Errorf("err missing parse context: %v", err)
+	}
+}
+
+func TestValidateDeps_AllPassWhenNoRequires(t *testing.T) {
+	reg := &registry.Registry{
+		Skills: []registry.Skill{
+			{Name: "a", Version: "1.0.0"},
+			{Name: "b", Version: "1.0.0"},
+		},
+	}
+	if got := registry.ValidateDeps(reg); len(got) != 0 {
+		t.Errorf("unexpected issues: %v", got)
+	}
+}
+
+func TestValidateDeps_UnknownDepFlagged(t *testing.T) {
+	reg := &registry.Registry{
+		Skills: []registry.Skill{
+			{Name: "a", Version: "1.0.0", Requires: []string{"ghost@1.0.0"}},
+		},
+	}
+	issues := registry.ValidateDeps(reg)
+	if len(issues) != 1 || issues[0].Kind != registry.IssueUnknown {
+		t.Errorf("issues = %v", issues)
+	}
+}
+
+func TestValidateDeps_UnsatisfiedDepFlagged(t *testing.T) {
+	reg := &registry.Registry{
+		Skills: []registry.Skill{
+			{Name: "a", Version: "1.0.0", Requires: []string{"b@>=2.0.0"}},
+			{Name: "b", Version: "1.0.0"},
+		},
+	}
+	issues := registry.ValidateDeps(reg)
+	if len(issues) != 1 || issues[0].Kind != registry.IssueUnsatisfied {
+		t.Errorf("issues = %v", issues)
+	}
+}
+
+func TestValidateDeps_UnparseableDepFlagged(t *testing.T) {
+	reg := &registry.Registry{
+		Skills: []registry.Skill{
+			{Name: "a", Version: "1.0.0", Requires: []string{"@@@bad"}},
+		},
+	}
+	issues := registry.ValidateDeps(reg)
+	if len(issues) != 1 || issues[0].Kind != registry.IssueParse {
+		t.Errorf("issues = %v", issues)
+	}
+}
+
+func TestValidateDeps_CycleFlagged(t *testing.T) {
+	reg := &registry.Registry{
+		Skills: []registry.Skill{
+			{Name: "a", Version: "1.0.0", Requires: []string{"b@1.0.0"}},
+			{Name: "b", Version: "1.0.0", Requires: []string{"a@1.0.0"}},
+		},
+	}
+	issues := registry.ValidateDeps(reg)
+	found := false
+	for _, i := range issues {
+		if i.Kind == registry.IssueCycle {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("cycle not flagged: %v", issues)
+	}
+}
+
+func TestValidateDeps_NilRegistryReturnsNoIssues(t *testing.T) {
+	if got := registry.ValidateDeps(nil); got != nil {
+		t.Errorf("got %v, want nil", got)
+	}
+}
+
+func TestIssue_Error_CycleOmitsSkillAndDep(t *testing.T) {
+	i := registry.Issue{Kind: registry.IssueCycle, Msg: "a -> b -> a"}
+	if !strings.Contains(i.Error(), "cycle") || strings.Contains(i.Error(), "skill ") {
+		t.Errorf("Error = %q", i.Error())
+	}
+}
+
+func TestIssue_Error_NonCycleIncludesSkillAndDep(t *testing.T) {
+	i := registry.Issue{Kind: registry.IssueUnknown, Skill: "a", Dep: "b", Msg: "missing"}
+	if !strings.Contains(i.Error(), `skill "a"`) || !strings.Contains(i.Error(), `dep "b"`) {
+		t.Errorf("Error = %q", i.Error())
+	}
+}
+
+// localPath handles URLs that url.Parse chokes on (bad percent-encoding
+// etc.). Production code fails back to a raw TrimPrefix.
+func TestLoadLocal_HandlesWeirdFileURL(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "registry.json")
+	if err := os.WriteFile(path, []byte(`{"schema_version":1}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// A URL with just "file://" + absolute path on a Mac hits the
+	// url.Parse branch.
+	f := registry.NewFetcher("file://"+path, t.TempDir())
+	if _, _, err := f.Load(); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+}

--- a/cli/internal/resolver/benchmark_test.go
+++ b/cli/internal/resolver/benchmark_test.go
@@ -1,0 +1,25 @@
+package resolver_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/jjfantini/humblSKILLS/cli/internal/resolver"
+)
+
+// BenchmarkTopoSort_100 tests a graph sized like a realistic skill
+// dependency set (100 nodes, ~3 edges each).
+func BenchmarkTopoSort_100(b *testing.B) {
+	g := resolver.New()
+	for i := 0; i < 100; i++ {
+		for j := 1; j <= 3 && i-j >= 0; j++ {
+			g.AddEdge(fmt.Sprintf("n%d", i), fmt.Sprintf("n%d", i-j))
+		}
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := g.TopoSort(); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/cli/internal/resolver/fuzz_test.go
+++ b/cli/internal/resolver/fuzz_test.go
@@ -1,0 +1,44 @@
+package resolver_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jjfantini/humblSKILLS/cli/internal/resolver"
+)
+
+// FuzzTopoSort feeds arbitrary edge sequences into the graph and
+// ensures TopoSort never panics. Cycles are a legitimate outcome
+// surfaced as *CycleError; any other error means the caller has a
+// bigger bug (none today — the function only returns *CycleError or nil).
+func FuzzTopoSort(f *testing.F) {
+	// Seed with well-formed and malformed graphs.
+	seeds := []string{
+		"",
+		"a b",          // edge a -> b
+		"a b\nb c",     // chain
+		"a b\nb a",     // cycle
+		"a a",          // self-loop
+		"a b\nc d",     // disconnected
+		"a b\nb c\nc a", // longer cycle
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+
+	f.Fuzz(func(t *testing.T, s string) {
+		g := resolver.New()
+		for _, line := range strings.Split(s, "\n") {
+			parts := strings.Fields(line)
+			if len(parts) == 0 {
+				continue
+			}
+			if len(parts) == 1 {
+				g.AddNode(parts[0])
+				continue
+			}
+			g.AddEdge(parts[0], parts[1])
+		}
+		_, _ = g.TopoSort()
+	})
+}

--- a/cli/internal/secrets/secrets_coverage_test.go
+++ b/cli/internal/secrets/secrets_coverage_test.go
@@ -1,0 +1,198 @@
+package secrets_test
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/jjfantini/humblSKILLS/cli/internal/secrets"
+	"github.com/jjfantini/humblSKILLS/cli/internal/testutil"
+)
+
+// Tests in this file use the testutil sandbox so XDG resolution hits
+// sandboxed paths, letting us exercise NewStore's default-path branch
+// and DefaultFilePath without risk of polluting the developer's home.
+
+func TestNewStore_DefaultsToXDGConfig(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	testutil.UseFakeKeyring(t)
+
+	store, err := secrets.NewStore("")
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	// Driving Set + Get confirms the default path is usable.
+	if _, err := store.Set("anthropic", "k"); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	// File may or may not exist depending on whether the mock keyring
+	// accepted the value, but DefaultFilePath must point inside the
+	// sandbox XDG config tree.
+	got, err := secrets.DefaultFilePath()
+	if err != nil {
+		t.Fatalf("DefaultFilePath: %v", err)
+	}
+	if !strings.HasPrefix(got, s.XDGConfigHome) {
+		t.Errorf("DefaultFilePath = %q, want prefix %q", got, s.XDGConfigHome)
+	}
+	if filepath.Base(got) != "secrets.json" {
+		t.Errorf("DefaultFilePath basename = %q", filepath.Base(got))
+	}
+}
+
+func TestSet_UnknownProvider(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	testutil.UseFakeKeyring(t)
+	store, _ := secrets.NewStore(s.SecretsPath)
+	if _, err := store.Set("nope", "value"); err == nil {
+		t.Fatal("expected error for unknown provider")
+	}
+}
+
+func TestSet_EmptyValueRefused(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	testutil.UseFakeKeyring(t)
+	store, _ := secrets.NewStore(s.SecretsPath)
+	if _, err := store.Set("anthropic", "   "); err == nil {
+		t.Fatal("expected error when storing empty/whitespace secret")
+	}
+}
+
+func TestSet_KeyringUnavailable_WithFileFallbackFailure(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	testutil.UseUnavailableKeyring(t, errors.New("dbus down"))
+
+	// Route the file path through a location that can't be created
+	// (an existing regular file at what should be the secrets dir).
+	blockPath := filepath.Join(s.Root, "blocker")
+	if err := os.WriteFile(blockPath, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	badSecretsPath := filepath.Join(blockPath, "secrets.json") // parent is a file!
+
+	store, err := secrets.NewStore(badSecretsPath)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	_, err = store.Set("anthropic", "should-fail")
+	if err == nil {
+		t.Fatal("expected error when both keyring and file fallback fail")
+	}
+	if !strings.Contains(err.Error(), "keyring unavailable") {
+		t.Errorf("err message should mention keyring unavailable: %v", err)
+	}
+}
+
+func TestGet_UnknownProviderErrors(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	testutil.UseFakeKeyring(t)
+	store, _ := secrets.NewStore(s.SecretsPath)
+	_, _, err := store.Get("ghost")
+	if err == nil {
+		t.Fatal("expected error for unknown provider")
+	}
+}
+
+func TestDelete_UnknownProviderErrors(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	testutil.UseFakeKeyring(t)
+	store, _ := secrets.NewStore(s.SecretsPath)
+	if err := store.Delete("ghost"); err == nil {
+		t.Fatal("expected error for unknown provider")
+	}
+}
+
+func TestSet_RemovesStaleFileCopyOnKeyringSuccess(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	testutil.UseFakeKeyring(t)
+	store, _ := secrets.NewStore(s.SecretsPath)
+
+	// Unavailable keyring puts the secret in the file...
+	testutil.UseUnavailableKeyring(t, errors.New("gone"))
+	if _, err := store.Set("anthropic", "from-file"); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	if _, err := os.Stat(s.SecretsPath); err != nil {
+		t.Fatalf("file should exist after file-fallback Set: %v", err)
+	}
+
+	// ...then keyring comes back online; a new Set should land in the
+	// keyring AND remove the stale file entry. writeFileSecret("") on
+	// the last key removes the whole file.
+	testutil.UseFakeKeyring(t)
+	if _, err := store.Set("anthropic", "from-keyring"); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	if _, err := os.Stat(s.SecretsPath); !os.IsNotExist(err) {
+		t.Errorf("stale file should be removed once keyring succeeds; stat err=%v", err)
+	}
+}
+
+func TestKeyringAvailable_WithMockInit(t *testing.T) {
+	testutil.UseFakeKeyring(t)
+	if !secrets.KeyringAvailable() {
+		t.Error("mock keyring should report Available=true")
+	}
+}
+
+func TestKeyringAvailable_WithBrokenKeyring(t *testing.T) {
+	testutil.UseUnavailableKeyring(t, errors.New("service missing"))
+	if secrets.KeyringAvailable() {
+		t.Error("broken keyring should report Available=false")
+	}
+}
+
+func TestReadFile_IgnoresCorruptJSON(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	// Keyring empty so Get must fall through to the file layer.
+	testutil.UseFakeKeyring(t)
+	if err := os.MkdirAll(filepath.Dir(s.SecretsPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(s.SecretsPath, []byte("not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	store, _ := secrets.NewStore(s.SecretsPath)
+	_, src, err := store.Get("anthropic")
+	if err != nil {
+		t.Fatalf("Get on corrupt file returned err: %v", err)
+	}
+	if src != secrets.SourceAbsent {
+		t.Errorf("source = %q, want absent (corrupt file treated as missing)", src)
+	}
+}
+
+func TestProviders_IsStableSorted(t *testing.T) {
+	ps := secrets.Providers()
+	if len(ps) == 0 {
+		t.Fatal("Providers returned empty list")
+	}
+	for i := 1; i < len(ps); i++ {
+		if ps[i].Name < ps[i-1].Name {
+			t.Errorf("Providers not sorted: %v", ps)
+			break
+		}
+	}
+}
+
+func TestFilePerm_IsHonoredOnPOSIX(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission bits not honored on windows")
+	}
+	s := testutil.NewSandbox(t)
+	testutil.UseUnavailableKeyring(t, errors.New("force file path"))
+	store, _ := secrets.NewStore(s.SecretsPath)
+	if _, err := store.Set("openai", "sk-file"); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	info, err := os.Stat(s.SecretsPath)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Errorf("perm = %o, want 0600", info.Mode().Perm())
+	}
+}

--- a/cli/internal/testutil/fakerunner.go
+++ b/cli/internal/testutil/fakerunner.go
@@ -1,0 +1,89 @@
+package testutil
+
+import (
+	"context"
+	"sync"
+
+	"github.com/jjfantini/humblSKILLS/cli/internal/eval/runner"
+)
+
+// FakeRunner is a scriptable runner.Runner for eval tests. Responses
+// can be queued in advance (Queue) or generated lazily (Handler).
+// Every Execute call is recorded on Calls for assertions.
+//
+// Unlike the production mock runner at internal/eval/runner/mock (which
+// mimics agent behaviour for end-to-end harness tests), FakeRunner
+// exists purely for unit tests that need deterministic control over
+// per-call behaviour — e.g. "first call succeeds, second returns rate
+// limit, third times out".
+type FakeRunner struct {
+	NameVal    string
+	Caps       runner.Capabilities
+	DoctorVal  runner.DoctorCheck
+	Handler    func(ctx context.Context, req runner.Request) (*runner.Result, error)
+
+	mu    sync.Mutex
+	queue []runnerResponse
+	calls []runner.Request
+}
+
+type runnerResponse struct {
+	res *runner.Result
+	err error
+}
+
+// NewFakeRunner returns a FakeRunner with name "fake" and empty caps.
+func NewFakeRunner() *FakeRunner {
+	return &FakeRunner{NameVal: "fake"}
+}
+
+// Queue appends a canned (result, err) to the response queue. Execute
+// pops from this queue in order; if empty, Handler is consulted; if
+// both are unset, Execute returns a minimal successful Result.
+func (f *FakeRunner) Queue(res *runner.Result, err error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.queue = append(f.queue, runnerResponse{res: res, err: err})
+}
+
+// Calls returns the requests observed so far, in call order. Safe to
+// call concurrently with Execute.
+func (f *FakeRunner) Calls() []runner.Request {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]runner.Request, len(f.calls))
+	copy(out, f.calls)
+	return out
+}
+
+// Reset clears both the call log and the response queue.
+func (f *FakeRunner) Reset() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = nil
+	f.queue = nil
+}
+
+func (f *FakeRunner) Name() string                        { return f.NameVal }
+func (f *FakeRunner) Capabilities() runner.Capabilities   { return f.Caps }
+func (f *FakeRunner) DoctorCheck(context.Context) runner.DoctorCheck {
+	return f.DoctorVal
+}
+
+func (f *FakeRunner) Execute(ctx context.Context, req runner.Request) (*runner.Result, error) {
+	f.mu.Lock()
+	f.calls = append(f.calls, req)
+	if len(f.queue) > 0 {
+		resp := f.queue[0]
+		f.queue = f.queue[1:]
+		f.mu.Unlock()
+		return resp.res, resp.err
+	}
+	handler := f.Handler
+	f.mu.Unlock()
+
+	if handler != nil {
+		return handler(ctx, req)
+	}
+	return &runner.Result{TotalTokens: 1}, nil
+}

--- a/cli/internal/testutil/fsgolden.go
+++ b/cli/internal/testutil/fsgolden.go
@@ -1,0 +1,165 @@
+package testutil
+
+import (
+	"flag"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// updateGolden is flipped by `go test -update`. When true, failing
+// AssertGoldenDir / AssertGoldenFile calls rewrite the golden data
+// rather than failing. The flag is registered once at package init.
+var updateGolden = flag.Bool("update", false, "update testutil golden files instead of comparing")
+
+// UpdateRequested reports whether -update was passed. Useful when
+// individual test packages want to key custom regeneration logic off
+// the same flag.
+func UpdateRequested() bool { return updateGolden != nil && *updateGolden }
+
+// SnapshotDir walks root and returns a deterministic map from
+// relative slash-paths to file contents. Directories are represented
+// as keys ending in "/" with empty value. Symlinks fail the test
+// (the production code refuses to emit them).
+func SnapshotDir(t testing.TB, root string) map[string]string {
+	t.Helper()
+	out := map[string]string{}
+	err := filepath.Walk(root, func(p string, fi os.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		rel, err := filepath.Rel(root, p)
+		if err != nil {
+			return err
+		}
+		if rel == "." {
+			return nil
+		}
+		rel = filepath.ToSlash(rel)
+		if fi.Mode()&os.ModeSymlink != 0 {
+			t.Fatalf("snapshot: unexpected symlink at %s", p)
+		}
+		if fi.IsDir() {
+			out[rel+"/"] = ""
+			return nil
+		}
+		data, err := os.ReadFile(p)
+		if err != nil {
+			return err
+		}
+		out[rel] = string(data)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("snapshot %s: %v", root, err)
+	}
+	return out
+}
+
+// AssertGoldenDir diffs the on-disk tree at actualDir against the
+// golden tree at goldenDir. When `-update` is set, goldenDir is
+// rewritten from actualDir. Otherwise any mismatch fails the test
+// with a minimal diff pointing at the first offending path.
+func AssertGoldenDir(t testing.TB, actualDir, goldenDir string) {
+	t.Helper()
+	actual := SnapshotDir(t, actualDir)
+
+	if UpdateRequested() {
+		if err := os.RemoveAll(goldenDir); err != nil {
+			t.Fatalf("clean golden %s: %v", goldenDir, err)
+		}
+		for rel, body := range actual {
+			dst := filepath.Join(goldenDir, filepath.FromSlash(rel))
+			if strings.HasSuffix(rel, "/") {
+				if err := os.MkdirAll(dst, 0o755); err != nil {
+					t.Fatalf("mkdir %s: %v", dst, err)
+				}
+				continue
+			}
+			if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+				t.Fatalf("mkdir %s: %v", filepath.Dir(dst), err)
+			}
+			if err := os.WriteFile(dst, []byte(body), 0o644); err != nil {
+				t.Fatalf("write %s: %v", dst, err)
+			}
+		}
+		return
+	}
+
+	expected := SnapshotDir(t, goldenDir)
+	diff := diffSnapshots(expected, actual)
+	if diff != "" {
+		t.Fatalf("%s does not match %s:\n%s\n(rerun with -update to regenerate)", actualDir, goldenDir, diff)
+	}
+}
+
+// AssertGoldenBytes compares data against the contents of goldenPath.
+// With -update, goldenPath is rewritten.
+func AssertGoldenBytes(t testing.TB, data []byte, goldenPath string) {
+	t.Helper()
+	if UpdateRequested() {
+		if err := os.MkdirAll(filepath.Dir(goldenPath), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", filepath.Dir(goldenPath), err)
+		}
+		if err := os.WriteFile(goldenPath, data, 0o644); err != nil {
+			t.Fatalf("write %s: %v", goldenPath, err)
+		}
+		return
+	}
+	want, err := os.ReadFile(goldenPath)
+	if err != nil {
+		t.Fatalf("read golden %s: %v (rerun with -update to create)", goldenPath, err)
+	}
+	if string(want) != string(data) {
+		t.Fatalf("%s mismatch\n--- want ---\n%s\n--- got ---\n%s",
+			goldenPath, truncate(string(want)), truncate(string(data)))
+	}
+}
+
+// diffSnapshots returns "" when the maps are equal, else a short
+// description of the first differing key (missing on either side or
+// mismatching body).
+func diffSnapshots(want, got map[string]string) string {
+	var keys []string
+	seen := map[string]struct{}{}
+	for k := range want {
+		if _, ok := seen[k]; !ok {
+			seen[k] = struct{}{}
+			keys = append(keys, k)
+		}
+	}
+	for k := range got {
+		if _, ok := seen[k]; !ok {
+			seen[k] = struct{}{}
+			keys = append(keys, k)
+		}
+	}
+	sort.Strings(keys)
+	var b strings.Builder
+	for _, k := range keys {
+		w, okW := want[k]
+		g, okG := got[k]
+		switch {
+		case !okW:
+			b.WriteString("  + unexpected: " + k + "\n")
+		case !okG:
+			b.WriteString("  - missing:    " + k + "\n")
+		case w != g:
+			b.WriteString("  ~ differs:    " + k + "\n")
+			b.WriteString("    want: " + truncate(w) + "\n")
+			b.WriteString("    got:  " + truncate(g) + "\n")
+		}
+	}
+	return b.String()
+}
+
+func truncate(s string) string {
+	const max = 200
+	s = strings.ReplaceAll(s, "\n", "\\n")
+	if len(s) > max {
+		return s[:max] + "…"
+	}
+	return s
+}

--- a/cli/internal/testutil/keyringfake.go
+++ b/cli/internal/testutil/keyringfake.go
@@ -1,0 +1,26 @@
+package testutil
+
+import (
+	"testing"
+
+	"github.com/zalando/go-keyring"
+)
+
+// UseFakeKeyring installs a process-wide in-memory keyring mock for
+// the duration of t. After the test returns, the mock is reinstalled
+// (fresh, empty) so leaked state never bleeds across tests.
+//
+// The real OS keyring is never touched. Safe to use on CI.
+func UseFakeKeyring(t testing.TB) {
+	t.Helper()
+	keyring.MockInit()
+	t.Cleanup(func() { keyring.MockInit() })
+}
+
+// UseUnavailableKeyring simulates an OS keyring that always fails.
+// Used to exercise the secrets package's file-fallback path.
+func UseUnavailableKeyring(t testing.TB, err error) {
+	t.Helper()
+	keyring.MockInitWithError(err)
+	t.Cleanup(func() { keyring.MockInit() })
+}

--- a/cli/internal/testutil/registryserver.go
+++ b/cli/internal/testutil/registryserver.go
@@ -1,0 +1,221 @@
+package testutil
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/jjfantini/humblSKILLS/cli/internal/registry"
+)
+
+// RegistryServer is an httptest.Server that serves a configurable
+// registry.json. Tarballs are not served here (the production Fetcher
+// hardcodes codeload.github.com); use SeedTarball to pre-populate the
+// on-disk tarball cache instead.
+type RegistryServer struct {
+	t   testing.TB
+	srv *httptest.Server
+
+	mu       sync.Mutex
+	body     []byte
+	status   int
+	requests int
+}
+
+// NewRegistryServer returns a started RegistryServer serving reg as the
+// initial payload. Status defaults to 200. The server is registered
+// with t.Cleanup and will be closed automatically.
+func NewRegistryServer(t testing.TB, reg *registry.Registry) *RegistryServer {
+	t.Helper()
+	rs := &RegistryServer{t: t, status: http.StatusOK}
+	rs.SetRegistry(reg)
+	rs.srv = httptest.NewServer(http.HandlerFunc(rs.handle))
+	t.Cleanup(rs.srv.Close)
+	return rs
+}
+
+// URL returns the base URL callers should pass as --registry or
+// HUMBLSKILLS_REGISTRY. It always maps to the registry.json endpoint.
+func (rs *RegistryServer) URL() string { return rs.srv.URL + "/registry.json" }
+
+// SetRegistry replaces the payload served on subsequent requests.
+func (rs *RegistryServer) SetRegistry(reg *registry.Registry) {
+	rs.mu.Lock()
+	defer rs.mu.Unlock()
+	if reg == nil {
+		rs.body = nil
+		return
+	}
+	if reg.SchemaVersion == 0 {
+		reg.SchemaVersion = registry.SchemaVersion
+	}
+	body, err := json.MarshalIndent(reg, "", "  ")
+	if err != nil {
+		rs.t.Fatalf("marshal registry: %v", err)
+	}
+	rs.body = body
+}
+
+// SetStatus sets the HTTP status returned on subsequent requests. Used
+// to simulate network failures (404/500) and cache fall-back behaviour.
+func (rs *RegistryServer) SetStatus(code int) {
+	rs.mu.Lock()
+	defer rs.mu.Unlock()
+	rs.status = code
+}
+
+// Requests returns the number of requests served so far.
+func (rs *RegistryServer) Requests() int {
+	rs.mu.Lock()
+	defer rs.mu.Unlock()
+	return rs.requests
+}
+
+// SetRawBody is an escape hatch for tests that want to exercise the
+// parser with deliberately malformed JSON or a mismatched
+// schema_version. Bypasses SetRegistry's marshalling.
+func (rs *RegistryServer) SetRawBody(body []byte) {
+	rs.mu.Lock()
+	defer rs.mu.Unlock()
+	rs.body = body
+}
+
+func (rs *RegistryServer) handle(w http.ResponseWriter, r *http.Request) {
+	rs.mu.Lock()
+	status := rs.status
+	body := append([]byte(nil), rs.body...)
+	rs.requests++
+	rs.mu.Unlock()
+
+	if !strings.HasSuffix(r.URL.Path, "/registry.json") {
+		http.NotFound(w, r)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_, _ = w.Write(body)
+}
+
+// ---- tarball seeding -------------------------------------------------------
+
+// SkillTree is the in-memory layout for one skill. Keys are
+// repo-relative paths *under* skillPath (e.g. "SKILL.md",
+// "data/notes.md" — not "skills/foo/SKILL.md").
+type SkillTree = map[string]string
+
+// TarballSpec describes what SeedTarball should write.
+type TarballSpec struct {
+	// Owner / Name / SHA match registry.Source. The tarball is written
+	// at cacheDir/tars/{owner}-{name}-{sha}.tar.gz.
+	Owner, Name, SHA string
+
+	// RepoPrefix is the top-level directory GitHub prepends to codeload
+	// tarballs, e.g. "jjfantini-humblSKILLS-abc1234". If empty, a
+	// deterministic value derived from Owner/Name/SHA is used.
+	RepoPrefix string
+
+	// Skills maps a repo-relative skill directory (e.g. "skills/foo")
+	// to the files inside that directory. Extra files outside skill
+	// roots can be added via ExtraFiles.
+	Skills map[string]SkillTree
+
+	// ExtraFiles writes additional repo-relative files into the
+	// tarball, e.g. "README.md", "registry.json". Useful for
+	// build-registry tests.
+	ExtraFiles map[string]string
+}
+
+// SeedTarball writes a gzipped tarball mimicking a codeload archive
+// into the fetch cache at cacheDir/tars/. Returns the tarball path.
+func SeedTarball(t testing.TB, cacheDir string, spec TarballSpec) string {
+	t.Helper()
+	if spec.Owner == "" || spec.Name == "" || spec.SHA == "" {
+		t.Fatalf("seed tarball: owner/name/sha required")
+	}
+	prefix := spec.RepoPrefix
+	if prefix == "" {
+		short := spec.SHA
+		if len(short) > 7 {
+			short = short[:7]
+		}
+		prefix = spec.Owner + "-" + spec.Name + "-" + short
+	}
+
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+
+	addDir := func(name string) {
+		if err := tw.WriteHeader(&tar.Header{
+			Name: name + "/", Typeflag: tar.TypeDir, Mode: 0o755,
+		}); err != nil {
+			t.Fatalf("tar dir %s: %v", name, err)
+		}
+	}
+	addFile := func(name, body string) {
+		if err := tw.WriteHeader(&tar.Header{
+			Name: name, Typeflag: tar.TypeReg, Mode: 0o644, Size: int64(len(body)),
+		}); err != nil {
+			t.Fatalf("tar hdr %s: %v", name, err)
+		}
+		if _, err := tw.Write([]byte(body)); err != nil {
+			t.Fatalf("tar body %s: %v", name, err)
+		}
+	}
+
+	addDir(prefix)
+
+	// Emit in sorted order so tarball bytes are deterministic across
+	// runs (useful for golden-file comparisons of DirSHA-adjacent code).
+	var skillPaths []string
+	for sp := range spec.Skills {
+		skillPaths = append(skillPaths, sp)
+	}
+	sort.Strings(skillPaths)
+	for _, sp := range skillPaths {
+		var files []string
+		for f := range spec.Skills[sp] {
+			files = append(files, f)
+		}
+		sort.Strings(files)
+		for _, f := range files {
+			addFile(prefix+"/"+sp+"/"+f, spec.Skills[sp][f])
+		}
+	}
+
+	var extras []string
+	for f := range spec.ExtraFiles {
+		extras = append(extras, f)
+	}
+	sort.Strings(extras)
+	for _, f := range extras {
+		addFile(prefix+"/"+f, spec.ExtraFiles[f])
+	}
+
+	if err := tw.Close(); err != nil {
+		t.Fatalf("tar close: %v", err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatalf("gz close: %v", err)
+	}
+
+	dir := filepath.Join(cacheDir, "tars")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+	fname := spec.Owner + "-" + spec.Name + "-" + spec.SHA + ".tar.gz"
+	tarPath := filepath.Join(dir, fname)
+	if err := os.WriteFile(tarPath, buf.Bytes(), 0o644); err != nil {
+		t.Fatalf("write %s: %v", tarPath, err)
+	}
+	return tarPath
+}

--- a/cli/internal/testutil/sandbox.go
+++ b/cli/internal/testutil/sandbox.go
@@ -1,0 +1,126 @@
+// Package testutil provides shared fixtures for humblskills tests:
+// isolated filesystem/env sandboxes, an HTTP registry test server,
+// tarball seeders, fake keyrings, golden-tree assertions, and a
+// configurable fake eval runner.
+//
+// This package is test-only. Nothing here should be imported by
+// production code.
+package testutil
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/adrg/xdg"
+)
+
+// Sandbox is an isolated filesystem + env for one test. Every XDG
+// base directory, $HOME, and the resolved humblskills paths live
+// under t.TempDir(), so tests never touch real user state.
+type Sandbox struct {
+	Root         string // t.TempDir()
+	Home         string
+	XDGDataHome  string
+	XDGConfigHome string
+	XDGStateHome string
+	XDGCacheHome string
+
+	// CacheDir is humblskills' cache root (tarballs + registry.json).
+	CacheDir string
+	// ManifestPath is the install manifest the CLI will read/write.
+	ManifestPath string
+	// ProfilePath is the profile config the CLI will read/write.
+	ProfilePath string
+	// SecretsPath is the file-fallback path for secrets.
+	SecretsPath string
+}
+
+// NewSandbox returns a fully-isolated Sandbox for the current test.
+// On return, HOME and all XDG_* env vars point inside t.TempDir(),
+// and xdg.Reload() has been called so xdg.ConfigFile/StateFile
+// resolve to sandboxed paths. Cleanup restores the previous env.
+func NewSandbox(t testing.TB) *Sandbox {
+	t.Helper()
+	root := t.TempDir()
+
+	s := &Sandbox{
+		Root:          root,
+		Home:          filepath.Join(root, "home"),
+		XDGDataHome:   filepath.Join(root, "xdg", "data"),
+		XDGConfigHome: filepath.Join(root, "xdg", "config"),
+		XDGStateHome:  filepath.Join(root, "xdg", "state"),
+		XDGCacheHome:  filepath.Join(root, "xdg", "cache"),
+	}
+	for _, d := range []string{s.Home, s.XDGDataHome, s.XDGConfigHome, s.XDGStateHome, s.XDGCacheHome} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", d, err)
+		}
+	}
+
+	s.CacheDir = filepath.Join(s.XDGCacheHome, "humblskills")
+	s.ManifestPath = filepath.Join(s.XDGStateHome, "humblskills", "manifest.json")
+	s.ProfilePath = filepath.Join(s.XDGConfigHome, "humblskills", "config.json")
+	s.SecretsPath = filepath.Join(s.XDGConfigHome, "humblskills", "secrets.json")
+
+	setenv(t, "HOME", s.Home)
+	setenv(t, "XDG_DATA_HOME", s.XDGDataHome)
+	setenv(t, "XDG_CONFIG_HOME", s.XDGConfigHome)
+	setenv(t, "XDG_STATE_HOME", s.XDGStateHome)
+	setenv(t, "XDG_CACHE_HOME", s.XDGCacheHome)
+	// Neutralise HUMBLSKILLS_* vars so tests can't pick up the caller's
+	// shell config. Tests that want to exercise these opt back in.
+	setenv(t, "HUMBLSKILLS_REGISTRY", "")
+	setenv(t, "HUMBLSKILLS_CACHE_DIR", "")
+	setenv(t, "HUMBLSKILLS_MANIFEST", "")
+	setenv(t, "HUMBLSKILLS_PROFILE", "")
+	// Provider API keys must not leak from the developer's shell into
+	// secrets-resolution tests. Tests that need a key set it explicitly.
+	setenv(t, "ANTHROPIC_API_KEY", "")
+	setenv(t, "OPENAI_API_KEY", "")
+
+	// xdg package snapshots env at package init; reload so our overrides
+	// actually take effect for xdg.ConfigFile/StateFile/DataFile callers.
+	xdg.Reload()
+	t.Cleanup(xdg.Reload)
+
+	return s
+}
+
+// setenv sets an env var and registers a t.Cleanup that restores the
+// previous value (or unsets it if previously unset).
+func setenv(t testing.TB, key, value string) {
+	t.Helper()
+	prev, had := os.LookupEnv(key)
+	if err := os.Setenv(key, value); err != nil {
+		t.Fatalf("setenv %s: %v", key, err)
+	}
+	t.Cleanup(func() {
+		if had {
+			_ = os.Setenv(key, prev)
+		} else {
+			_ = os.Unsetenv(key)
+		}
+	})
+}
+
+// Setenv exposes setenv so tests can override individual vars while
+// still getting cleanup tracking.
+func (s *Sandbox) Setenv(t testing.TB, key, value string) {
+	t.Helper()
+	setenv(t, key, value)
+}
+
+// WriteFile writes data under the sandbox root at the given relative
+// path, creating parents as needed. Returns the absolute path.
+func (s *Sandbox) WriteFile(t testing.TB, rel string, data []byte) string {
+	t.Helper()
+	abs := filepath.Join(s.Root, rel)
+	if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(abs), err)
+	}
+	if err := os.WriteFile(abs, data, 0o644); err != nil {
+		t.Fatalf("write %s: %v", abs, err)
+	}
+	return abs
+}

--- a/cli/internal/testutil/sandbox.go
+++ b/cli/internal/testutil/sandbox.go
@@ -64,6 +64,10 @@ func NewSandbox(t testing.TB) *Sandbox {
 	s.SecretsPath = filepath.Join(s.XDGConfigHome, "humblskills", "secrets.json")
 
 	setenv(t, "HOME", s.Home)
+	// Windows resolves os.UserHomeDir() via %USERPROFILE%; without this
+	// override, ~-expansion and adapter detection on Windows CI still
+	// points at the real runner home rather than the sandbox.
+	setenv(t, "USERPROFILE", s.Home)
 	setenv(t, "XDG_DATA_HOME", s.XDGDataHome)
 	setenv(t, "XDG_CONFIG_HOME", s.XDGConfigHome)
 	setenv(t, "XDG_STATE_HOME", s.XDGStateHome)

--- a/cli/internal/testutil/skillfixture.go
+++ b/cli/internal/testutil/skillfixture.go
@@ -1,0 +1,103 @@
+package testutil
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/jjfantini/humblSKILLS/cli/internal/registry"
+)
+
+// SkillFixture describes one skill to include in a BuildRegistry call.
+type SkillFixture struct {
+	Name        string
+	Version     string
+	Description string
+	Tags        []string
+	Platforms   []string
+	Requires    []string
+	Preserve    []string
+	// Path inside the (fake) repo, e.g. "skills/foo". Defaults to
+	// "skills/" + Name when empty.
+	Path string
+	// Files maps paths *inside* the skill directory to bodies. At
+	// minimum supply a "SKILL.md".
+	Files SkillTree
+}
+
+// BuildRegistry builds a registry.Registry pinned to owner/name@sha
+// containing every SkillFixture (with correct DirSHA), and seeds the
+// fetch tarball cache at cacheDir so install.Engine can resolve it
+// offline.
+//
+// Returns the fully-populated Registry. Callers typically pass the
+// result to install.Engine.Execute or write it to disk for
+// file://-url registry tests.
+func BuildRegistry(t testing.TB, cacheDir, owner, name, sha string, fixtures []SkillFixture) *registry.Registry {
+	t.Helper()
+
+	skills := make(map[string]SkillTree, len(fixtures))
+	reg := &registry.Registry{
+		SchemaVersion: registry.SchemaVersion,
+		Source: registry.Source{
+			Repo: "github.com/" + owner + "/" + name,
+			SHA:  sha,
+		},
+	}
+
+	sorted := append([]SkillFixture(nil), fixtures...)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].Name < sorted[j].Name })
+
+	for _, f := range sorted {
+		path := f.Path
+		if path == "" {
+			path = "skills/" + f.Name
+		}
+		if _, ok := f.Files["SKILL.md"]; !ok {
+			t.Fatalf("fixture %q: Files must include SKILL.md", f.Name)
+		}
+		skills[path] = f.Files
+
+		reg.Skills = append(reg.Skills, registry.Skill{
+			Name:        f.Name,
+			Version:     f.Version,
+			Description: f.Description,
+			Tags:        f.Tags,
+			Platforms:   f.Platforms,
+			Requires:    f.Requires,
+			Preserve:    f.Preserve,
+			Path:        path,
+			DirSHA:      dirSHAForFiles(t, f.Files),
+		})
+	}
+
+	SeedTarball(t, cacheDir, TarballSpec{
+		Owner: owner, Name: name, SHA: sha,
+		Skills: skills,
+	})
+
+	return reg
+}
+
+// dirSHAForFiles materialises files in a temp directory and returns
+// registry.DirSHA(dir). Because DirSHA walks the tree deterministically,
+// this must match what install.Engine computes after extraction.
+func dirSHAForFiles(t testing.TB, files SkillTree) string {
+	t.Helper()
+	dir := t.TempDir()
+	for rel, body := range files {
+		abs := filepath.Join(dir, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", filepath.Dir(abs), err)
+		}
+		if err := os.WriteFile(abs, []byte(body), 0o644); err != nil {
+			t.Fatalf("write %s: %v", abs, err)
+		}
+	}
+	sha, err := registry.DirSHA(dir)
+	if err != nil {
+		t.Fatalf("dir_sha: %v", err)
+	}
+	return sha
+}

--- a/cli/internal/testutil/testutil_test.go
+++ b/cli/internal/testutil/testutil_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -178,8 +179,9 @@ func TestUnavailableKeyring_FallsBackToFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("stat secrets: %v", err)
 	}
-	// 0o600 enforced on write.
-	if info.Mode().Perm() != 0o600 {
+	// 0o600 enforced on write — but Windows doesn't honor the Unix
+	// permission bits passed to OpenFile, so this assertion is POSIX-only.
+	if runtime.GOOS != "windows" && info.Mode().Perm() != 0o600 {
 		t.Errorf("secrets perm = %o, want 0600", info.Mode().Perm())
 	}
 }

--- a/cli/internal/testutil/testutil_test.go
+++ b/cli/internal/testutil/testutil_test.go
@@ -1,0 +1,213 @@
+package testutil_test
+
+import (
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/adrg/xdg"
+
+	"github.com/jjfantini/humblSKILLS/cli/internal/fetch"
+	"github.com/jjfantini/humblSKILLS/cli/internal/registry"
+	"github.com/jjfantini/humblSKILLS/cli/internal/secrets"
+	"github.com/jjfantini/humblSKILLS/cli/internal/testutil"
+)
+
+func TestSandbox_IsolatesEnvAndXDG(t *testing.T) {
+	prevHome := os.Getenv("HOME")
+
+	s := testutil.NewSandbox(t)
+
+	if got := os.Getenv("HOME"); got != s.Home {
+		t.Errorf("HOME = %q, want %q", got, s.Home)
+	}
+	if got := os.Getenv("XDG_CONFIG_HOME"); got != s.XDGConfigHome {
+		t.Errorf("XDG_CONFIG_HOME = %q, want %q", got, s.XDGConfigHome)
+	}
+	if !strings.HasPrefix(xdg.ConfigHome, s.XDGConfigHome) {
+		t.Errorf("xdg.ConfigHome = %q, want prefix %q", xdg.ConfigHome, s.XDGConfigHome)
+	}
+	// HUMBLSKILLS_* should be cleared, not inherited.
+	if got := os.Getenv("HUMBLSKILLS_REGISTRY"); got != "" {
+		t.Errorf("HUMBLSKILLS_REGISTRY leaked: %q", got)
+	}
+	// ANTHROPIC_API_KEY must be neutralised so secret tests are deterministic.
+	if got := os.Getenv("ANTHROPIC_API_KEY"); got != "" {
+		t.Errorf("ANTHROPIC_API_KEY leaked: %q", got)
+	}
+
+	// After the test returns, env must be restored. We can't observe
+	// t.Cleanup directly from within the same test, but we can assert
+	// that the previous value we captured still lives somewhere and
+	// t.Cleanup will run later. Sanity check: prev captured non-empty.
+	if prevHome == "" {
+		t.Log("developer HOME was empty — cleanup check skipped")
+	}
+}
+
+func TestRegistryServer_ServesRegistryAndTracksRequests(t *testing.T) {
+	testutil.NewSandbox(t)
+
+	reg := &registry.Registry{
+		SchemaVersion: registry.SchemaVersion,
+		Source:        registry.Source{Repo: "x/y", SHA: "deadbeef"},
+	}
+	srv := testutil.NewRegistryServer(t, reg)
+
+	// 200 first
+	resp, err := http.Get(srv.URL())
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Errorf("status = %d", resp.StatusCode)
+	}
+	if !strings.Contains(string(body), `"sha": "deadbeef"`) {
+		t.Errorf("body missing sha: %s", body)
+	}
+
+	// switch to 500 and confirm the new status flows
+	srv.SetStatus(500)
+	resp2, _ := http.Get(srv.URL())
+	resp2.Body.Close()
+	if resp2.StatusCode != 500 {
+		t.Errorf("status after SetStatus(500) = %d", resp2.StatusCode)
+	}
+
+	if got := srv.Requests(); got != 2 {
+		t.Errorf("requests = %d, want 2", got)
+	}
+}
+
+func TestBuildRegistry_SeedsTarballAndEngineCanExtract(t *testing.T) {
+	s := testutil.NewSandbox(t)
+
+	reg := testutil.BuildRegistry(t, s.CacheDir, "example", "repo", "0123456789abcdef", []testutil.SkillFixture{
+		{
+			Name:    "foo",
+			Version: "1.0.0",
+			Files: testutil.SkillTree{
+				"SKILL.md":       "# foo\n",
+				"data/notes.md":  "hello\n",
+			},
+		},
+	})
+
+	if len(reg.Skills) != 1 {
+		t.Fatalf("skills = %d", len(reg.Skills))
+	}
+	skill := reg.Skills[0]
+	if skill.DirSHA == "" {
+		t.Error("DirSHA empty")
+	}
+
+	// Extract via the production Fetch path and confirm the seeded
+	// tarball is usable and DirSHA recomputes to the same value.
+	f := fetch.NewFetcher(s.CacheDir)
+	tarPath, err := f.Fetch(reg.Source.Repo, reg.Source.SHA)
+	if err != nil {
+		t.Fatalf("fetch: %v", err)
+	}
+	dest := filepath.Join(t.TempDir(), "out")
+	if err := fetch.Extract(tarPath, skill.Path, dest); err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	got, err := registry.DirSHA(dest)
+	if err != nil {
+		t.Fatalf("dir_sha: %v", err)
+	}
+	if got != skill.DirSHA {
+		t.Errorf("DirSHA mismatch after round-trip: seeded=%s got=%s", skill.DirSHA, got)
+	}
+}
+
+func TestFakeKeyring_IntegratesWithSecretsLayeredStore(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	testutil.UseFakeKeyring(t)
+
+	store, err := secrets.NewStore(s.SecretsPath)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	src, err := store.Set("anthropic", "sk-test-abc")
+	if err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	if src != secrets.SourceKeyring {
+		t.Errorf("Set source = %q, want keyring", src)
+	}
+	got, src, err := store.Get("anthropic")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got != "sk-test-abc" || src != secrets.SourceKeyring {
+		t.Errorf("Get = (%q, %q), want (sk-test-abc, keyring)", got, src)
+	}
+
+	// After Delete, no source should hold the secret.
+	if err := store.Delete("anthropic"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	_, src, _ = store.Get("anthropic")
+	if src != secrets.SourceAbsent {
+		t.Errorf("post-Delete source = %q, want absent", src)
+	}
+}
+
+func TestUnavailableKeyring_FallsBackToFile(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	testutil.UseUnavailableKeyring(t, errBoom{})
+
+	store, err := secrets.NewStore(s.SecretsPath)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	src, err := store.Set("anthropic", "sk-file")
+	if err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	if src != secrets.SourceFile {
+		t.Errorf("Set source = %q, want file", src)
+	}
+	info, err := os.Stat(s.SecretsPath)
+	if err != nil {
+		t.Fatalf("stat secrets: %v", err)
+	}
+	// 0o600 enforced on write.
+	if info.Mode().Perm() != 0o600 {
+		t.Errorf("secrets perm = %o, want 0600", info.Mode().Perm())
+	}
+}
+
+type errBoom struct{}
+
+func (errBoom) Error() string { return "boom" }
+
+func TestSnapshotAndGoldenDir_RoundTrip(t *testing.T) {
+	src := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(src, "sub"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "a.txt"), []byte("alpha"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "sub", "b.txt"), []byte("beta"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	snap := testutil.SnapshotDir(t, src)
+	if snap["a.txt"] != "alpha" {
+		t.Errorf("snap[a.txt] = %q", snap["a.txt"])
+	}
+	if snap["sub/b.txt"] != "beta" {
+		t.Errorf("snap[sub/b.txt] = %q", snap["sub/b.txt"])
+	}
+	if _, ok := snap["sub/"]; !ok {
+		t.Errorf("snap missing sub/ directory marker: %v", snap)
+	}
+}

--- a/cli/internal/testutil/yamlutil.go
+++ b/cli/internal/testutil/yamlutil.go
@@ -1,0 +1,63 @@
+package testutil
+
+import (
+	"bytes"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ParseYAMLMapping unmarshals yml into a YAML mapping node. Fails the
+// test if the input is not a top-level mapping. Shared helper for
+// tests that need to inspect or rewrite frontmatter-style YAML.
+func ParseYAMLMapping(t testing.TB, yml string) *yaml.Node {
+	t.Helper()
+	var root yaml.Node
+	if err := yaml.Unmarshal([]byte(yml), &root); err != nil {
+		t.Fatalf("parse yaml: %v", err)
+	}
+	if root.Kind != yaml.DocumentNode || len(root.Content) == 0 {
+		t.Fatalf("unexpected root: %#v", root)
+	}
+	m := root.Content[0]
+	if m.Kind != yaml.MappingNode {
+		t.Fatalf("root is not a mapping: %#v", m)
+	}
+	return m
+}
+
+// EncodeYAML serialises a YAML node at indent 2 and returns the result.
+func EncodeYAML(t testing.TB, node *yaml.Node) string {
+	t.Helper()
+	var buf bytes.Buffer
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(2)
+	if err := enc.Encode(node); err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	if err := enc.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	return buf.String()
+}
+
+// MappingKeys returns the ordered list of top-level scalar keys in a
+// YAML mapping node.
+func MappingKeys(m *yaml.Node) []string {
+	var out []string
+	for i := 0; i+1 < len(m.Content); i += 2 {
+		out = append(out, m.Content[i].Value)
+	}
+	return out
+}
+
+// MappingSub returns the node stored under key in mapping m, or nil if
+// key is absent.
+func MappingSub(m *yaml.Node, key string) *yaml.Node {
+	for i := 0; i+1 < len(m.Content); i += 2 {
+		if m.Content[i].Value == key {
+			return m.Content[i+1]
+		}
+	}
+	return nil
+}

--- a/cli/internal/tui/dashboard_test.go
+++ b/cli/internal/tui/dashboard_test.go
@@ -1,0 +1,278 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/jjfantini/humblSKILLS/cli/internal/ui"
+)
+
+func TestDefaultDashboardTiles_Shape(t *testing.T) {
+	tiles := DefaultDashboardTiles()
+	if len(tiles) < 9 {
+		t.Fatalf("want at least 9 tiles, got %d", len(tiles))
+	}
+	hotkeys := map[string]bool{}
+	commands := map[string]bool{}
+	for _, tl := range tiles {
+		if tl.Command == "" {
+			t.Errorf("tile missing command: %+v", tl)
+		}
+		if tl.Label == "" {
+			t.Errorf("tile missing label: %+v", tl)
+		}
+		if tl.Hotkey != "" && hotkeys[tl.Hotkey] {
+			t.Errorf("duplicate hotkey %q", tl.Hotkey)
+		}
+		hotkeys[tl.Hotkey] = true
+		if commands[tl.Command] {
+			t.Errorf("duplicate command %q", tl.Command)
+		}
+		commands[tl.Command] = true
+	}
+	// Every expected command shipped.
+	for _, want := range []string{"install", "list", "update", "search", "uninstall", "profile", "doctor", "registry", "version", "eval"} {
+		if !commands[want] {
+			t.Errorf("missing dashboard command %q", want)
+		}
+	}
+}
+
+func TestBuildDashboardGreeting_PopulatesFields(t *testing.T) {
+	g := BuildDashboardGreeting(5)
+	if g.Updates != 5 {
+		t.Errorf("Updates = %d", g.Updates)
+	}
+	// User & Cwd may be empty in sandboxed CI — just sanity-check types.
+	_ = g.User
+	_ = g.Cwd
+}
+
+func TestCompactPath(t *testing.T) {
+	// Direct compactPath call — when HOME is set and path starts with
+	// it, expect ~ prefix.
+	t.Setenv("HOME", "/tmp/userhome")
+	got := compactPath("/tmp/userhome/work/x")
+	if !strings.HasPrefix(got, "~") {
+		t.Errorf("compactPath should prefix ~: %q", got)
+	}
+	if got := compactPath("/other/path"); got != "/other/path" {
+		t.Errorf("unrelated path changed: %q", got)
+	}
+}
+
+func TestDashboardStatus_Fields(t *testing.T) {
+	// Round-trip through RenderStatusMeta just to ensure it doesn't panic
+	// and renders something visible.
+	th := ui.DefaultTheme()
+	got := RenderStatusMeta(th, DashboardStatus{Healthy: true, Platforms: 2, Skills: 5})
+	if !strings.Contains(got, "2") || !strings.Contains(got, "5") {
+		t.Errorf("status missing counts: %q", got)
+	}
+}
+
+func TestDashboardModel_QuitKeys(t *testing.T) {
+	m := dashboardModel{
+		cfg: DashboardConfig{
+			Theme: ui.DefaultTheme(),
+			Tiles: DefaultDashboardTiles(),
+		},
+	}
+	m.rebuildVisible()
+
+	cases := []string{"q", "esc", "ctrl+c"}
+	for _, k := range cases {
+		out, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(k)})
+		if k == "ctrl+c" {
+			out, cmd = m.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
+		} else if k == "esc" {
+			out, cmd = m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+		}
+		dm, ok := out.(dashboardModel)
+		if !ok {
+			t.Fatalf("key %q: Update did not return dashboardModel", k)
+		}
+		if !dm.result.Quit {
+			t.Errorf("key %q: expected Quit=true, got %+v", k, dm.result)
+		}
+		if cmd == nil {
+			t.Errorf("key %q: expected tea.Quit cmd", k)
+		}
+	}
+}
+
+func TestDashboardModel_HotkeyLaunchesCommand(t *testing.T) {
+	m := dashboardModel{
+		cfg: DashboardConfig{
+			Theme: ui.DefaultTheme(),
+			Tiles: DefaultDashboardTiles(),
+		},
+	}
+	m.rebuildVisible()
+
+	// "i" is install's hotkey.
+	out, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("i")})
+	dm, ok := out.(dashboardModel)
+	if !ok {
+		t.Fatal("Update did not return dashboardModel")
+	}
+	if dm.result.Command != "install" {
+		t.Errorf("Command = %q, want install", dm.result.Command)
+	}
+}
+
+func TestDashboardModel_SearchTogglesAndFilters(t *testing.T) {
+	m := dashboardModel{
+		cfg: DashboardConfig{
+			Theme: ui.DefaultTheme(),
+			Tiles: DefaultDashboardTiles(),
+		},
+	}
+	m.rebuildVisible()
+
+	// Press / to open search.
+	out, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("/")})
+	dm := out.(dashboardModel)
+	if !dm.searchOn {
+		t.Fatal("searchOn should be true after /")
+	}
+	// Type "ins".
+	for _, r := range "ins" {
+		out, _ = dm.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+		dm = out.(dashboardModel)
+	}
+	if dm.query != "ins" {
+		t.Errorf("query = %q", dm.query)
+	}
+	// "install" tile should be visible; "list" might not be.
+	sawInstall := false
+	for _, idx := range dm.visible {
+		if dm.cfg.Tiles[idx].Command == "install" {
+			sawInstall = true
+		}
+	}
+	if !sawInstall {
+		t.Errorf("install not in filtered visible set: %v", dm.visible)
+	}
+
+	// Esc clears query and closes search.
+	out, _ = dm.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	dm = out.(dashboardModel)
+	if dm.searchOn {
+		t.Error("searchOn should be false after esc")
+	}
+	if dm.query != "" {
+		t.Errorf("query should be cleared: %q", dm.query)
+	}
+}
+
+func TestDashboardModel_BackspaceShrinksQuery(t *testing.T) {
+	m := dashboardModel{cfg: DashboardConfig{Theme: ui.DefaultTheme(), Tiles: DefaultDashboardTiles()}}
+	m.rebuildVisible()
+	out, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("/")})
+	dm := out.(dashboardModel)
+	for _, r := range "abc" {
+		out, _ = dm.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+		dm = out.(dashboardModel)
+	}
+	out, _ = dm.Update(tea.KeyMsg{Type: tea.KeyBackspace})
+	dm = out.(dashboardModel)
+	if dm.query != "ab" {
+		t.Errorf("query = %q", dm.query)
+	}
+}
+
+func TestDashboardModel_EnterLaunchesCursor(t *testing.T) {
+	m := dashboardModel{cfg: DashboardConfig{Theme: ui.DefaultTheme(), Tiles: DefaultDashboardTiles()}}
+	m.rebuildVisible()
+	out, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	dm := out.(dashboardModel)
+	if dm.result.Command == "" {
+		t.Errorf("enter should emit a command: %+v", dm.result)
+	}
+}
+
+func TestTruncateDisplay(t *testing.T) {
+	cases := map[string]int{
+		"hello":                       10,
+		"this is a very long string":  10,
+	}
+	for in, width := range cases {
+		got := truncateDisplay(in, width)
+		// Display width must not exceed the target.
+		// Don't overspecify the ellipsis format — just that it fits.
+		if len([]rune(got)) > width+3 {
+			t.Errorf("truncateDisplay(%q, %d) = %q too wide", in, width, got)
+		}
+	}
+}
+
+func TestIndentBlock_AddsLeadingSpaces(t *testing.T) {
+	got := indentBlock("a\nb", 4)
+	for _, line := range strings.Split(got, "\n") {
+		if !strings.HasPrefix(line, "    ") {
+			t.Errorf("line not indented: %q", line)
+		}
+	}
+}
+
+func TestPluralDash(t *testing.T) {
+	if pluralDash(1) != "" {
+		t.Errorf("1 should not pluralize: %q", pluralDash(1))
+	}
+	if pluralDash(2) != "s" {
+		t.Errorf("2 should pluralize: %q", pluralDash(2))
+	}
+}
+
+func TestVersionScreenModel_QuitOnKey(t *testing.T) {
+	m := versionScreenModel{
+		cfg:    VersionScreenConfig{Theme: ui.DefaultTheme(), Info: VersionInfo{Version: "v1", Commit: "abc"}},
+		width:  80,
+		height: 24,
+	}
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("q")})
+	if cmd == nil {
+		t.Error("expected Quit cmd on q")
+	}
+	_, cmd = m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	if cmd == nil {
+		t.Error("expected Quit cmd on esc")
+	}
+	_, cmd = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd == nil {
+		t.Error("expected Quit cmd on enter")
+	}
+}
+
+func TestVersionScreenModel_View_RendersInfo(t *testing.T) {
+	m := versionScreenModel{
+		cfg:    VersionScreenConfig{Theme: ui.DefaultTheme(), Info: VersionInfo{Version: "v1.2.3", Commit: "abc123", Dirty: true}},
+		width:  100,
+		height: 24,
+	}
+	view := m.View()
+	for _, want := range []string{"humblskills", "v1.2.3", "abc123", "dirty"} {
+		if !strings.Contains(view, want) {
+			t.Errorf("view missing %q:\n%s", want, view)
+		}
+	}
+}
+
+func TestVersionScreenModel_View_EmptyBeforeSize(t *testing.T) {
+	m := versionScreenModel{cfg: VersionScreenConfig{Theme: ui.DefaultTheme()}}
+	if got := m.View(); got != "" {
+		t.Errorf("view should be empty before size set, got:\n%s", got)
+	}
+}
+
+func TestPadRight(t *testing.T) {
+	if padRight("abc", 6) != "abc   " {
+		t.Errorf("got %q", padRight("abc", 6))
+	}
+	if padRight("abcdef", 3) != "abcdef" {
+		t.Errorf("got %q", padRight("abcdef", 3))
+	}
+}

--- a/cli/internal/tui/dashboard_test.go
+++ b/cli/internal/tui/dashboard_test.go
@@ -1,6 +1,8 @@
 package tui
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -51,10 +53,17 @@ func TestBuildDashboardGreeting_PopulatesFields(t *testing.T) {
 }
 
 func TestCompactPath(t *testing.T) {
-	// Direct compactPath call — when HOME is set and path starts with
-	// it, expect ~ prefix.
+	// Drive compactPath with the actual home directory as resolved by
+	// os.UserHomeDir (Unix reads $HOME, Windows reads %USERPROFILE%)
+	// so the prefix-match logic behaves the same on every platform.
 	t.Setenv("HOME", "/tmp/userhome")
-	got := compactPath("/tmp/userhome/work/x")
+	t.Setenv("USERPROFILE", "/tmp/userhome")
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("UserHomeDir: %v", err)
+	}
+	got := compactPath(filepath.Join(home, "work", "x"))
 	if !strings.HasPrefix(got, "~") {
 		t.Errorf("compactPath should prefix ~: %q", got)
 	}

--- a/cli/internal/tui/dashboard_test.go
+++ b/cli/internal/tui/dashboard_test.go
@@ -53,22 +53,24 @@ func TestBuildDashboardGreeting_PopulatesFields(t *testing.T) {
 }
 
 func TestCompactPath(t *testing.T) {
-	// Drive compactPath with the actual home directory as resolved by
-	// os.UserHomeDir (Unix reads $HOME, Windows reads %USERPROFILE%)
-	// so the prefix-match logic behaves the same on every platform.
-	t.Setenv("HOME", "/tmp/userhome")
-	t.Setenv("USERPROFILE", "/tmp/userhome")
+	// Use a real tempdir as the "home" so the path separators match
+	// whatever the OS natively produces. Point both HOME and
+	// USERPROFILE at it — Unix reads $HOME, Windows reads %USERPROFILE%.
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
 
-	home, err := os.UserHomeDir()
-	if err != nil {
-		t.Fatalf("UserHomeDir: %v", err)
-	}
-	got := compactPath(filepath.Join(home, "work", "x"))
-	if !strings.HasPrefix(got, "~") {
+	inside := filepath.Join(home, "work", "x")
+	if got := compactPath(inside); !strings.HasPrefix(got, "~") {
 		t.Errorf("compactPath should prefix ~: %q", got)
 	}
-	if got := compactPath("/other/path"); got != "/other/path" {
-		t.Errorf("unrelated path changed: %q", got)
+
+	// A path unrelated to home passes through unchanged. Use the OS's
+	// temp dir root so we get an actually-unrelated absolute path on
+	// every platform.
+	unrelated := filepath.Join(os.TempDir(), "definitely-not-home-"+filepath.Base(home))
+	if got := compactPath(unrelated); got != unrelated {
+		t.Errorf("unrelated path changed: got %q want %q", got, unrelated)
 	}
 }
 

--- a/cli/internal/tui/listdetail_test.go
+++ b/cli/internal/tui/listdetail_test.go
@@ -1,0 +1,189 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/jjfantini/humblSKILLS/cli/internal/ui"
+)
+
+type testItem struct {
+	name, filter string
+}
+
+func (t testItem) Key() string                                     { return t.name }
+func (t testItem) FilterValue() string                              { return t.filter }
+func (t testItem) Row(_ *ui.Theme, _ int, selected bool) string    { return t.name }
+func (t testItem) Detail(_ *ui.Theme, _ int) string                { return "detail:" + t.name }
+
+func newTestListDetail(items []Item, actions []ActionSpec) Model {
+	return NewListDetail(Config{
+		Theme:      ui.DefaultTheme(),
+		Section:    "Test",
+		Version:    "v1",
+		Items:      items,
+		LeftTitle:  "LEFT",
+		RightTitle: "RIGHT",
+		Actions:    actions,
+		EmptyMsg:   "empty",
+	})
+}
+
+func TestNewListDetail_AppliesDefaults(t *testing.T) {
+	m := NewListDetail(Config{})
+	if m.cfg.LeftTitle != "ITEMS" {
+		t.Errorf("LeftTitle = %q", m.cfg.LeftTitle)
+	}
+	if m.cfg.RightTitle != "DETAIL" {
+		t.Errorf("RightTitle = %q", m.cfg.RightTitle)
+	}
+	if m.cfg.Theme == nil {
+		t.Error("Theme should default to DefaultTheme")
+	}
+}
+
+func TestModel_QuitKey(t *testing.T) {
+	m := newTestListDetail([]Item{testItem{name: "a", filter: "a"}}, nil)
+	out, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("q")})
+	mm := out.(Model)
+	if !mm.result.Quit {
+		t.Error("expected Quit")
+	}
+	if cmd == nil {
+		t.Error("expected Quit cmd")
+	}
+}
+
+func TestModel_DownArrow_MovesCursor(t *testing.T) {
+	m := newTestListDetail([]Item{
+		testItem{name: "a", filter: "a"},
+		testItem{name: "b", filter: "b"},
+	}, nil)
+	m.width, m.height = 80, 24
+	out, _ := m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	mm := out.(Model)
+	if mm.cursor != 1 {
+		t.Errorf("cursor = %d, want 1", mm.cursor)
+	}
+}
+
+func TestModel_UpArrow_BoundedAtZero(t *testing.T) {
+	m := newTestListDetail([]Item{testItem{name: "a", filter: "a"}}, nil)
+	out, _ := m.Update(tea.KeyMsg{Type: tea.KeyUp})
+	mm := out.(Model)
+	if mm.cursor != 0 {
+		t.Errorf("cursor should stay at 0, got %d", mm.cursor)
+	}
+}
+
+func TestModel_FilterTogglesAndMatches(t *testing.T) {
+	m := newTestListDetail([]Item{
+		testItem{name: "alpha", filter: "alpha"},
+		testItem{name: "beta", filter: "beta"},
+	}, nil)
+	m.width, m.height = 80, 24
+
+	// Press / to open filter.
+	out, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("/")})
+	mm := out.(Model)
+	if !mm.filtOn {
+		t.Fatal("expected filter on")
+	}
+	// Type "bet".
+	for _, r := range "bet" {
+		out, _ = mm.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+		mm = out.(Model)
+	}
+	// Only beta survives.
+	if len(mm.items) != 1 || mm.items[0].Key() != "beta" {
+		t.Errorf("filter failed: %+v", mm.items)
+	}
+
+	// Enter closes filter but keeps the selection.
+	out, _ = mm.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	mm = out.(Model)
+	if mm.filtOn {
+		t.Error("enter should close filter")
+	}
+}
+
+func TestModel_FilterEscClears(t *testing.T) {
+	m := newTestListDetail([]Item{
+		testItem{name: "alpha", filter: "alpha"},
+		testItem{name: "beta", filter: "beta"},
+	}, nil)
+	// Open filter, type, then ESC.
+	out, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("/")})
+	mm := out.(Model)
+	out, _ = mm.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("a")})
+	mm = out.(Model)
+	out, _ = mm.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	mm = out.(Model)
+	if mm.filtOn {
+		t.Error("esc should close filter")
+	}
+	if len(mm.items) != 2 {
+		t.Errorf("filter not cleared: %d items", len(mm.items))
+	}
+}
+
+func TestModel_EnterFiresFirstAction(t *testing.T) {
+	m := newTestListDetail(
+		[]Item{testItem{name: "a", filter: "a"}},
+		[]ActionSpec{{Key: "i", Label: "install", Action: "install"}},
+	)
+	m.width, m.height = 80, 24
+	out, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	mm := out.(Model)
+	if mm.result.Action != "install" {
+		t.Errorf("action = %q", mm.result.Action)
+	}
+	if cmd == nil {
+		t.Error("expected Quit cmd")
+	}
+}
+
+func TestModel_ActionKeyRunsAction(t *testing.T) {
+	m := newTestListDetail(
+		[]Item{testItem{name: "a", filter: "a"}},
+		[]ActionSpec{{Key: "u", Label: "update", Action: "update"}},
+	)
+	m.width, m.height = 80, 24
+	out, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("u")})
+	mm := out.(Model)
+	if mm.result.Action != "update" {
+		t.Errorf("action = %q", mm.result.Action)
+	}
+}
+
+func TestModel_Selected_DefaultState(t *testing.T) {
+	m := newTestListDetail([]Item{testItem{name: "a", filter: "a"}}, nil)
+	r := m.Selected()
+	if r.Quit || r.Action != "" {
+		t.Errorf("initial state should be zero-valued: %+v", r)
+	}
+}
+
+func TestModel_ViewMentionsTitles(t *testing.T) {
+	m := newTestListDetail([]Item{testItem{name: "item-a", filter: "a"}}, nil)
+	m.width, m.height = 80, 24
+	m.resize()
+	v := m.View()
+	for _, want := range []string{"LEFT", "RIGHT", "item-a"} {
+		if !strings.Contains(v, want) {
+			t.Errorf("view missing %q:\n%s", want, v)
+		}
+	}
+}
+
+func TestModel_EmptyItemsShowsEmptyMsg(t *testing.T) {
+	m := newTestListDetail(nil, nil)
+	m.width, m.height = 80, 24
+	m.resize()
+	v := m.View()
+	if !strings.Contains(v, "empty") {
+		t.Errorf("empty msg missing:\n%s", v)
+	}
+}

--- a/cli/internal/tui/progress_test.go
+++ b/cli/internal/tui/progress_test.go
@@ -1,0 +1,174 @@
+package tui
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/jjfantini/humblSKILLS/cli/internal/install"
+	"github.com/jjfantini/humblSKILLS/cli/internal/ui"
+)
+
+func newTestProgress(t *testing.T) ProgressModel {
+	t.Helper()
+	events := make(chan install.Event, 8)
+	doneErr := make(chan error, 1)
+	return NewProgressModel(ui.DefaultTheme(), "install", events, doneErr)
+}
+
+func TestProgressModel_ApplyEventLifecycle(t *testing.T) {
+	m := newTestProgress(t)
+
+	// RunStart → total set.
+	m.applyEvent(install.Event{Phase: install.PhaseRunStart, Total: 3})
+	if m.total != 3 {
+		t.Errorf("total = %d", m.total)
+	}
+	// TargetStart → current set, entry tracked.
+	m.applyEvent(install.Event{
+		Phase: install.PhaseTargetStart,
+		Skill: "foo", Platform: "claude-code", Scope: "user",
+	})
+	if m.current == nil || m.current.skill != "foo" {
+		t.Errorf("current = %+v", m.current)
+	}
+	// TargetDone → done incremented, outcome recorded.
+	m.applyEvent(install.Event{
+		Phase:    install.PhaseTargetDone,
+		Skill:    "foo", Platform: "claude-code", Scope: "user",
+		Outcome:  install.OutcomeInstalled,
+	})
+	if m.done != 1 {
+		t.Errorf("done = %d", m.done)
+	}
+	if m.items[0].outcome != install.OutcomeInstalled {
+		t.Errorf("outcome not recorded: %+v", m.items[0])
+	}
+}
+
+func TestProgressModel_DeduplicatesSameKey(t *testing.T) {
+	m := newTestProgress(t)
+	for i := 0; i < 3; i++ {
+		m.applyEvent(install.Event{
+			Phase: install.PhaseTargetStart,
+			Skill: "foo", Platform: "x", Scope: "user",
+		})
+	}
+	if len(m.items) != 1 {
+		t.Errorf("items = %d, want 1", len(m.items))
+	}
+}
+
+func TestProgressModel_ErrorPhaseCapturesErr(t *testing.T) {
+	m := newTestProgress(t)
+	boom := errors.New("boom")
+	m.applyEvent(install.Event{
+		Phase: install.PhaseError,
+		Skill: "foo", Platform: "x", Scope: "user",
+		Err:   boom,
+	})
+	if m.items[0].errored != true {
+		t.Error("expected errored=true")
+	}
+	if m.err == nil || m.err.Error() != "boom" {
+		t.Errorf("err = %v", m.err)
+	}
+}
+
+func TestProgressModel_UpsertReturnsExisting(t *testing.T) {
+	m := newTestProgress(t)
+	ev := install.Event{Skill: "foo", Platform: "x", Scope: "user"}
+	a := m.upsert(ev)
+	b := m.upsert(ev)
+	if a != b {
+		t.Error("upsert must return the same entry for the same key")
+	}
+}
+
+func TestProgressModel_ViewMentionsCommandAndCounts(t *testing.T) {
+	m := newTestProgress(t)
+	m.width = 80
+	m.applyEvent(install.Event{Phase: install.PhaseRunStart, Total: 2})
+	m.applyEvent(install.Event{
+		Phase: install.PhaseTargetStart,
+		Skill: "foo", Platform: "x", Scope: "user",
+	})
+	v := m.View()
+	if !strings.Contains(v, "install") {
+		t.Errorf("view missing command header:\n%s", v)
+	}
+	if !strings.Contains(v, "0 / 2") {
+		t.Errorf("view missing counter:\n%s", v)
+	}
+	if !strings.Contains(v, "foo") {
+		t.Errorf("view missing skill:\n%s", v)
+	}
+}
+
+func TestProgressModel_ViewClosedWithError(t *testing.T) {
+	m := newTestProgress(t)
+	m.width = 80
+	m.err = errors.New("boom-err")
+	m.running = false
+	v := m.View()
+	if !strings.Contains(v, "boom-err") {
+		t.Errorf("view missing error:\n%s", v)
+	}
+	if !strings.Contains(v, "close") {
+		t.Errorf("view should show close footer when done:\n%s", v)
+	}
+}
+
+func TestSubscribe_ReadsEventThenDone(t *testing.T) {
+	events := make(chan install.Event, 1)
+	doneErr := make(chan error, 1)
+
+	events <- install.Event{Phase: install.PhaseRunStart, Total: 1}
+	cmd := Subscribe(events, doneErr)
+	got := cmd()
+	ev, ok := got.(ProgressEventMsg)
+	if !ok {
+		t.Fatalf("got %T, want ProgressEventMsg", got)
+	}
+	if ev.Event.Total != 1 {
+		t.Errorf("event = %+v", ev.Event)
+	}
+
+	// Now close events and supply an error on doneErr.
+	close(events)
+	doneErr <- errors.New("final")
+	got = Subscribe(events, doneErr)()
+	done, ok := got.(ProgressDoneMsg)
+	if !ok {
+		t.Fatalf("got %T, want ProgressDoneMsg", got)
+	}
+	if done.Err == nil || done.Err.Error() != "final" {
+		t.Errorf("err = %v", done.Err)
+	}
+}
+
+func TestProgressModel_KeyMsgAfterDoneQuits(t *testing.T) {
+	m := newTestProgress(t)
+	m.running = false
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd == nil {
+		t.Error("expected Quit cmd on enter after done")
+	}
+	_, cmd = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("q")})
+	if cmd == nil {
+		t.Error("expected Quit cmd on q after done")
+	}
+}
+
+func TestProgressEntry_Key(t *testing.T) {
+	e := progressEntry{skill: "a", platform: "b", scope: "c"}
+	if e.key() == "" {
+		t.Error("key empty")
+	}
+	e2 := progressEntry{skill: "a", platform: "b", scope: "d"}
+	if e.key() == e2.key() {
+		t.Error("different scopes should differ")
+	}
+}

--- a/cli/internal/tui/tui_test.go
+++ b/cli/internal/tui/tui_test.go
@@ -1,0 +1,186 @@
+// Tests for the shared TUI helpers that don't require driving a full
+// bubbletea program. Rendering and keymap assertions live here; full
+// interactive model tests live alongside each screen's _test.go.
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/bubbles/key"
+
+	"github.com/jjfantini/humblSKILLS/cli/internal/ui"
+)
+
+func TestShouldUseTUI_FlagsOverrideTTY(t *testing.T) {
+	cases := []struct {
+		name                  string
+		json, quiet, yes, want bool
+	}{
+		{"json disables", true, false, false, false},
+		{"quiet disables", false, true, false, false},
+		{"yes disables", false, false, true, false},
+		// Default case depends on TTY; we only assert the disable paths.
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ShouldUseTUI(tc.json, tc.quiet, tc.yes); got != tc.want {
+				t.Errorf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDefaultKeys_RegistersEveryBinding(t *testing.T) {
+	k := DefaultKeys()
+	// Every binding should have at least one key.
+	for _, b := range []key.Binding{
+		k.Up, k.Down, k.Left, k.Right, k.Filter, k.Enter, k.Back, k.Help, k.Quit,
+	} {
+		if len(b.Keys()) == 0 {
+			t.Errorf("binding missing keys: help=%q", b.Help())
+		}
+	}
+	// Arrow + vim bindings: Up should include both "up" and "k".
+	has := func(bind key.Binding, k string) bool {
+		for _, kk := range bind.Keys() {
+			if kk == k {
+				return true
+			}
+		}
+		return false
+	}
+	if !has(k.Up, "up") || !has(k.Up, "k") {
+		t.Errorf("Up missing arrow or vim binding")
+	}
+	if !has(k.Down, "down") || !has(k.Down, "j") {
+		t.Errorf("Down missing arrow or vim binding")
+	}
+	if !has(k.Quit, "ctrl+c") {
+		t.Errorf("Quit missing ctrl+c")
+	}
+}
+
+func TestBadge_EmptyTextReturnsEmpty(t *testing.T) {
+	th := ui.DefaultTheme()
+	if got := Badge(th, BadgeDetected, "  "); got != "" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestBadge_AllKindsRender(t *testing.T) {
+	th := ui.DefaultTheme()
+	for _, kind := range []BadgeKind{BadgeDetected, BadgeMissing, BadgeRW, BadgeRO, BadgeGhost} {
+		got := Badge(th, kind, "text")
+		if !strings.Contains(got, "text") {
+			t.Errorf("kind %d lost text: %q", kind, got)
+		}
+	}
+}
+
+func TestHeader_RendersBrandAndMetaAndRule(t *testing.T) {
+	th := ui.DefaultTheme()
+	got := Header(th, HeaderSpec{Version: "v1.2.3", Section: "Install", Meta: "3 / 3 detected"}, 80)
+	for _, want := range []string{"humblskills", "v1.2.3", "Install", "3 / 3 detected", "╌"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("Header missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestHeader_ClampsShortWidth(t *testing.T) {
+	th := ui.DefaultTheme()
+	got := Header(th, HeaderSpec{Version: "v1", Section: "x"}, 10)
+	if got == "" {
+		t.Error("Header returned empty for narrow width")
+	}
+}
+
+func TestFooter_KeyHintsAndRule(t *testing.T) {
+	th := ui.DefaultTheme()
+	hints := []KeyHint{
+		{Keys: "↑↓", Label: "select"},
+		{Keys: "q", Label: "quit"},
+	}
+	got := Footer(th, hints, "focused: x", 80)
+	for _, want := range []string{"↑↓", "select", "q", "quit", "focused: x", "╌"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("Footer missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestFooter_EmptyHints(t *testing.T) {
+	th := ui.DefaultTheme()
+	got := Footer(th, nil, "", 80)
+	if !strings.Contains(got, "╌") {
+		t.Errorf("Footer missing rule:\n%s", got)
+	}
+}
+
+func TestDashedRule_MinWidth(t *testing.T) {
+	th := ui.DefaultTheme()
+	// Even at width=1 the helper clamps to a minimum usable length.
+	if got := DashedRule(th, 1); got == "" {
+		t.Error("DashedRule returned empty")
+	}
+}
+
+func TestFrame_ComposesHeaderBodyFooter(t *testing.T) {
+	got := Frame("HEADER", "BODY", "FOOTER", 4)
+	// Body lifted to 4 rows then footer on the fifth.
+	if !strings.Contains(got, "HEADER") || !strings.Contains(got, "FOOTER") {
+		t.Errorf("missing chrome:\n%s", got)
+	}
+	if !strings.Contains(got, "BODY") {
+		t.Errorf("missing body:\n%s", got)
+	}
+}
+
+func TestFrame_ShortCircuitsWithZeroHeight(t *testing.T) {
+	got := Frame("H", "B", "F", 0)
+	if !strings.Contains(got, "B") {
+		t.Errorf("body dropped at height 0:\n%s", got)
+	}
+}
+
+func TestPadBetween_RoomForBoth(t *testing.T) {
+	got := padBetween("LEFT", "RIGHT", 20)
+	if len(got) < 20 {
+		t.Errorf("got width %d", len(got))
+	}
+	if !strings.HasPrefix(got, "LEFT") || !strings.HasSuffix(got, "RIGHT") {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestPadBetween_NoRoom(t *testing.T) {
+	// Width too small → single-space fallback.
+	got := padBetween("LEFT", "RIGHT", 2)
+	if !strings.Contains(got, "LEFT RIGHT") {
+		t.Errorf("fallback failed: %q", got)
+	}
+}
+
+func TestPadToHeight_AddsLines(t *testing.T) {
+	got := padToHeight("line1\nline2", 5)
+	if strings.Count(got, "\n") < 4 {
+		t.Errorf("expected 5 rows, got: %q", got)
+	}
+}
+
+func TestPadToHeight_NoOpWhenTallEnough(t *testing.T) {
+	got := padToHeight("a\nb\nc", 2)
+	if got != "a\nb\nc" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestMaxHelper(t *testing.T) {
+	if max(1, 2) != 2 {
+		t.Error()
+	}
+	if max(5, 3) != 5 {
+		t.Error()
+	}
+}

--- a/cli/internal/ui/ui_coverage_test.go
+++ b/cli/internal/ui/ui_coverage_test.go
@@ -1,0 +1,237 @@
+package ui_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/jjfantini/humblSKILLS/cli/internal/ui"
+)
+
+func printer(opts ui.Options) (*ui.Printer, *bytes.Buffer, *bytes.Buffer) {
+	out := &bytes.Buffer{}
+	errW := &bytes.Buffer{}
+	opts.Out = out
+	opts.Err = errW
+	opts.NoColor = true
+	return ui.New(opts), out, errW
+}
+
+func TestPrintln_NormalEmitsLine(t *testing.T) {
+	p, out, _ := printer(ui.Options{Level: ui.LevelNormal})
+	p.Println("hi")
+	if got := strings.TrimSpace(out.String()); got != "hi" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestPrintln_QuietSuppressed(t *testing.T) {
+	p, out, _ := printer(ui.Options{Level: ui.LevelQuiet})
+	p.Println("hidden")
+	if out.Len() != 0 {
+		t.Errorf("expected empty, got %q", out.String())
+	}
+}
+
+func TestPrintln_JSONSuppressed(t *testing.T) {
+	p, out, _ := printer(ui.Options{JSON: true})
+	p.Println("hidden")
+	if out.Len() != 0 {
+		t.Errorf("expected empty in json mode, got %q", out.String())
+	}
+}
+
+func TestHeader_NormalPrints(t *testing.T) {
+	p, out, _ := printer(ui.Options{Level: ui.LevelNormal})
+	p.Header("install")
+	s := out.String()
+	if !strings.Contains(s, "humblskills") || !strings.Contains(s, "install") {
+		t.Errorf("header missing pieces: %q", s)
+	}
+}
+
+func TestHeader_QuietSuppressed(t *testing.T) {
+	p, out, _ := printer(ui.Options{Level: ui.LevelQuiet})
+	p.Header("anything")
+	if out.Len() != 0 {
+		t.Errorf("header should be silent in quiet")
+	}
+}
+
+func TestSection_NormalPrintsLabel(t *testing.T) {
+	p, out, _ := printer(ui.Options{Level: ui.LevelNormal})
+	p.Section("Adapters:")
+	if !strings.Contains(out.String(), "Adapters:") {
+		t.Errorf("section label missing: %q", out.String())
+	}
+}
+
+func TestSection_JSONSuppressed(t *testing.T) {
+	p, out, _ := printer(ui.Options{JSON: true})
+	p.Section("x")
+	if out.Len() != 0 {
+		t.Errorf("section should be silent in json mode")
+	}
+}
+
+func TestIsJSON_FlagRoundTrips(t *testing.T) {
+	p, _, _ := printer(ui.Options{JSON: true})
+	if !p.IsJSON() {
+		t.Error("IsJSON = false after JSON:true")
+	}
+	p2, _, _ := printer(ui.Options{JSON: false})
+	if p2.IsJSON() {
+		t.Error("IsJSON = true after JSON:false")
+	}
+}
+
+func TestOutErrAccessors_ReturnInjectedWriters(t *testing.T) {
+	out := &bytes.Buffer{}
+	errW := &bytes.Buffer{}
+	p := ui.New(ui.Options{Out: out, Err: errW})
+	if p.Out() != out {
+		t.Error("Out() did not return injected writer")
+	}
+	if p.Err() != errW {
+		t.Error("Err() did not return injected writer")
+	}
+}
+
+func TestTheme_Accessor_Works(t *testing.T) {
+	p, _, _ := printer(ui.Options{})
+	if p.Theme() == nil {
+		t.Error("Theme() returned nil")
+	}
+}
+
+func TestNewPrompter_YesBypassesTTYDetection(t *testing.T) {
+	p := ui.NewPrompter(true)
+	if !p.Yes {
+		t.Error("Yes not set")
+	}
+	// With Yes, Confirm returns true regardless of dflt.
+	got, err := p.Confirm("proceed?", false)
+	if err != nil {
+		t.Fatalf("Confirm: %v", err)
+	}
+	if !got {
+		t.Error("Yes mode should return true from Confirm")
+	}
+}
+
+func TestNewPrompter_NonInteractiveConfirmReturnsDefault(t *testing.T) {
+	// NewPrompter in tests runs without a TTY, so Interactive=false.
+	p := ui.NewPrompter(false)
+	if p.Interactive {
+		// Running under a TTY (unusual for CI but possible in local dev) —
+		// this test's assumption breaks; skip rather than flake.
+		t.Skip("stderr reports TTY; test can't exercise non-interactive path")
+	}
+	v, err := p.Confirm("q", true)
+	if err != nil {
+		t.Fatalf("Confirm: %v", err)
+	}
+	if !v {
+		t.Error("non-interactive Confirm should return dflt=true")
+	}
+	v, _ = p.Confirm("q", false)
+	if v {
+		t.Error("non-interactive Confirm should return dflt=false")
+	}
+}
+
+func TestMultiSelect_EmptyOptionsNoOp(t *testing.T) {
+	p := ui.NewPrompter(true)
+	got, err := p.MultiSelect("pick", nil)
+	if err != nil {
+		t.Fatalf("MultiSelect: %v", err)
+	}
+	if got != nil {
+		t.Errorf("empty options should yield nil, got %v", got)
+	}
+}
+
+func TestMultiSelect_YesReturnsAllValues(t *testing.T) {
+	p := ui.NewPrompter(true)
+	opts := []ui.MultiSelectOption{
+		{Label: "A", Value: "a"},
+		{Label: "B", Value: "b"},
+	}
+	got, err := p.MultiSelect("pick", opts)
+	if err != nil {
+		t.Fatalf("MultiSelect: %v", err)
+	}
+	if len(got) != 2 || got[0] != "a" || got[1] != "b" {
+		t.Errorf("got %v", got)
+	}
+}
+
+func TestMultiSelect_NonInteractiveReturnsErrNonInteractive(t *testing.T) {
+	p := ui.NewPrompter(false)
+	if p.Interactive {
+		t.Skip("stderr reports TTY; test can't exercise non-interactive path")
+	}
+	_, err := p.MultiSelect("pick", []ui.MultiSelectOption{{Value: "a"}})
+	if err != ui.ErrNonInteractive {
+		t.Errorf("err = %v, want ErrNonInteractive", err)
+	}
+}
+
+func TestSelect_EmptyOptionsReturnsEmpty(t *testing.T) {
+	p := ui.NewPrompter(true)
+	got, err := p.Select("pick", "", nil)
+	if err != nil {
+		t.Fatalf("Select: %v", err)
+	}
+	if got != "" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestSelect_YesCantPickForUser(t *testing.T) {
+	p := ui.NewPrompter(true)
+	_, err := p.Select("pick", "", []ui.SelectOption{{Value: "a"}})
+	if err != ui.ErrNonInteractive {
+		t.Errorf("err = %v, want ErrNonInteractive", err)
+	}
+}
+
+func TestSelect_NonInteractiveReturnsErrNonInteractive(t *testing.T) {
+	p := ui.NewPrompter(false)
+	if p.Interactive {
+		t.Skip("stderr reports TTY; test can't exercise non-interactive path")
+	}
+	_, err := p.Select("pick", "d", []ui.SelectOption{{Value: "a"}})
+	if err != ui.ErrNonInteractive {
+		t.Errorf("err = %v, want ErrNonInteractive", err)
+	}
+}
+
+func TestSecret_NonInteractiveReturnsErrNonInteractive(t *testing.T) {
+	p := ui.NewPrompter(false)
+	if p.Interactive {
+		t.Skip("stderr reports TTY; test can't exercise non-interactive path")
+	}
+	_, err := p.Secret("enter key")
+	if err != ui.ErrNonInteractive {
+		t.Errorf("err = %v, want ErrNonInteractive", err)
+	}
+}
+
+func TestDefaultTheme_ReturnsUsableTheme(t *testing.T) {
+	th := ui.DefaultTheme()
+	if th == nil {
+		t.Fatal("DefaultTheme returned nil")
+	}
+	// A rendered string must not be empty.
+	if got := th.Brand.Render("x"); got == "" {
+		t.Error("Brand render produced empty string")
+	}
+}
+
+func TestHuhTheme_DerivedFromPalette(t *testing.T) {
+	th := ui.HuhTheme(ui.DefaultTheme())
+	if th == nil {
+		t.Fatal("HuhTheme returned nil")
+	}
+}


### PR DESCRIPTION
## Summary

- Adds an exhaustive pre-refactor regression safety net so simplifying the CLI can't silently break anything. Every package is now tested, including previously-zero-coverage ones (cmd/humblskills, build-registry, all 6 eval runners, evalruntime, profile, TUI).
- Ships shared testutil scaffolding (sandboxed FS+env, httptest registry, tarball seeder, fake keyring, scriptable fake runner, golden-tree assertions).
- Five fuzz targets + benchmark baselines on hot paths (DirSHA, topo-sort, manifest load/save, frontmatter parse/dep).
- CI: -race + coverage profile on the Ubuntu/macOS/Windows matrix, plus a dedicated fuzz job (10s per target).

## What changed in source (minor)

To enable deterministic runner contract tests without reaching into package internals, three packages gained a `NewWithOptions` constructor so tests can inject `option.WithBaseURL` at the SDK layer:
- `internal/eval/grader/anthropicjudge`
- `internal/eval/runner/anthropicapi`
- `internal/eval/runner/openaiapi`

Production callers still use `New(...)` unchanged.

## Coverage after

Every one of the 33 packages is green under `-race`. Sorted coverage floor: cmd/humblskills 26.3%, internal/tui 26.8%, all other packages ≥77%, many at 100%. Pre-change, 9 packages had 0%.

## Test plan

- [x] `go test -race -count=1 ./...` green (33 pkgs)
- [x] `go test -fuzz=FuzzTopoSort -fuzztime=3s ./internal/resolver/` surfaces no panics
- [x] `go test -bench=. -benchtime=1x ./internal/registry/ ./internal/resolver/ ./internal/manifest/ ./internal/frontmatter/` runs clean
- [ ] CI matrix (Ubuntu/macOS/Windows) green
- [ ] Fuzz CI job completes 10s per target without findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)