### PR TITLE
ci(registry): make registry auto-commit race-safe and branch-only

### DIFF
--- a/.github/workflows/registry.yml
+++ b/.github/workflows/registry.yml
@@ -1,13 +1,17 @@
 name: Registry
 
-# Self-healing registry.json. Runs on every push (any branch) whose paths
-# could affect the generated registry. If drift is detected, regenerates
-# and commits back to the pushed branch with [skip ci] so the bot's own
-# commit does not loop. This replaces the former pre-merge "registry-check"
-# gate — drift is now auto-fixed rather than blocking merges.
+# Self-healing registry.json. Runs on branch pushes whose paths could affect
+# the generated registry. If drift is detected, regenerates and commits back to
+# the pushed branch with [skip ci] so the bot's own commit does not loop. This
+# replaces the former pre-merge "registry-check" gate — drift is now auto-fixed
+# rather than blocking merges.
 
 on:
   push:
+    # Branch pushes only. Tag pushes (e.g. the vX.Y.Z / cli/vX.Y.Z release tags)
+    # check out a detached ref with nowhere to push, so they must NOT run here.
+    branches:
+      - "**"
     paths:
       - "skills/**"
       - "cli/cmd/build-registry/**"
@@ -41,19 +45,39 @@ jobs:
           go-version: "1.23"
           cache-dependency-path: cli/go.sum
 
-      - name: Rebuild registry.json
-        run: make registry
-
-      - name: Commit if changed
+      - name: Rebuild and push registry.json (race-safe)
+        env:
+          REF: ${{ github.ref_name }}
         run: |
           set -euo pipefail
-          if git diff --quiet -- registry.json; then
-            echo "registry.json already in sync; nothing to commit."
-            exit 0
-          fi
-
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add registry.json
-          git commit -m "chore(registry): regenerate registry.json [skip ci]"
-          git push
+
+          # Regenerate, commit, and push. If another push (e.g. a sibling merge
+          # during a release) advances the branch first, our push is a
+          # non-fast-forward and is rejected. Re-sync to the remote tip and
+          # retry — the regeneration is deterministic, so it converges quickly.
+          for attempt in 1 2 3 4 5; do
+            make registry
+
+            if git diff --quiet -- registry.json; then
+              echo "registry.json already in sync; nothing to commit."
+              exit 0
+            fi
+
+            git add registry.json
+            git commit -m "chore(registry): regenerate registry.json [skip ci]"
+
+            if git push origin "HEAD:${REF}"; then
+              echo "pushed regenerated registry.json (attempt ${attempt})"
+              exit 0
+            fi
+
+            echo "push rejected (attempt ${attempt}); re-syncing to origin/${REF} and retrying"
+            git reset --hard "HEAD~1"
+            git fetch origin "${REF}"
+            git reset --hard FETCH_HEAD
+          done
+
+          echo "::error::failed to push registry.json after 5 attempts"
+          exit 1


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

During the `v2.17.0` release the `Registry` workflow failed on `main`:

```
[main 95dacd5] chore(registry): regenerate registry.json [skip ci]
 ! [rejected]        main -> main (fetch first)
error: failed to push some refs ... remote contains work that you do not have locally
```

Two root causes:
1. **Race:** the `develop→main` merge triggered the registry rebuild; while it ran, release-please's release-PR merge landed on `main`, so the bot's push was a non-fast-forward and died with no retry. Result: `registry.json`'s `source.sha` was left pointing at a pre-skill commit (had to be fixed manually).
2. **Tag runs:** the workflow had no `branches:` filter, so it also fired on the `vX.Y.Z` / `cli/vX.Y.Z` release tags, where the checkout is detached and `git push` has no branch to target - guaranteed failures.

The failure was a non-fast-forward (`fetch first`), **not** a permissions/branch-protection block, so no token changes are needed.

## Fix

- `on.push.branches: ["**"]` so the workflow runs on branch pushes only (skips tags).
- Replace the single `git commit && git push` with a regenerate → commit → push loop that, on rejection, `reset`s to the remote tip, re-fetches, and retries (up to 5×). Deterministic regeneration converges immediately.

## Testing

- ✅ Local harness reproducing a non-fast-forward race (a competitor commit lands on `main` before the runner pushes): **attempt 1 rejected → resync → attempt 2 pushed**; the competitor's commit + `CHANGELOG` are preserved and `registry.json` is regenerated on top (no force-push, no data loss).
- ✅ `python3 -c yaml.safe_load` parses the workflow; `bash -n` on the embedded script passes.

Note: pushing this change does not touch the workflow's trigger paths (`skills/**`, `cli/**`), so it won't trigger the Registry workflow itself; the new behavior takes effect on subsequent skill pushes once merged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3ab934da-565c-4433-aa98-36da724c1d3d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3ab934da-565c-4433-aa98-36da724c1d3d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

