### PR TITLE
fix(ci): scope auto-merge job to release environment for PAT access

### DIFF
--- a/.github/workflows/release-auto-merge.yml
+++ b/.github/workflows/release-auto-merge.yml
@@ -35,6 +35,10 @@ jobs:
       contains(github.head_ref, 'release-please--') &&
       github.event.pull_request.draft == false
     runs-on: ubuntu-latest
+    # RELEASE_PLEASE_TOKEN is an environment secret on `release`. Without
+    # this declaration, secrets.RELEASE_PLEASE_TOKEN resolves to empty
+    # and gh errors out with "GH_TOKEN ... not set".
+    environment: release
     steps:
       # Use the release-please PAT, not GITHUB_TOKEN. When auto-merge fires
       # with GITHUB_TOKEN, the resulting merge commit is authored by


### PR DESCRIPTION
## Summary
- Release PR #89 (2.9.1) didn't auto-merge because \`RELEASE_PLEASE_TOKEN\` is an **environment secret** on \`release\`, and the auto-merge job had no \`environment:\` declaration. \`secrets.RELEASE_PLEASE_TOKEN\` resolved to empty, so \`gh pr merge\` exited with "GH_TOKEN not set".
- Adding \`environment: release\` to the job exposes the PAT the same way \`release.yml\` already does.

## Test plan
- [ ] CI passes
- [ ] After merge, release PR #89's sync re-runs auto-merge with a non-empty token → auto-merge flips on → 2.9.1 ships end-to-end