### PR TITLE
fix(ci): use PAT for auto-merge so release workflow cascades

### DIFF
--- a/.github/workflows/release-auto-merge.yml
+++ b/.github/workflows/release-auto-merge.yml
@@ -36,10 +36,16 @@ jobs:
       github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
+      # Use the release-please PAT, not GITHUB_TOKEN. When auto-merge fires
+      # with GITHUB_TOKEN, the resulting merge commit is authored by
+      # github-actions[bot] and GitHub suppresses downstream workflow
+      # triggers — so the `release` workflow never runs, no v tag, no
+      # GoReleaser artifacts. A PAT-authored merge cascades normally.
+      #
       # `gh pr merge` shells out to `git` to auto-discover the repo, which
-      # fails ("not a git repository") when we haven't done actions/checkout.
-      # Passing -R skips the git lookup entirely — no checkout needed.
+      # fails ("not a git repository") without actions/checkout. Passing -R
+      # skips the git lookup entirely.
       - name: Enable auto-merge (merge commit)
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
         run: gh pr merge -R "${{ github.repository }}" "${{ github.event.pull_request.number }}" --merge --auto


### PR DESCRIPTION
## Summary
- Auto-merge uses \`GITHUB_TOKEN\`, so the merge commit it creates is authored by \`github-actions[bot]\`. GitHub's anti-loop rule suppresses downstream workflow triggers for those events — which is why merging release PR #86 did **not** fire the \`release\` workflow, \`v2.9.0\` was never tagged, and GoReleaser never ran.
- Switch to \`RELEASE_PLEASE_TOKEN\` (the PAT \`release.yml\` already uses for the same reason). PAT-authored commits cascade normally.

## Context
Part two of unbreaking release-please auto-merge. PR #87 fixed the \`not a git repository\` error; this fixes the silent "merge succeeds but nothing downstream runs" failure mode.

## Recovery for 2.9.0
Merging this PR will push a normal commit to \`main\`, which re-triggers \`release-please\` → it notices the 2.9.0 release-please commits already on main and creates the \`v2.9.0\` tag + GitHub release.

## Test plan
- [ ] CI passes
- [ ] After merge, confirm the \`release\` workflow runs on the merge commit
- [ ] Confirm \`v2.9.0\` tag and GitHub release appear