### PR TITLE
feat(install): prefer claude-code default, add info pane, dedupe keys

### DIFF
--- a/cli/cmd/humblskills/install.go
+++ b/cli/cmd/humblskills/install.go
@@ -145,7 +145,9 @@ func runInstall(app *App, skill string, f installFlags, fromDashboard bool) erro
 
 // selectPlatforms returns the adapter names to install onto. If the user
 // passed --platform, it's the intersection of that list with the declared
-// adapters; otherwise it's every detected adapter.
+// adapters; otherwise it falls back to the same default cascade the TUI
+// uses (issue #84: prefer claude-code over cursor when both are detected,
+// since Cursor can read ~/.claude/skills natively).
 func selectPlatforms(adapterList []adapters.Adapter, requested []string) ([]string, error) {
 	known := adapters.NameSet(adapterList)
 	if len(requested) > 0 {
@@ -159,13 +161,11 @@ func selectPlatforms(adapterList []adapters.Adapter, requested []string) ([]stri
 		return out, nil
 	}
 
-	detected := adapters.Detect(adapterList)
-	out := make([]string, 0, len(detected))
-	for _, d := range detected {
-		if d.Detected {
-			out = append(out, d.Name)
-		}
+	detected := map[string]bool{}
+	for _, d := range adapters.Detect(adapterList) {
+		detected[d.Name] = d.Detected
 	}
+	out := adapters.PreferredDefaults(adapterList, detected, nil)
 	sort.Strings(out)
 	return out, nil
 }

--- a/cli/cmd/humblskills/install_test.go
+++ b/cli/cmd/humblskills/install_test.go
@@ -266,6 +266,94 @@ func TestInstall_SelectPlatforms_DetectedOnly(t *testing.T) {
 	}
 }
 
+func TestInstall_DefaultsPreferClaudeCodeWhenBothDetected(t *testing.T) {
+	// Issue #84: when both Claude Code and Cursor are detected and the user
+	// doesn't pass --platform, only claude-code should be installed — Cursor
+	// can read ~/.claude/skills natively.
+	s := testutil.NewSandbox(t)
+	enableClaudeCode(t, s)
+	if err := os.MkdirAll(filepath.Join(s.Home, ".cursor"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	regURL := seedTestRegistry(t, s, []testutil.SkillFixture{
+		{
+			Name: "foo", Version: "1.0.0",
+			Platforms: []string{"claude-code", "cursor"},
+			Files:     testutil.SkillTree{"SKILL.md": sampleSkillMD},
+		},
+	})
+	res := runCLIWithStdoutCapture(t,
+		"install", "foo",
+		"--registry", regURL,
+		"--cache-dir", s.CacheDir,
+		"--manifest", s.ManifestPath,
+		"--scope", "user",
+		"--yes", "--json",
+	)
+	if res.RunErr != nil {
+		t.Fatalf("run: %v\nerr: %s", res.RunErr, res.Err)
+	}
+	m, err := manifest.Load(s.ManifestPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, inst := range m.Installations {
+		if inst.Platform == "cursor" {
+			t.Errorf("cursor should not be installed by default when claude-code is also detected: %+v", inst)
+		}
+	}
+	found := false
+	for _, inst := range m.Installations {
+		if inst.Platform == "claude-code" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("claude-code missing from manifest")
+	}
+}
+
+func TestInstall_ExplicitPlatformBothStillWorks(t *testing.T) {
+	// Users who really want both IDEs can still ask for them via --platform.
+	s := testutil.NewSandbox(t)
+	enableClaudeCode(t, s)
+	if err := os.MkdirAll(filepath.Join(s.Home, ".cursor"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	regURL := seedTestRegistry(t, s, []testutil.SkillFixture{
+		{
+			Name: "foo", Version: "1.0.0",
+			Platforms: []string{"claude-code", "cursor"},
+			Files:     testutil.SkillTree{"SKILL.md": sampleSkillMD},
+		},
+	})
+	res := runCLIWithStdoutCapture(t,
+		"install", "foo",
+		"--registry", regURL,
+		"--cache-dir", s.CacheDir,
+		"--manifest", s.ManifestPath,
+		"--platform", "claude-code,cursor",
+		"--scope", "user",
+		"--yes", "--json",
+	)
+	if res.RunErr != nil {
+		t.Fatalf("run: %v\nerr: %s", res.RunErr, res.Err)
+	}
+	m, err := manifest.Load(s.ManifestPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	platforms := map[string]bool{}
+	for _, inst := range m.Installations {
+		platforms[inst.Platform] = true
+	}
+	if !platforms["claude-code"] || !platforms["cursor"] {
+		t.Errorf("explicit --platform both should install to both; got %v", platforms)
+	}
+}
+
 func TestInstall_NoPlatformsDetectedErrors(t *testing.T) {
 	s := testutil.NewSandbox(t)
 	// Neither ~/.claude nor ~/.cursor exist. Auto-detect yields nothing.

--- a/cli/internal/adapters/defaults.go
+++ b/cli/internal/adapters/defaults.go
@@ -1,0 +1,45 @@
+package adapters
+
+// PreferredDefaults returns the pre-selected adapters when the user hasn't
+// explicitly chosen any. Used by both the install TUI's pre-check state and
+// the non-interactive `--yes` path so the two stay symmetric.
+//
+// Policy (issue #84): Cursor can read ~/.claude/skills directly when its
+// "Include Third-Party Plugins, Skills and other configs" setting is on,
+// so installing to both by default creates duplicate copies that drift.
+// When both claude-code and cursor are detected, we prefer claude-code
+// and drop cursor from the defaults. Cursor stays a visible opt-in in the
+// TUI and remains explicit via `--platform cursor`.
+//
+// Profile defaults always win — a user who saved a preference gets it back.
+func PreferredDefaults(adapterList []Adapter, detected map[string]bool, profileDefaults []string) []string {
+	if len(profileDefaults) > 0 {
+		known := NameSet(adapterList)
+		out := make([]string, 0, len(profileDefaults))
+		for _, name := range profileDefaults {
+			if _, ok := known[name]; ok {
+				out = append(out, name)
+			}
+		}
+		return out
+	}
+
+	out := make([]string, 0, len(adapterList))
+	for _, a := range adapterList {
+		if detected[a.Name] {
+			out = append(out, a.Name)
+		}
+	}
+
+	if detected["claude-code"] && detected["cursor"] {
+		filtered := make([]string, 0, len(out))
+		for _, name := range out {
+			if name != "cursor" {
+				filtered = append(filtered, name)
+			}
+		}
+		out = filtered
+	}
+
+	return out
+}

--- a/cli/internal/adapters/defaults_test.go
+++ b/cli/internal/adapters/defaults_test.go
@@ -1,0 +1,89 @@
+package adapters
+
+import (
+	"reflect"
+	"testing"
+)
+
+var testAdapters = []Adapter{
+	{Name: "claude-code"},
+	{Name: "cursor"},
+}
+
+func TestPreferredDefaults_BothDetected_ClaudeCodeOnly(t *testing.T) {
+	got := PreferredDefaults(testAdapters, map[string]bool{
+		"claude-code": true,
+		"cursor":      true,
+	}, nil)
+	want := []string{"claude-code"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestPreferredDefaults_OnlyClaudeDetected(t *testing.T) {
+	got := PreferredDefaults(testAdapters, map[string]bool{
+		"claude-code": true,
+	}, nil)
+	want := []string{"claude-code"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestPreferredDefaults_OnlyCursorDetected(t *testing.T) {
+	got := PreferredDefaults(testAdapters, map[string]bool{
+		"cursor": true,
+	}, nil)
+	want := []string{"cursor"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestPreferredDefaults_NoneDetected(t *testing.T) {
+	got := PreferredDefaults(testAdapters, map[string]bool{}, nil)
+	if len(got) != 0 {
+		t.Errorf("got %v, want empty", got)
+	}
+}
+
+func TestPreferredDefaults_ProfileWins(t *testing.T) {
+	got := PreferredDefaults(testAdapters, map[string]bool{
+		"claude-code": true,
+		"cursor":      true,
+	}, []string{"cursor"})
+	want := []string{"cursor"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestPreferredDefaults_ProfileDropsUnknown(t *testing.T) {
+	got := PreferredDefaults(testAdapters, map[string]bool{
+		"claude-code": true,
+	}, []string{"cursor", "ghost"})
+	want := []string{"cursor"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestPreferredDefaults_CascadeOnlyDropsCursor(t *testing.T) {
+	// A hypothetical third adapter should survive the dedup cascade —
+	// the rule is specifically about claude/cursor duplication.
+	adapterList := []Adapter{
+		{Name: "claude-code"},
+		{Name: "cursor"},
+		{Name: "other"},
+	}
+	got := PreferredDefaults(adapterList, map[string]bool{
+		"claude-code": true,
+		"cursor":      true,
+		"other":       true,
+	}, nil)
+	want := []string{"claude-code", "other"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}

--- a/cli/internal/tui/install_modal.go
+++ b/cli/internal/tui/install_modal.go
@@ -30,18 +30,8 @@ func RunInstallPlatformModal(
 	}
 
 	selected := map[string]bool{}
-	if len(p.DefaultPlatforms) > 0 {
-		for _, name := range p.DefaultPlatforms {
-			if detected[name] {
-				selected[name] = true
-			}
-		}
-	} else {
-		for _, a := range adapterList {
-			if detected[a.Name] {
-				selected[a.Name] = true
-			}
-		}
+	for _, name := range adapters.PreferredDefaults(adapterList, detected, p.DefaultPlatforms) {
+		selected[name] = true
 	}
 
 	scopes := []scopeOpt{
@@ -199,8 +189,7 @@ func (m installModalModel) togglePlatform() installModalModel {
 func (m installModalModel) onEnter() (tea.Model, tea.Cmd) {
 	switch m.group {
 	case groupPlatforms:
-		// Enter toggles in the platforms group, matching `space`.
-		return m.togglePlatform(), nil
+		return m.nextGroup(1), nil
 	case groupScope:
 		m.scopeIdx = m.cursor
 		return m.nextGroup(1), nil
@@ -283,12 +272,44 @@ func (m installModalModel) groupLabel() string {
 }
 
 func (m installModalModel) renderBody() string {
-	th := m.theme
 	width := m.width - 4
 	if width < 40 {
 		width = 40
 	}
 
+	// Narrow terminals fall back to the single-column layout — the info pane
+	// would wrap past legibility below ~80 cols.
+	if m.width < 80 {
+		return m.renderLeftStacked(width)
+	}
+
+	leftW, rightW := m.paneWidths(width)
+	left := m.renderLeftStacked(leftW)
+	left = padLinesToWidth(left, leftW)
+	right := m.renderRight(rightW)
+	return lipgloss.JoinHorizontal(lipgloss.Top, left, right)
+}
+
+// paneWidths splits the body width between the left groups and the right
+// info pane. Right pane stays in [24, 48] cols so the message is always
+// readable without dominating the screen.
+func (m installModalModel) paneWidths(total int) (int, int) {
+	right := total * 2 / 5
+	if right < 24 {
+		right = 24
+	}
+	if right > 48 {
+		right = 48
+	}
+	left := total - right - 1
+	if left < 40 {
+		left = 40
+	}
+	return left, right
+}
+
+func (m installModalModel) renderLeftStacked(width int) string {
+	th := m.theme
 	var sb strings.Builder
 	sb.WriteString("  ")
 	sb.WriteString(th.DetailTitle.Render("Install " + m.skill + " to:"))
@@ -301,6 +322,84 @@ func (m installModalModel) renderBody() string {
 	sb.WriteString(m.renderGroup(groupAction, "ACTION", m.actionRows(), width))
 
 	return sb.String()
+}
+
+// renderRight draws the contextual INFO pane to the right of the groups.
+// Title sits in col 0 (no bar); every row below gets a `│` prefix so the
+// divider reads as one unbroken vertical line from `I` downward — matching
+// the DETAIL pane in listdetail.go.
+func (m installModalModel) renderRight(width int) string {
+	th := m.theme
+	bar := th.Divider.Render("│")
+	title := th.SectionTitle.Render("INFO")
+
+	contentW := width - 2
+	if contentW < 10 {
+		contentW = 10
+	}
+
+	heading, body := m.infoContent(contentW)
+
+	lines := []string{title, bar}
+	if heading != "" {
+		lines = append(lines, bar+" "+heading, bar)
+	}
+	for _, ln := range strings.Split(body, "\n") {
+		lines = append(lines, bar+" "+ln)
+	}
+	return strings.Join(lines, "\n")
+}
+
+// infoContent returns (heading, body) for the right pane based on the
+// current platform selection. Pure function of m.selected + m.detected —
+// no state field needed, so no bookkeeping and no flicker.
+func (m installModalModel) infoContent(width int) (heading, body string) {
+	th := m.theme
+	wrap := lipgloss.NewStyle().Width(width)
+
+	hasClaude := m.selected["claude-code"]
+	hasCursor := m.selected["cursor"]
+
+	switch {
+	case hasClaude && hasCursor:
+		heading = th.Warn.Render("! Duplicate install")
+		body = wrap.Render(
+			"Installing to both creates two copies of each skill that can drift. " +
+				"Cursor can read ~/.claude/skills directly — enable \"Include " +
+				"Third-Party Plugins, Skills and other configs\" in Cursor → Rules, " +
+				"Skills and Plugins, then deselect cursor here.",
+		)
+	case hasClaude:
+		heading = th.DetailTitle.Render("Tip")
+		body = wrap.Render(
+			"Skills install to .claude/skills. Enable \"Include Third-Party " +
+				"Plugins, Skills and other configs\" in Cursor → Rules, Skills and " +
+				"Plugins so it picks them up natively — no duplication.",
+		)
+	case hasCursor:
+		heading = th.DetailTitle.Render("Note")
+		msg := "claude-code is not selected; these skills won't be available in Claude Code."
+		if !m.detected["claude-code"] {
+			msg += "\n(claude-code not detected)"
+		}
+		body = wrap.Render(msg)
+	default:
+		body = wrap.Render("Select a platform on the left.")
+	}
+	return heading, body
+}
+
+// padLinesToWidth right-pads every line of s to `width` display cells so
+// lipgloss.JoinHorizontal lines the right pane up at a fixed column.
+func padLinesToWidth(s string, width int) string {
+	lines := strings.Split(s, "\n")
+	for i, ln := range lines {
+		w := lipgloss.Width(ln)
+		if w < width {
+			lines[i] = ln + strings.Repeat(" ", width-w)
+		}
+	}
+	return strings.Join(lines, "\n")
 }
 
 func (m installModalModel) renderGroup(g modalGroup, label string, rows []string, width int) string {
@@ -388,18 +487,19 @@ func (m installModalModel) actionRows() []string {
 }
 
 func (m installModalModel) hints() []KeyHint {
-	base := []KeyHint{
-		{Keys: "↑↓", Label: "select"},
-		{Keys: "tab", Label: "next group"},
-	}
+	base := []KeyHint{{Keys: "↑↓", Label: "select"}}
 	switch m.group {
 	case groupPlatforms:
-		base = append(base, KeyHint{Keys: "space", Label: "toggle"})
+		base = append(base,
+			KeyHint{Keys: "space", Label: "toggle"},
+			KeyHint{Keys: "↵", Label: "next"},
+		)
+	case groupScope:
+		base = append(base, KeyHint{Keys: "↵", Label: "next"})
+	case groupAction:
+		base = append(base, KeyHint{Keys: "↵", Label: "confirm"})
 	}
-	base = append(base,
-		KeyHint{Keys: "↵", Label: "confirm"},
-		KeyHint{Keys: "esc", Label: "back"},
-	)
+	base = append(base, KeyHint{Keys: "esc", Label: "back"})
 	return base
 }
 

--- a/cli/internal/tui/install_modal_test.go
+++ b/cli/internal/tui/install_modal_test.go
@@ -1,0 +1,262 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/jjfantini/humblSKILLS/cli/internal/adapters"
+	"github.com/jjfantini/humblSKILLS/cli/internal/ui"
+)
+
+func newTestModal(selected, detected map[string]bool) installModalModel {
+	if selected == nil {
+		selected = map[string]bool{}
+	}
+	if detected == nil {
+		detected = map[string]bool{}
+	}
+	return installModalModel{
+		theme: ui.DefaultTheme(),
+		skill: "foo",
+		adapters: []adapters.Adapter{
+			{Name: "claude-code"},
+			{Name: "cursor"},
+		},
+		detected: detected,
+		selected: selected,
+		scopes: []scopeOpt{
+			{label: "adapter default", value: ""},
+			{label: "user", value: "user"},
+			{label: "project", value: "project"},
+		},
+		scopeIdx: 0,
+		actions: []actionOpt{
+			{label: "install", value: "install"},
+			{label: "cancel", value: "cancel"},
+		},
+		actionIdx: 0,
+		group:     groupPlatforms,
+		cursor:    0,
+		width:     120,
+		height:    30,
+	}
+}
+
+func TestInstallModal_SpaceTogglesInPlatforms(t *testing.T) {
+	m := newTestModal(
+		map[string]bool{"claude-code": true},
+		map[string]bool{"claude-code": true, "cursor": true},
+	)
+	out, _ := m.Update(tea.KeyMsg{Type: tea.KeyDown}) // move to cursor row
+	m = out.(installModalModel)
+	if m.cursor != 1 {
+		t.Fatalf("cursor = %d, want 1", m.cursor)
+	}
+	out, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{' '}})
+	m = out.(installModalModel)
+	if !m.selected["cursor"] {
+		t.Error("space should toggle cursor on")
+	}
+	if m.group != groupPlatforms {
+		t.Errorf("space must not advance group; got %v", m.group)
+	}
+}
+
+func TestInstallModal_EnterAdvancesFromPlatforms_NoToggle(t *testing.T) {
+	m := newTestModal(
+		map[string]bool{"claude-code": true},
+		map[string]bool{"claude-code": true, "cursor": true},
+	)
+	out, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = out.(installModalModel)
+	if m.group != groupScope {
+		t.Errorf("enter should advance to scope; got group=%v", m.group)
+	}
+	if !m.selected["claude-code"] {
+		t.Error("enter must not toggle selection off")
+	}
+	if m.selected["cursor"] {
+		t.Error("enter must not toggle selection on")
+	}
+}
+
+func TestInstallModal_EnterAdvancesFromScope(t *testing.T) {
+	m := newTestModal(nil, nil)
+	m.group = groupScope
+	m.cursor = 1
+	out, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = out.(installModalModel)
+	if m.group != groupAction {
+		t.Errorf("enter should advance to action; got %v", m.group)
+	}
+	if m.scopeIdx != 1 {
+		t.Errorf("scopeIdx = %d, want 1", m.scopeIdx)
+	}
+}
+
+func TestInstallModal_TabKeptAsSilentAdvance(t *testing.T) {
+	m := newTestModal(nil, nil)
+	out, _ := m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	m = out.(installModalModel)
+	if m.group != groupScope {
+		t.Errorf("tab should still advance; got %v", m.group)
+	}
+}
+
+func TestInstallModal_Hints_PlatformsGroup(t *testing.T) {
+	m := newTestModal(nil, nil)
+	m.group = groupPlatforms
+	hints := m.hints()
+	keys := hintKeys(hints)
+	if !contains(keys, "space") {
+		t.Errorf("platforms hints missing 'space': %v", keys)
+	}
+	if !contains(keys, "↵") {
+		t.Errorf("platforms hints missing '↵': %v", keys)
+	}
+	if contains(keys, "tab") {
+		t.Errorf("platforms hints should not advertise tab: %v", keys)
+	}
+}
+
+func TestInstallModal_Hints_ScopeGroup(t *testing.T) {
+	m := newTestModal(nil, nil)
+	m.group = groupScope
+	keys := hintKeys(m.hints())
+	if contains(keys, "space") {
+		t.Errorf("scope hints should not mention space: %v", keys)
+	}
+	if contains(keys, "tab") {
+		t.Errorf("scope hints should not mention tab: %v", keys)
+	}
+	if !contains(keys, "↵") {
+		t.Errorf("scope hints missing '↵': %v", keys)
+	}
+}
+
+func TestInstallModal_InfoPane_BothSelected_Warning(t *testing.T) {
+	m := newTestModal(
+		map[string]bool{"claude-code": true, "cursor": true},
+		map[string]bool{"claude-code": true, "cursor": true},
+	)
+	heading, body := m.infoContent(40)
+	if !strings.Contains(heading, "Duplicate") {
+		t.Errorf("heading should warn about duplicates; got %q", heading)
+	}
+	if !strings.Contains(body, "drift") {
+		t.Errorf("body should mention drift; got %q", body)
+	}
+}
+
+func TestInstallModal_InfoPane_ClaudeOnly_Tip(t *testing.T) {
+	m := newTestModal(
+		map[string]bool{"claude-code": true},
+		map[string]bool{"claude-code": true, "cursor": true},
+	)
+	heading, body := m.infoContent(40)
+	if !strings.Contains(heading, "Tip") {
+		t.Errorf("heading should be a tip; got %q", heading)
+	}
+	if !strings.Contains(body, "Cursor") {
+		t.Errorf("body should mention Cursor; got %q", body)
+	}
+}
+
+func TestInstallModal_InfoPane_CursorOnly_Note(t *testing.T) {
+	m := newTestModal(
+		map[string]bool{"cursor": true},
+		map[string]bool{"claude-code": true, "cursor": true},
+	)
+	heading, body := m.infoContent(40)
+	if !strings.Contains(heading, "Note") {
+		t.Errorf("heading should be a note; got %q", heading)
+	}
+	if !strings.Contains(body, "claude-code is not selected") {
+		t.Errorf("body should explain claude-code is not selected; got %q", body)
+	}
+}
+
+func TestInstallModal_InfoPane_CursorOnly_ClaudeNotDetected(t *testing.T) {
+	m := newTestModal(
+		map[string]bool{"cursor": true},
+		map[string]bool{"cursor": true},
+	)
+	_, body := m.infoContent(40)
+	if !strings.Contains(body, "not detected") {
+		t.Errorf("body should note claude-code not detected; got %q", body)
+	}
+}
+
+func TestInstallModal_InfoPane_NoneSelected_EmptyState(t *testing.T) {
+	m := newTestModal(nil, map[string]bool{"claude-code": true})
+	heading, body := m.infoContent(40)
+	if heading != "" {
+		t.Errorf("empty state should have no heading; got %q", heading)
+	}
+	if !strings.Contains(body, "Select") {
+		t.Errorf("empty state body should prompt selection; got %q", body)
+	}
+}
+
+func TestInstallModal_NarrowTerminal_NoDivider(t *testing.T) {
+	m := newTestModal(
+		map[string]bool{"claude-code": true, "cursor": true},
+		map[string]bool{"claude-code": true, "cursor": true},
+	)
+	m.width = 70
+	body := m.renderBody()
+	if strings.Contains(body, "│") {
+		t.Errorf("narrow terminal should omit divider; got:\n%s", body)
+	}
+}
+
+func TestInstallModal_WideTerminal_HasDivider(t *testing.T) {
+	m := newTestModal(
+		map[string]bool{"claude-code": true, "cursor": true},
+		map[string]bool{"claude-code": true, "cursor": true},
+	)
+	m.width = 120
+	body := m.renderBody()
+	if !strings.Contains(body, "│") {
+		t.Errorf("wide terminal should render divider; got:\n%s", body)
+	}
+}
+
+func TestInstallModal_PaneWidths_Clamp(t *testing.T) {
+	m := newTestModal(nil, nil)
+	// Tiny total: right pane clamped to 24, left clamped to 40.
+	leftW, rightW := m.paneWidths(50)
+	if rightW != 24 {
+		t.Errorf("rightW = %d, want 24 (clamped min)", rightW)
+	}
+	if leftW != 40 {
+		t.Errorf("leftW = %d, want 40 (clamped min)", leftW)
+	}
+
+	// Huge total: right pane clamped to 48.
+	_, rightW = m.paneWidths(300)
+	if rightW != 48 {
+		t.Errorf("rightW = %d, want 48 (clamped max)", rightW)
+	}
+}
+
+// --- helpers ---
+
+func hintKeys(hs []KeyHint) []string {
+	out := make([]string, 0, len(hs))
+	for _, h := range hs {
+		out = append(out, h.Keys)
+	}
+	return out
+}
+
+func contains(xs []string, x string) bool {
+	for _, s := range xs {
+		if s == x {
+			return true
+		}
+	}
+	return false
+}

--- a/registry.json
+++ b/registry.json
@@ -1,10 +1,10 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-04-21T12:42:19Z",
+  "generated_at": "2026-04-23T18:25:55Z",
   "source": {
     "repo": "github.com/jjfantini/humblSKILLS",
-    "ref": "skill/create-video-transition",
-    "sha": "6052d45c4ab5ac19fb55d0d8eab5305bc630d5a0"
+    "ref": "claude/lucid-kilby-7e5e39",
+    "sha": "b2ef9efd121033a4c1e4914669bf0b20c23299e3"
   },
   "skills": [
     {


### PR DESCRIPTION
Closes #84.

## Summary

- **Default platform changes to claude-code only** when both IDEs are detected. Cursor can read `~/.claude/skills` directly via its _Include Third-Party Plugins, Skills and other configs_ setting, so installing to both by default is a drift risk. Cursor stays a visible opt-in via space in the TUI or `--platform cursor` on the CLI.
- **Right-side INFO pane** inside the same install modal — tip when only claude-code is selected (how to enable the Cursor setting), yellow duplicate-install warning when both are selected, and a note when only cursor is selected. Pane width is fixed per terminal size so selection changes don't shift the left pane — no flicker.
- **Key bindings collapsed to one path per action**: space toggles (platforms only), enter confirms and advances through every group. Footer hints are now per-group and advertise only the current group's keys. Tab is kept as a silent secondary advance for muscle memory.
- **Narrow terminal fallback** (<80 cols) reverts to the original single-column layout where the info text would wrap past legibility.

## Behavior change for scripted flows

`humblskills install foo --yes` with both IDEs detected now installs to claude-code only. Users who want the old behavior can pass `--platform claude-code,cursor` explicitly. Call out in release notes.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` — new tests in `cli/internal/adapters/defaults_test.go`, `cli/internal/tui/install_modal_test.go`, `cli/cmd/humblskills/install_test.go`
- [ ] Manual TUI run: `humblskills install foo` in a repo with both `~/.claude` and `~/.cursor` — verify claude-code is pre-checked, tip shows on the right, space on cursor flips to the duplicate warning without layout shift, enter advances groups, tab still advances silently.
- [ ] Narrow terminal (<80 cols) — right pane omitted, groups still usable.
- [ ] `humblskills install foo --yes` with both detected → only claude-code in manifest. With `--platform claude-code,cursor` → both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)