### PR TITLE
fix(ci): unbreak release-please auto-merge

### DIFF
--- a/.github/workflows/release-auto-merge.yml
+++ b/.github/workflows/release-auto-merge.yml
@@ -36,7 +36,10 @@ jobs:
       github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
+      # `gh pr merge` shells out to `git` to auto-discover the repo, which
+      # fails ("not a git repository") when we haven't done actions/checkout.
+      # Passing -R skips the git lookup entirely — no checkout needed.
       - name: Enable auto-merge (merge commit)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh pr merge "${{ github.event.pull_request.number }}" --merge --auto
+        run: gh pr merge -R "${{ github.repository }}" "${{ github.event.pull_request.number }}" --merge --auto


### PR DESCRIPTION
## Summary
- The `enable-auto-merge` job in `release-auto-merge.yml` has been failing on every release PR with `fatal: not a git repository` because `gh pr merge` shells out to `git` to resolve the repo and the workflow has no `actions/checkout` step.
- Fix is a one-liner: pass `-R "${{ github.repository }}"` so `gh` skips the git-remote lookup entirely. No checkout needed, no extra minutes.
- Release 2.8.0's PR had to be merged by hand for this reason; 2.9.0 would too without this fix.

## Test plan
- [ ] CI passes on this PR
- [ ] After merge, force-push release PR #86 so its `pull_request` workflow re-runs against the fixed `main` — expect `enable-auto-merge` to succeed and auto-merge to flip on.