### PR TITLE
fix(ci): use PAT for sibling cli/ tag push in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,10 +79,15 @@ jobs:
             echo "tag=${{ needs.release_please.outputs.tag_name }}" >> "$GITHUB_OUTPUT"
           fi
 
+      # token: RELEASE_PLEASE_TOKEN so the sibling tag push below can touch
+      # commits that include workflow file changes. GITHUB_TOKEN cannot
+      # push refs referencing commits that modify .github/workflows/
+      # without the `workflows` app permission, which it doesn't have.
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ steps.resolve.outputs.tag }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
 
       - name: Push sibling cli/* tag for go install
         # Go's nested-module resolution requires `cli/vX.Y.Z` to exist on the


### PR DESCRIPTION
## Summary
- Release 2.9.0 failed at the sibling \`cli/vX.Y.Z\` tag push with \`remote rejected ... refusing to allow a GitHub App to create or update workflow\` — \`GITHUB_TOKEN\` cannot push refs that point at commits touching \`.github/workflows/\`, because the default token lacks the \`workflows\` GitHub App permission.
- Until now this was dormant: past release commits happened not to touch workflows. The v2.9.0 merge commit includes PR #87's workflow edit, which tripped it.
- Fix: pass \`RELEASE_PLEASE_TOKEN\` to the \`goreleaser\` job's \`actions/checkout\` so the git remote uses the PAT (which has workflow push rights) for the subsequent \`git push origin cli/vX.Y.Z\`.

## Recovery for 2.9.0
After this merges, I'll \`workflow_dispatch\` \`release.yml\` with \`tag: v2.9.0\` to run GoReleaser against the existing tag — that publishes the missing binaries and updates the Homebrew tap.

## Test plan
- [ ] CI passes on this PR
- [ ] Dispatch \`release.yml\` with \`tag=v2.9.0\` after merge
- [ ] \`cli/v2.9.0\` sibling tag exists
- [ ] v2.9.0 GitHub release has binary assets
- [ ] \`jjfantini/homebrew-humbl\` tap updated to 2.9.0