### PR TITLE
docs: add AGENTS.md with Cursor Cloud dev environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,41 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This repo is the **humblskills** project: a single-binary Go CLI (`cli/`) that installs
+[agentskills.io](https://agentskills.io)-format skills, a markdown skill registry (`skills/` → `registry.json`),
+and an MkDocs docs site (`docs/`). The CLI is fully local ("zero servers, zero accounts, zero telemetry"),
+so **no backend/database/network services are required** to build, test, or run it.
+
+### Toolchain notes (non-obvious)
+- The CLI requires **Go 1.23+** (`cli/go.mod` pins `go 1.23.0`). The base VM image ships an older Go, so a
+  newer Go (1.26.x) is installed at `/usr/local/go` and symlinked to `/usr/local/bin/go`. The startup update
+  script keeps Go module deps fetched; if `go version` ever reports < 1.23, re-install Go before building.
+- `cli/` is a **nested Go module**. The root `Makefile` drives everything via `go -C cli ...` — run make
+  targets from the repo root, not from inside `cli/`.
+
+### Commands (all from repo root; see `Makefile`)
+- Build: `make build` → binary at `bin/humblskills`.
+- Lint/vet: `make vet` (CI uses `go vet`; there is no golangci-lint config).
+- Test: `make test`, or CI-equivalent `go -C cli test -race -count=1 ./...`.
+- Registry: `make registry` regenerates `registry.json`; `make registry-check` fails if it's stale
+  (enforced in CI — run it after editing anything under `skills/`).
+- Eval (no external deps): `make eval-mock` runs the eval harness with the deterministic `mock` runner,
+  writing artifacts to `.eval-workspace/` (gitignored). Real eval runners (`claudecode`, `cursor-agent`,
+  `codex`, `anthropic-api`, `openai-api`) are optional and need their respective agent CLI or
+  `ANTHROPIC_API_KEY` / `OPENAI_API_KEY`.
+
+### Running the CLI
+- `./bin/humblskills doctor` — shows detected agent platforms + registry/eval readiness.
+- `./bin/humblskills search <q>` / `install <skill>` / `list` / `update`.
+- To exercise the **local** code against the in-repo registry (instead of the hosted one), pass
+  `--registry file:///workspace/registry.json`. Use `--yes` (and optionally `--platform`/`--scope`) to run
+  non-interactively; with no args many commands open an interactive TUI.
+- Install writes to platform skill dirs (e.g. `.cursor/skills/`, `~/.humblskills/`). In this repo
+  `.cursor/`, `.claude/`, `bin/`, `site/`, `.eval-workspace/` are gitignored, but `~/.humblskills/` (created
+  by `--global` or default installs) is NOT — clean up stray `.humblskills/` if it appears in the worktree.
+
+### Docs site (optional)
+- Needs Python venv tooling (`python3.12-venv`). Build with the venv at `~/.venvs/humblskills-docs`:
+  `~/.venvs/humblskills-docs/bin/mkdocs build --strict` (config: `mkdocs.yml`). `mkdocs serve` for preview.
+  Note `mkdocs build` drops a `docs/__pycache__/` (not gitignored) — remove it after building.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the Cloud Agent development environment for the **humblskills** Go CLI and documents durable, non-obvious dev/run guidance for future agents.

This PR only adds `AGENTS.md` (no code changes). Environment provisioning (Go toolchain install + module download) is handled via the VM update script / snapshot, not committed code.

### Environment set up
- Installed **Go 1.26.4** (base image had Go 1.22.2; `cli/go.mod` requires Go 1.23+) at `/usr/local/go`, symlinked into PATH.
- `go -C cli mod download` (also the registered startup update script — minimal, idempotent dependency refresh).
- Optional docs: `python3.12-venv` + `~/.venvs/humblskills-docs` with `docs/requirements.txt`.

### Verified
| Component | Command | Result |
|---|---|---|
| CLI build | `make build` | pass |
| Lint | `make vet` | pass |
| Tests | `go -C cli test -race -count=1 ./...` | pass (all packages) |
| Registry | `make registry-check` | pass |
| Eval harness | `make eval-mock` | pass |
| Docs site | `mkdocs build --strict` | pass |

### Hello-world
Installed a skill end-to-end against the local registry and confirmed it landed on disk + appears in `list`:
`humblskills install use-smart-commit --registry file:///workspace/registry.json --platform cursor --scope project --yes`

[humblskills_hello_world_demo.log](https://cursor.com/artifacts/c/art-032c3122-406e-40b1-9643-bacc9c160381)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5012fad2-2444-48d6-bad2-4b5106187e35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5012fad2-2444-48d6-bad2-4b5106187e35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

