### PR TITLE
Install/list UX overhaul: global-by-default scope, real post-install summary, source-of-truth list

### DIFF
--- a/cli/cmd/humblskills/browse_skills.go
+++ b/cli/cmd/humblskills/browse_skills.go
@@ -27,10 +27,25 @@ const (
 
 // skillItem adapts a registry.Skill (with optional installed-state overlay)
 // to the tui.Item interface. Shared by search, install, list, uninstall.
+//
+// installs holds *every* manifest entry for this skill — one per
+// (platform, scope) the engine wrote a symlink for — not just the first one
+// found. That's what lets Detail() show the canonical humblskills store
+// (source of truth) plus every platform it's symlinked to, instead of
+// whichever platform happened to be inserted into the manifest first.
 type skillItem struct {
-	s         registry.Skill
-	installed *manifest.Installation // nil if not installed on this machine
-	outdated  bool                   // registry version > installed version
+	s        registry.Skill
+	installs []manifest.Installation // empty if not installed on this machine
+	outdated bool                    // any installed entry's version != registry version
+}
+
+// primary returns the first installed entry, or nil if none. Used where a
+// single representative install is enough (e.g. the left-pane row dot).
+func (s skillItem) primary() *manifest.Installation {
+	if len(s.installs) == 0 {
+		return nil
+	}
+	return &s.installs[0]
 }
 
 func (s skillItem) Key() string { return s.s.Name }
@@ -50,14 +65,13 @@ func (s skillItem) NaturalWidth(th *ui.Theme) int {
 
 func (s skillItem) Row(th *ui.Theme, width int, selected bool) string {
 	var dot string
-	if s.installed != nil {
-		if s.outdated {
-			dot = th.DotWarn.Render("●")
-		} else {
-			dot = th.DotOK.Render("●")
-		}
-	} else {
+	switch {
+	case len(s.installs) == 0:
 		dot = th.DotNo.Render("●")
+	case s.outdated:
+		dot = th.DotWarn.Render("●")
+	default:
+		dot = th.DotOK.Render("●")
 	}
 
 	name := rowName(th, s.s.Name, selected, true)
@@ -73,9 +87,10 @@ func (s skillItem) Row(th *ui.Theme, width int, selected bool) string {
 
 func (s skillItem) Detail(th *ui.Theme, width int) string {
 	var sb strings.Builder
+	primary := s.primary()
 	sub := "v" + s.s.Version
-	if s.installed != nil && s.installed.Version != s.s.Version {
-		sub = "v" + s.installed.Version + " → v" + s.s.Version
+	if primary != nil && primary.Version != s.s.Version {
+		sub = "v" + primary.Version + " → v" + s.s.Version
 	}
 	sb.WriteString(th.DetailTitle.Render(s.s.Name) + "  " +
 		th.DetailSub.Render(sub) + "\n\n")
@@ -103,39 +118,80 @@ func (s skillItem) Detail(th *ui.Theme, width int) string {
 		sb.WriteString(kvRow(th, "deps", th.KVValue.Render(strings.Join(s.s.Requires, ", "))))
 	}
 
-	if s.installed != nil {
-		sb.WriteString("\n" + th.SectionTitle.Render("INSTALLED") + "\n")
-		sb.WriteString(kvRow(th, "version", th.KVValue.Render("v"+s.installed.Version)))
-		sb.WriteString(kvRow(th, "platform", th.KVValue.Render(s.installed.Platform)))
-		sb.WriteString(kvRow(th, "scope", th.KVValue.Render(s.installed.Scope)))
-		sb.WriteString(kvRow(th, "path", th.KVValue.Render(s.installed.Path)))
-		if !s.installed.InstalledAt.IsZero() {
+	if len(s.installs) > 0 {
+		sb.WriteString(s.installedSection(th, width))
+	}
+	return sb.String()
+}
+
+// installedSection renders the "INSTALLED" block: the canonical humblskills
+// store (source of truth — every platform below is a symlink to this one
+// directory) followed by every platform/scope it's symlinked to. Falls back
+// gracefully for legacy manifest entries written before store_path existed.
+func (s skillItem) installedSection(th *ui.Theme, width int) string {
+	var sb strings.Builder
+	sb.WriteString("\n" + th.SectionTitle.Render("INSTALLED") + "\n")
+
+	store := ""
+	for _, inst := range s.installs {
+		if inst.StorePath != "" {
+			store = inst.StorePath
+			break
+		}
+	}
+	if store != "" {
+		sb.WriteString(kvRow(th, "store", th.KVValue.Render(store)))
+	}
+
+	sb.WriteString("\n" + th.SectionTitle.Render("SYMLINKED PLATFORMS") + "\n")
+	for i, inst := range s.installs {
+		if i > 0 {
+			sb.WriteString(tui.DashedRule(th, width) + "\n")
+		}
+		ver := "v" + inst.Version
+		if inst.Version != s.s.Version {
+			ver = "v" + inst.Version + " → v" + s.s.Version
+		}
+		sb.WriteString(kvRow(th, "platform", th.Platform.Render(inst.Platform)+"  "+th.KVValue.Render(ver)))
+		sb.WriteString(kvRow(th, "scope", th.KVValue.Render(inst.Scope)))
+		sb.WriteString(kvRow(th, "path", th.KVValue.Render(inst.Path)))
+		if !inst.InstalledAt.IsZero() {
 			sb.WriteString(kvRow(th, "at", th.KVValue.Render(
-				s.installed.InstalledAt.Format("2006-01-02 15:04"))))
+				inst.InstalledAt.Format("2006-01-02 15:04"))))
 		}
 	}
 	return sb.String()
 }
 
 // buildSkillItems joins a registry listing with the install manifest so the
-// returned items know whether they're installed and/or drifted.
+// returned items know every (platform, scope) they're installed onto, and
+// whether any of those have drifted from the registry version.
 func buildSkillItems(skills []registry.Skill, m *manifest.Manifest) []skillItem {
-	installed := map[string]*manifest.Installation{}
+	installed := map[string][]manifest.Installation{}
 	if m != nil {
-		for i := range m.Installations {
-			it := &m.Installations[i]
-			if _, seen := installed[it.Skill]; !seen {
-				installed[it.Skill] = it
-			}
+		for _, inst := range m.Installations {
+			installed[inst.Skill] = append(installed[inst.Skill], inst)
+		}
+		for name, insts := range installed {
+			sort.SliceStable(insts, func(i, j int) bool {
+				if insts[i].Platform != insts[j].Platform {
+					return insts[i].Platform < insts[j].Platform
+				}
+				return insts[i].Scope < insts[j].Scope
+			})
+			installed[name] = insts
 		}
 	}
 	items := make([]skillItem, 0, len(skills))
 	for _, s := range skills {
 		it := skillItem{s: s}
-		if inst, ok := installed[s.Name]; ok {
-			it.installed = inst
-			if inst.Version != s.Version {
-				it.outdated = true
+		if insts, ok := installed[s.Name]; ok {
+			it.installs = insts
+			for _, inst := range insts {
+				if inst.Version != s.Version {
+					it.outdated = true
+					break
+				}
 			}
 		}
 		items = append(items, it)
@@ -179,7 +235,7 @@ func runSkillBrowser(app *App, section string, skills []skillItem, mode skillsBr
 
 	installedCount, outdatedCount := 0, 0
 	for _, s := range skills {
-		if s.installed != nil {
+		if len(s.installs) > 0 {
 			installedCount++
 		}
 		if s.outdated {

--- a/cli/cmd/humblskills/browse_skills_test.go
+++ b/cli/cmd/humblskills/browse_skills_test.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jjfantini/humblSKILLS/cli/internal/manifest"
+	"github.com/jjfantini/humblSKILLS/cli/internal/registry"
+	"github.com/jjfantini/humblSKILLS/cli/internal/ui"
+)
+
+func TestBuildSkillItems_CarriesEveryInstallationForASkill(t *testing.T) {
+	m := &manifest.Manifest{SchemaVersion: manifest.SchemaVersion}
+	m.Upsert(manifest.Installation{
+		Skill: "foo", Version: "1.0.0", Platform: "claude-code", Scope: "user",
+		Path: "/home/u/.claude/skills/foo", StorePath: "/home/u/.humblskills/skills/foo",
+	})
+	m.Upsert(manifest.Installation{
+		Skill: "foo", Version: "1.0.0", Platform: "cursor", Scope: "user",
+		Path: "/home/u/.cursor/skills/foo", StorePath: "/home/u/.humblskills/skills/foo",
+	})
+	m.Upsert(manifest.Installation{
+		Skill: "foo", Version: "1.0.0", Platform: "codex", Scope: "user",
+		Path: "/home/u/.agents/skills/foo", StorePath: "/home/u/.humblskills/skills/foo",
+	})
+
+	items := buildSkillItems([]registry.Skill{{Name: "foo", Version: "1.0.0"}}, m)
+	if len(items) != 1 {
+		t.Fatalf("items = %d, want 1", len(items))
+	}
+	it := items[0]
+	if len(it.installs) != 3 {
+		t.Fatalf("installs = %d, want 3: %+v", len(it.installs), it.installs)
+	}
+	if it.outdated {
+		t.Error("should not be outdated when every install matches the registry version")
+	}
+	platforms := map[string]bool{}
+	for _, inst := range it.installs {
+		platforms[inst.Platform] = true
+	}
+	for _, want := range []string{"claude-code", "cursor", "codex"} {
+		if !platforms[want] {
+			t.Errorf("missing platform %q in installs: %+v", want, it.installs)
+		}
+	}
+}
+
+func TestBuildSkillItems_OutdatedWhenAnyInstallDrifts(t *testing.T) {
+	m := &manifest.Manifest{SchemaVersion: manifest.SchemaVersion}
+	m.Upsert(manifest.Installation{
+		Skill: "foo", Version: "1.0.0", Platform: "claude-code", Scope: "user",
+		Path: "/home/u/.claude/skills/foo", StorePath: "/home/u/.humblskills/skills/foo",
+	})
+	m.Upsert(manifest.Installation{
+		Skill: "foo", Version: "0.9.0", Platform: "cursor", Scope: "user",
+		Path: "/home/u/.cursor/skills/foo", StorePath: "/home/u/.humblskills/skills/foo",
+	})
+
+	items := buildSkillItems([]registry.Skill{{Name: "foo", Version: "1.0.0"}}, m)
+	if !items[0].outdated {
+		t.Error("expected outdated=true when one install lags the registry version")
+	}
+}
+
+func TestSkillItem_Detail_ShowsStorePathAndEveryPlatform(t *testing.T) {
+	it := skillItem{
+		s: registry.Skill{Name: "foo", Version: "1.0.0"},
+		installs: []manifest.Installation{
+			{
+				Skill: "foo", Version: "1.0.0", Platform: "claude-code", Scope: "user",
+				Path: "/home/u/.claude/skills/foo", StorePath: "/home/u/.humblskills/skills/foo",
+				InstalledAt: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+			},
+			{
+				Skill: "foo", Version: "1.0.0", Platform: "cursor", Scope: "user",
+				Path: "/home/u/.cursor/skills/foo", StorePath: "/home/u/.humblskills/skills/foo",
+				InstalledAt: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+			},
+		},
+	}
+	detail := it.Detail(ui.DefaultTheme(), 80)
+	for _, want := range []string{
+		"/home/u/.humblskills/skills/foo", // canonical store
+		"claude-code", "/home/u/.claude/skills/foo",
+		"cursor", "/home/u/.cursor/skills/foo",
+	} {
+		if !strings.Contains(detail, want) {
+			t.Errorf("detail missing %q:\n%s", want, detail)
+		}
+	}
+}
+
+func TestSkillItem_Detail_NotInstalled_NoInstalledSection(t *testing.T) {
+	it := skillItem{s: registry.Skill{Name: "foo", Version: "1.0.0"}}
+	detail := it.Detail(ui.DefaultTheme(), 80)
+	if strings.Contains(detail, "INSTALLED") {
+		t.Errorf("uninstalled skill should not render an INSTALLED section:\n%s", detail)
+	}
+}

--- a/cli/cmd/humblskills/install.go
+++ b/cli/cmd/humblskills/install.go
@@ -18,6 +18,7 @@ type installFlags struct {
 	platforms    []string
 	platformsSet bool
 	scope        string
+	scopeSet     bool
 	force        bool
 	global       bool
 }
@@ -36,13 +37,14 @@ func newInstallCmd(app *App) *cobra.Command {
 				skill = args[0]
 			}
 			f.platformsSet = cmd.Flags().Changed("platform")
+			f.scopeSet = cmd.Flags().Changed("scope")
 			return runInstall(app, skill, f, false)
 		},
 	}
-	cmd.Flags().StringSliceVar(&f.platforms, "platform", nil, "restrict install to these adapters (default: all detected)")
-	cmd.Flags().StringVar(&f.scope, "scope", "", "install scope (user|project; default: adapter's default)")
+	cmd.Flags().StringSliceVar(&f.platforms, "platform", nil, "restrict install to these adapters (default: profile default, else all detected)")
+	cmd.Flags().StringVar(&f.scope, "scope", "", "install scope: global|user|project|adapter-default (default: your profile's default scope, itself global unless changed)")
 	cmd.Flags().BoolVar(&f.force, "force", false, "reinstall even if already up-to-date")
-	cmd.Flags().BoolVar(&f.global, "global", false, "install once into ~/.humblskills and symlink to all detected platforms")
+	cmd.Flags().BoolVar(&f.global, "global", false, "alias for --scope global: install once into ~/.humblskills and symlink to the selected platforms")
 	return cmd
 }
 
@@ -67,11 +69,21 @@ func runInstall(app *App, skill string, f installFlags, fromDashboard bool) erro
 		}
 	}
 
+	p, err := profile.Load(app.Config.ProfilePath)
+	if err != nil {
+		return err
+	}
+
+	// Any explicit flag (--platform, --scope, --global) opts out of the
+	// interactive modal — scripted/explicit invocations should never be
+	// silently overridden by a prompt the caller can't see.
+	explicitFlags := f.platformsSet || f.scopeSet || f.global
 	platforms := f.platforms
 	scope := f.scope
-	useTUIForModal := !f.platformsSet && tui.ShouldUseTUI(app.Config.JSON, app.Config.Quiet, app.Config.Yes)
+	global := f.global
+	useTUIForModal := !explicitFlags && tui.ShouldUseTUI(app.Config.JSON, app.Config.Quiet, app.Config.Yes)
 	if useTUIForModal {
-		plats, scp, global, ok, err := promptInstallTargets(app, adapterList, skill)
+		plats, scp, glob, ok, err := promptInstallTargets(app, adapterList, skill)
 		if err != nil {
 			return err
 		}
@@ -82,20 +94,16 @@ func runInstall(app *App, skill string, f installFlags, fromDashboard bool) erro
 			return fmt.Errorf("install cancelled")
 		}
 		platforms = plats
-		if scp != "" {
-			scope = scp
+		scope = scp
+		global = glob
+	} else {
+		scope, global, err = resolveInstallScope(f, p)
+		if err != nil {
+			return err
 		}
-		f.global = global
 	}
 
-	if f.global && f.platformsSet {
-		return fmt.Errorf("--global cannot be combined with --platform")
-	}
-	if f.global && scope == "project" {
-		return fmt.Errorf("--global installs to user-scope platform targets; use project scope without --global")
-	}
-
-	selected, err := selectPlatforms(adapterList, platforms, f.global)
+	selected, err := selectPlatforms(adapterList, platforms, global, p.DefaultPlatforms)
 	if err != nil {
 		return err
 	}
@@ -129,7 +137,7 @@ func runInstall(app *App, skill string, f installFlags, fromDashboard bool) erro
 			Platforms: selected,
 			Scope:     scope,
 			Force:     f.force,
-			Global:    f.global,
+			Global:    global,
 			OnEvent:   sink,
 		})
 		res = r
@@ -140,10 +148,13 @@ func runInstall(app *App, skill string, f installFlags, fromDashboard bool) erro
 		if err := tui.ExecuteWithProgress(app.UI.Theme(), "install", run); err != nil {
 			return err
 		}
-	} else {
-		if err := run(nil); err != nil {
-			return err
-		}
+		// Feedback already lives in the progress model's blocking done/summary
+		// screen — printing to the normal buffer here would just get hidden
+		// the instant the dashboard loop re-enters the alt-screen.
+		return nil
+	}
+	if err := run(nil); err != nil {
+		return err
 	}
 
 	if app.Config.JSON {
@@ -154,12 +165,48 @@ func runInstall(app *App, skill string, f installFlags, fromDashboard bool) erro
 	return nil
 }
 
+// resolveInstallScope figures out the effective (scope, global) pair when
+// the install isn't going through the interactive platform modal (the modal
+// resolves its own scope/global from the profile internally). Precedence:
+// explicit --global / --scope flags, then the profile's resolved default,
+// then the historical "adapter default" catch-all.
+func resolveInstallScope(f installFlags, p *profile.Profile) (scope string, global bool, err error) {
+	if f.global {
+		if f.scopeSet && f.scope == profile.ScopeProject {
+			return "", false, fmt.Errorf("--global installs to user-scope platform targets; use --scope project without --global")
+		}
+		return "", true, nil
+	}
+	if f.scopeSet {
+		switch f.scope {
+		case profile.ScopeGlobal:
+			return "", true, nil
+		case profile.ScopeAdapterDefault, "":
+			return "", false, nil
+		case profile.ScopeUser, profile.ScopeProject:
+			return f.scope, false, nil
+		default:
+			return "", false, fmt.Errorf("unknown scope %q — valid: global, user, project, adapter-default", f.scope)
+		}
+	}
+	switch p.ResolvedScope() {
+	case profile.ScopeGlobal:
+		return "", true, nil
+	case profile.ScopeUser, profile.ScopeProject:
+		return p.DefaultScope, false, nil
+	default: // adapter-default
+		return "", false, nil
+	}
+}
+
 // selectPlatforms returns the adapter names to install onto. If the user
 // passed --platform, it's the intersection of that list with the declared
-// adapters; otherwise it falls back to the same default cascade the TUI
-// uses (issue #84: prefer claude-code over cursor when both are detected,
-// since Cursor can read ~/.claude/skills natively).
-func selectPlatforms(adapterList []adapters.Adapter, requested []string, global bool) ([]string, error) {
+// adapters — an explicit request always wins, global or not. Otherwise it
+// falls back to the profile's saved platforms, or (failing that) the same
+// default cascade the TUI uses: global scope symlinks every detected
+// platform; non-global scopes prefer claude-code over cursor when both are
+// detected, since Cursor can read ~/.claude/skills natively (issue #84).
+func selectPlatforms(adapterList []adapters.Adapter, requested []string, global bool, profileDefaults []string) ([]string, error) {
 	known := adapters.NameSet(adapterList)
 	if len(requested) > 0 {
 		out := make([]string, 0, len(requested))
@@ -176,17 +223,7 @@ func selectPlatforms(adapterList []adapters.Adapter, requested []string, global 
 	for _, d := range adapters.Detect(adapterList) {
 		detected[d.Name] = d.Detected
 	}
-	if global {
-		out := make([]string, 0, len(adapterList))
-		for _, a := range adapterList {
-			if detected[a.Name] {
-				out = append(out, a.Name)
-			}
-		}
-		sort.Strings(out)
-		return out, nil
-	}
-	out := adapters.PreferredDefaults(adapterList, detected, nil)
+	out := adapters.PreferredDefaults(adapterList, detected, profileDefaults, global)
 	sort.Strings(out)
 	return out, nil
 }

--- a/cli/cmd/humblskills/install_test.go
+++ b/cli/cmd/humblskills/install_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/jjfantini/humblSKILLS/cli/internal/manifest"
+	"github.com/jjfantini/humblSKILLS/cli/internal/profile"
 	"github.com/jjfantini/humblSKILLS/cli/internal/testutil"
 )
 
@@ -161,6 +162,256 @@ func TestInstall_GlobalFanoutInstallsCanonicalStoreAndSymlinksDetectedPlatforms(
 		if inst.InstallMode != "global" {
 			t.Errorf("%s install_mode = %q, want global", inst.Platform, inst.InstallMode)
 		}
+	}
+}
+
+func TestInstall_NoFlagsAtAll_DefaultsToGlobalAcrossAllDetectedPlatforms(t *testing.T) {
+	// The recommended default — no --scope, no --global, no --platform, no
+	// saved profile — should resolve to global humblskills: one canonical
+	// copy symlinked to every detected platform.
+	s := testutil.NewSandbox(t)
+	enableClaudeCode(t, s)
+	enableCursor(t, s)
+	enableCodex(t, s)
+
+	regURL := seedTestRegistry(t, s, []testutil.SkillFixture{
+		{
+			Name:        "foo",
+			Version:     "1.0.0",
+			Description: "test skill",
+			Files:       testutil.SkillTree{"SKILL.md": sampleSkillMD},
+		},
+	})
+
+	res := runCLIWithStdoutCapture(t,
+		"install", "foo",
+		"--registry", regURL,
+		"--cache-dir", s.CacheDir,
+		"--manifest", s.ManifestPath,
+		"--yes", "--json",
+	)
+	if res.RunErr != nil {
+		t.Fatalf("run: %v\nerr: %s\nout: %s", res.RunErr, res.Err, res.Out)
+	}
+
+	canonical := filepath.Join(s.Home, ".humblskills", "skills", "foo")
+	if _, err := os.Stat(filepath.Join(canonical, "SKILL.md")); err != nil {
+		t.Fatalf("canonical SKILL.md missing: %v", err)
+	}
+
+	m, err := manifest.Load(s.ManifestPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(m.Installations) != 3 {
+		t.Fatalf("manifest installs = %d, want 3 (every detected platform): %+v", len(m.Installations), m.Installations)
+	}
+	platforms := map[string]bool{}
+	for _, inst := range m.Installations {
+		platforms[inst.Platform] = true
+		if inst.InstallMode != "global" {
+			t.Errorf("%s install_mode = %q, want global", inst.Platform, inst.InstallMode)
+		}
+		if inst.StorePath != canonical {
+			t.Errorf("%s store_path = %q, want %q", inst.Platform, inst.StorePath, canonical)
+		}
+	}
+	for _, want := range []string{"claude-code", "cursor", "codex"} {
+		if !platforms[want] {
+			t.Errorf("missing platform %q in default global install: %+v", want, m.Installations)
+		}
+	}
+}
+
+func TestInstall_ScopeFlagGlobalIsAliasForGlobalFlag(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	enableClaudeCode(t, s)
+
+	regURL := seedTestRegistry(t, s, []testutil.SkillFixture{
+		{Name: "foo", Version: "1.0.0", Files: testutil.SkillTree{"SKILL.md": sampleSkillMD}},
+	})
+
+	res := runCLIWithStdoutCapture(t,
+		"install", "foo",
+		"--registry", regURL,
+		"--cache-dir", s.CacheDir,
+		"--manifest", s.ManifestPath,
+		"--scope", "global",
+		"--yes", "--json",
+	)
+	if res.RunErr != nil {
+		t.Fatalf("run: %v\nerr: %s", res.RunErr, res.Err)
+	}
+	m, err := manifest.Load(s.ManifestPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(m.Installations) != 1 || m.Installations[0].InstallMode != "global" {
+		t.Errorf("expected one global install, got: %+v", m.Installations)
+	}
+}
+
+func TestInstall_GlobalWithExplicitPlatform_NoLongerConflicts(t *testing.T) {
+	// Scope and platform selection are orthogonal: --global picks the
+	// canonical-store-and-symlink scope, --platform picks which adapters
+	// get a symlink. This used to be a hard error; it no longer is.
+	s := testutil.NewSandbox(t)
+	enableClaudeCode(t, s)
+	enableCursor(t, s)
+
+	regURL := seedTestRegistry(t, s, []testutil.SkillFixture{
+		{Name: "foo", Version: "1.0.0", Files: testutil.SkillTree{"SKILL.md": sampleSkillMD}},
+	})
+
+	res := runCLIWithStdoutCapture(t,
+		"install", "foo",
+		"--registry", regURL,
+		"--cache-dir", s.CacheDir,
+		"--manifest", s.ManifestPath,
+		"--global", "--platform", "cursor",
+		"--yes", "--json",
+	)
+	if res.RunErr != nil {
+		t.Fatalf("run: %v\nerr: %s", res.RunErr, res.Err)
+	}
+	m, err := manifest.Load(s.ManifestPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(m.Installations) != 1 {
+		t.Fatalf("installs = %d, want 1 (cursor only): %+v", len(m.Installations), m.Installations)
+	}
+	inst := m.Installations[0]
+	if inst.Platform != "cursor" || inst.InstallMode != "global" {
+		t.Errorf("unexpected install: %+v", inst)
+	}
+}
+
+func TestInstall_GlobalWithProjectScopeStillErrors(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	enableClaudeCode(t, s)
+
+	regURL := seedTestRegistry(t, s, []testutil.SkillFixture{
+		{Name: "foo", Version: "1.0.0", Files: testutil.SkillTree{"SKILL.md": sampleSkillMD}},
+	})
+
+	res := runCLIWithStdoutCapture(t,
+		"install", "foo",
+		"--registry", regURL,
+		"--cache-dir", s.CacheDir,
+		"--manifest", s.ManifestPath,
+		"--global", "--scope", "project",
+		"--yes", "--json",
+	)
+	if res.RunErr == nil {
+		t.Fatal("expected error combining --global with --scope project")
+	}
+}
+
+func TestInstall_ProfileDefaultScope_HonoredWithoutTUI(t *testing.T) {
+	// Regression: the scripted (--yes) path used to ignore the profile
+	// entirely. A saved "user" scope must still apply with zero install
+	// flags passed.
+	s := testutil.NewSandbox(t)
+	enableClaudeCode(t, s)
+
+	if err := profile.Save(s.ProfilePath, &profile.Profile{DefaultScope: profile.ScopeUser}); err != nil {
+		t.Fatal(err)
+	}
+
+	regURL := seedTestRegistry(t, s, []testutil.SkillFixture{
+		{Name: "foo", Version: "1.0.0", Platforms: []string{"claude-code"}, Files: testutil.SkillTree{"SKILL.md": sampleSkillMD}},
+	})
+
+	res := runCLIWithStdoutCapture(t,
+		"install", "foo",
+		"--registry", regURL,
+		"--cache-dir", s.CacheDir,
+		"--manifest", s.ManifestPath,
+		"--yes", "--json",
+	)
+	if res.RunErr != nil {
+		t.Fatalf("run: %v\nerr: %s", res.RunErr, res.Err)
+	}
+	m, err := manifest.Load(s.ManifestPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(m.Installations) != 1 {
+		t.Fatalf("installs = %d, want 1: %+v", len(m.Installations), m.Installations)
+	}
+	got := m.Installations[0]
+	if got.InstallMode == "global" {
+		t.Errorf("profile scope=user should not install globally: %+v", got)
+	}
+	if got.Scope != "user" {
+		t.Errorf("scope = %q, want user", got.Scope)
+	}
+}
+
+func TestInstall_ProfileDefaultPlatforms_HonoredWithoutTUI(t *testing.T) {
+	// Regression: profile.DefaultPlatforms was never consulted on the
+	// scripted path — only the TUI modal read it.
+	s := testutil.NewSandbox(t)
+	enableClaudeCode(t, s)
+	enableCursor(t, s)
+
+	if err := profile.Save(s.ProfilePath, &profile.Profile{DefaultPlatforms: []string{"cursor"}}); err != nil {
+		t.Fatal(err)
+	}
+
+	regURL := seedTestRegistry(t, s, []testutil.SkillFixture{
+		{Name: "foo", Version: "1.0.0", Platforms: []string{"claude-code", "cursor"}, Files: testutil.SkillTree{"SKILL.md": sampleSkillMD}},
+	})
+
+	res := runCLIWithStdoutCapture(t,
+		"install", "foo",
+		"--registry", regURL,
+		"--cache-dir", s.CacheDir,
+		"--manifest", s.ManifestPath,
+		"--yes", "--json",
+	)
+	if res.RunErr != nil {
+		t.Fatalf("run: %v\nerr: %s", res.RunErr, res.Err)
+	}
+	m, err := manifest.Load(s.ManifestPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(m.Installations) != 1 || m.Installations[0].Platform != "cursor" {
+		t.Errorf("expected only cursor (profile default), got: %+v", m.Installations)
+	}
+}
+
+func TestInstall_AdapterDefaultScopeFlag_FallsBackToAdapterScope(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	enableClaudeCode(t, s)
+
+	regURL := seedTestRegistry(t, s, []testutil.SkillFixture{
+		{Name: "foo", Version: "1.0.0", Platforms: []string{"claude-code"}, Files: testutil.SkillTree{"SKILL.md": sampleSkillMD}},
+	})
+
+	res := runCLIWithStdoutCapture(t,
+		"install", "foo",
+		"--registry", regURL,
+		"--cache-dir", s.CacheDir,
+		"--manifest", s.ManifestPath,
+		"--scope", "adapter-default",
+		"--yes", "--json",
+	)
+	if res.RunErr != nil {
+		t.Fatalf("run: %v\nerr: %s", res.RunErr, res.Err)
+	}
+	m, err := manifest.Load(s.ManifestPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(m.Installations) != 1 || m.Installations[0].Scope != "user" {
+		// claude-code.yaml's default_scope is "user".
+		t.Errorf("expected adapter-default to resolve to claude-code's own default (user): %+v", m.Installations)
+	}
+	if m.Installations[0].InstallMode == "global" {
+		t.Error("adapter-default must not install globally")
 	}
 }
 

--- a/cli/cmd/humblskills/list.go
+++ b/cli/cmd/humblskills/list.go
@@ -57,25 +57,32 @@ func runList(app *App, fromDashboard bool) error {
 }
 
 // renderListTable prints installs as a bordered table using the shared theme.
-// Used in non-TTY / piped paths.
+// Used in non-TTY / piped paths. "Source" is the canonical humblskills store
+// every row's Path symlinks to — the source of truth — so scripted/piped
+// output reflects the real install location, not just the platform copy.
 func renderListTable(app *App, installs []manifest.Installation) {
 	th := app.UI.Theme()
 	app.UI.Header("list")
 
 	rows := make([][]string, 0, len(installs))
 	for _, inst := range installs {
+		source := inst.StorePath
+		if source == "" {
+			source = "-"
+		}
 		rows = append(rows, []string{
 			th.Name.Render(inst.Skill),
 			th.Version.Render("v" + inst.Version),
 			th.Platform.Render(inst.Platform),
 			th.Label.Render(inst.Scope),
 			th.Detail.Render(inst.Path),
+			th.Detail.Render(source),
 		})
 	}
 	tbl := table.New().
 		Border(lipgloss.RoundedBorder()).
 		BorderStyle(th.RuleLine).
-		Headers("Skill", "Version", "Platform", "Scope", "Path").
+		Headers("Skill", "Version", "Platform", "Scope", "Path", "Source").
 		Rows(rows...).
 		StyleFunc(func(row, _ int) lipgloss.Style {
 			if row == table.HeaderRow {

--- a/cli/cmd/humblskills/list_test.go
+++ b/cli/cmd/humblskills/list_test.go
@@ -91,6 +91,45 @@ func TestList_PopulatedManifest_JSON(t *testing.T) {
 	}
 }
 
+func TestList_TextOutput_ShowsSourceColumn(t *testing.T) {
+	s := testutil.NewSandbox(t)
+
+	m := &manifest.Manifest{SchemaVersion: manifest.SchemaVersion}
+	m.Upsert(manifest.Installation{
+		Skill: "foo", Version: "1.0.0", Platform: "claude-code",
+		Scope: "user", Path: "/tmp/.claude/skills/foo",
+		StorePath:   "/tmp/.humblskills/skills/foo",
+		InstalledAt: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+	})
+	m.Upsert(manifest.Installation{
+		Skill: "foo", Version: "1.0.0", Platform: "cursor",
+		Scope: "user", Path: "/tmp/.cursor/skills/foo",
+		StorePath:   "/tmp/.humblskills/skills/foo",
+		InstalledAt: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+	})
+	if err := manifest.Save(s.ManifestPath, m); err != nil {
+		t.Fatal(err)
+	}
+
+	res := runCLIWithStdoutCapture(t,
+		"list",
+		"--manifest", s.ManifestPath,
+		"--yes",
+	)
+	if res.RunErr != nil {
+		t.Fatalf("run: %v\n%s", res.RunErr, res.Err)
+	}
+	if !strings.Contains(res.Out, "Source") {
+		t.Errorf("table should have a Source column header:\n%s", res.Out)
+	}
+	if !strings.Contains(res.Out, "/tmp/.humblskills/skills/foo") {
+		t.Errorf("table should show the canonical store path:\n%s", res.Out)
+	}
+	if !strings.Contains(res.Out, "claude-code") || !strings.Contains(res.Out, "cursor") {
+		t.Errorf("table should show every symlinked platform:\n%s", res.Out)
+	}
+}
+
 func TestList_EmptyManifest_TextOutputHint(t *testing.T) {
 	s := testutil.NewSandbox(t)
 

--- a/cli/cmd/humblskills/migrate.go
+++ b/cli/cmd/humblskills/migrate.go
@@ -87,7 +87,7 @@ func runMigrate(app *App, sourcePlatform string, f migrateFlags) error {
 	sort.Strings(candidates)
 	sort.Strings(skipped)
 
-	selectedPlatforms, err := selectPlatforms(adapterList, nil, f.global)
+	selectedPlatforms, err := selectPlatforms(adapterList, nil, f.global, nil)
 	if err != nil {
 		return err
 	}

--- a/cli/cmd/humblskills/profile.go
+++ b/cli/cmd/humblskills/profile.go
@@ -45,7 +45,7 @@ func newProfileShowCmd(app *App) *cobra.Command {
 func newProfileSetCmd(app *App) *cobra.Command {
 	return &cobra.Command{
 		Use:   "set <key> <value>",
-		Short: "Set a profile value. Keys: platforms, scope.",
+		Short: "Set a profile value. Keys: platforms (csv), scope (global|user|project|adapter-default).",
 		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runProfileSet(app, args[0], args[1])
@@ -157,7 +157,7 @@ func runProfileSet(app *App, key, value string) error {
 		}
 	case "scope":
 		if !profile.IsValidScope(value) {
-			return fmt.Errorf("invalid scope %q — valid: user, project, \"\"", value)
+			return fmt.Errorf("invalid scope %q — valid: global, user, project, adapter-default, \"\"", value)
 		}
 		p.DefaultScope = value
 	default:
@@ -232,8 +232,16 @@ func formatPlatforms(p []string) string {
 }
 
 func formatScope(s string) string {
-	if s == "" {
-		return "(adapter default)"
+	p := profile.Profile{DefaultScope: s}
+	switch resolved := p.ResolvedScope(); resolved {
+	case profile.ScopeGlobal:
+		if s == "" {
+			return "global humblskills (default)"
+		}
+		return "global humblskills"
+	case profile.ScopeAdapterDefault:
+		return "adapter default"
+	default:
+		return resolved
 	}
-	return s
 }

--- a/cli/cmd/humblskills/profile_test.go
+++ b/cli/cmd/humblskills/profile_test.go
@@ -53,6 +53,28 @@ func TestProfileSet_ValidScope(t *testing.T) {
 	}
 }
 
+func TestProfileSet_ValidScope_GlobalAndAdapterDefault(t *testing.T) {
+	s := testutil.NewSandbox(t)
+
+	for _, scope := range []string{"global", "adapter-default", "project"} {
+		res := runCLIWithStdoutCapture(t,
+			"profile", "set", "scope", scope,
+			"--profile", s.ProfilePath,
+			"--json",
+		)
+		if res.RunErr != nil {
+			t.Fatalf("scope=%q: run: %v", scope, res.RunErr)
+		}
+		p, err := profile.Load(s.ProfilePath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if p.DefaultScope != scope {
+			t.Errorf("scope=%q: DefaultScope = %q", scope, p.DefaultScope)
+		}
+	}
+}
+
 func TestProfileSet_InvalidScope(t *testing.T) {
 	s := testutil.NewSandbox(t)
 
@@ -166,12 +188,12 @@ func TestProfilePath_PrintsResolvedPath(t *testing.T) {
 
 func TestParseCSV(t *testing.T) {
 	cases := map[string][]string{
-		"":                nil,
-		"   ":             nil,
-		"a":               {"a"},
-		"a,b":             {"a", "b"},
-		"a,  b ,c":        {"a", "b", "c"},
-		", a ,,b ,":       {"a", "b"},
+		"":          nil,
+		"   ":       nil,
+		"a":         {"a"},
+		"a,b":       {"a", "b"},
+		"a,  b ,c":  {"a", "b", "c"},
+		", a ,,b ,": {"a", "b"},
 	}
 	for in, want := range cases {
 		got := parseCSV(in)
@@ -197,10 +219,19 @@ func TestFormatPlatforms(t *testing.T) {
 }
 
 func TestFormatScope(t *testing.T) {
-	if got := formatScope(""); got != "(adapter default)" {
+	if got := formatScope(""); got != "global humblskills (default)" {
+		t.Errorf("got %q", got)
+	}
+	if got := formatScope(profile.ScopeGlobal); got != "global humblskills" {
 		t.Errorf("got %q", got)
 	}
 	if got := formatScope("user"); got != "user" {
+		t.Errorf("got %q", got)
+	}
+	if got := formatScope("project"); got != "project" {
+		t.Errorf("got %q", got)
+	}
+	if got := formatScope(profile.ScopeAdapterDefault); got != "adapter default" {
 		t.Errorf("got %q", got)
 	}
 }

--- a/cli/cmd/humblskills/update.go
+++ b/cli/cmd/humblskills/update.go
@@ -156,10 +156,12 @@ func runUpdate(app *App, only []string, f updateFlags) error {
 		if err := tui.ExecuteWithProgress(app.UI.Theme(), "update", run); err != nil {
 			return err
 		}
-	} else {
-		if err := run(nil); err != nil {
-			return err
-		}
+		// Feedback already lives in the progress model's blocking done/summary
+		// screen — see runInstall for why we don't also print to stdout here.
+		return nil
+	}
+	if err := run(nil); err != nil {
+		return err
 	}
 
 	if app.Config.JSON {

--- a/cli/internal/adapters/defaults.go
+++ b/cli/internal/adapters/defaults.go
@@ -4,15 +4,20 @@ package adapters
 // explicitly chosen any. Used by both the install TUI's pre-check state and
 // the non-interactive `--yes` path so the two stay symmetric.
 //
-// Policy (issue #84): Cursor can read ~/.claude/skills directly when its
-// "Include Third-Party Plugins, Skills and other configs" setting is on,
-// so installing to both by default creates duplicate copies that drift.
-// When both claude-code and cursor are detected, we prefer claude-code
-// and drop cursor from the defaults. Cursor stays a visible opt-in in the
-// TUI and remains explicit via `--platform cursor`.
+// global controls the claude/cursor dedup heuristic below: the "global
+// humblskills" scope's whole point is one canonical store symlinked to
+// every detected platform, so global==true always returns every detected
+// adapter. global==false (explicit user/project scope, or adapter-default)
+// keeps the issue #84 heuristic: Cursor can read ~/.claude/skills directly
+// when its "Include Third-Party Plugins, Skills and other configs" setting
+// is on, so installing to both by default creates a redundant copy. When
+// both claude-code and cursor are detected, we prefer claude-code and drop
+// cursor from the defaults. Cursor stays a visible opt-in and remains
+// explicit via `--platform cursor`.
 //
-// Profile defaults always win — a user who saved a preference gets it back.
-func PreferredDefaults(adapterList []Adapter, detected map[string]bool, profileDefaults []string) []string {
+// Profile defaults always win — a user who saved a preference gets it back,
+// regardless of global.
+func PreferredDefaults(adapterList []Adapter, detected map[string]bool, profileDefaults []string, global bool) []string {
 	if len(profileDefaults) > 0 {
 		known := NameSet(adapterList)
 		out := make([]string, 0, len(profileDefaults))
@@ -31,7 +36,7 @@ func PreferredDefaults(adapterList []Adapter, detected map[string]bool, profileD
 		}
 	}
 
-	if detected["claude-code"] && detected["cursor"] {
+	if !global && detected["claude-code"] && detected["cursor"] {
 		filtered := make([]string, 0, len(out))
 		for _, name := range out {
 			if name != "cursor" {

--- a/cli/internal/adapters/defaults_test.go
+++ b/cli/internal/adapters/defaults_test.go
@@ -14,7 +14,7 @@ func TestPreferredDefaults_BothDetected_ClaudeCodeOnly(t *testing.T) {
 	got := PreferredDefaults(testAdapters, map[string]bool{
 		"claude-code": true,
 		"cursor":      true,
-	}, nil)
+	}, nil, false)
 	want := []string{"claude-code"}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("got %v, want %v", got, want)
@@ -24,7 +24,7 @@ func TestPreferredDefaults_BothDetected_ClaudeCodeOnly(t *testing.T) {
 func TestPreferredDefaults_OnlyClaudeDetected(t *testing.T) {
 	got := PreferredDefaults(testAdapters, map[string]bool{
 		"claude-code": true,
-	}, nil)
+	}, nil, false)
 	want := []string{"claude-code"}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("got %v, want %v", got, want)
@@ -34,7 +34,7 @@ func TestPreferredDefaults_OnlyClaudeDetected(t *testing.T) {
 func TestPreferredDefaults_OnlyCursorDetected(t *testing.T) {
 	got := PreferredDefaults(testAdapters, map[string]bool{
 		"cursor": true,
-	}, nil)
+	}, nil, false)
 	want := []string{"cursor"}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("got %v, want %v", got, want)
@@ -42,7 +42,7 @@ func TestPreferredDefaults_OnlyCursorDetected(t *testing.T) {
 }
 
 func TestPreferredDefaults_NoneDetected(t *testing.T) {
-	got := PreferredDefaults(testAdapters, map[string]bool{}, nil)
+	got := PreferredDefaults(testAdapters, map[string]bool{}, nil, false)
 	if len(got) != 0 {
 		t.Errorf("got %v, want empty", got)
 	}
@@ -52,7 +52,18 @@ func TestPreferredDefaults_ProfileWins(t *testing.T) {
 	got := PreferredDefaults(testAdapters, map[string]bool{
 		"claude-code": true,
 		"cursor":      true,
-	}, []string{"cursor"})
+	}, []string{"cursor"}, false)
+	want := []string{"cursor"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestPreferredDefaults_ProfileWins_EvenWhenGlobal(t *testing.T) {
+	got := PreferredDefaults(testAdapters, map[string]bool{
+		"claude-code": true,
+		"cursor":      true,
+	}, []string{"cursor"}, true)
 	want := []string{"cursor"}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("got %v, want %v", got, want)
@@ -62,7 +73,7 @@ func TestPreferredDefaults_ProfileWins(t *testing.T) {
 func TestPreferredDefaults_ProfileDropsUnknown(t *testing.T) {
 	got := PreferredDefaults(testAdapters, map[string]bool{
 		"claude-code": true,
-	}, []string{"cursor", "ghost"})
+	}, []string{"cursor", "ghost"}, false)
 	want := []string{"cursor"}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("got %v, want %v", got, want)
@@ -81,9 +92,29 @@ func TestPreferredDefaults_CascadeOnlyDropsCursor(t *testing.T) {
 		"claude-code": true,
 		"cursor":      true,
 		"other":       true,
-	}, nil)
+	}, nil, false)
 	want := []string{"claude-code", "other"}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestPreferredDefaults_Global_KeepsBothClaudeAndCursor(t *testing.T) {
+	// Global humblskills scope always symlinks every detected platform — no
+	// claude/cursor dedup heuristic applies.
+	got := PreferredDefaults(testAdapters, map[string]bool{
+		"claude-code": true,
+		"cursor":      true,
+	}, nil, true)
+	want := []string{"claude-code", "cursor"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestPreferredDefaults_Global_NoneDetected(t *testing.T) {
+	got := PreferredDefaults(testAdapters, map[string]bool{}, nil, true)
+	if len(got) != 0 {
+		t.Errorf("got %v, want empty", got)
 	}
 }

--- a/cli/internal/install/engine.go
+++ b/cli/internal/install/engine.go
@@ -30,11 +30,16 @@ const (
 
 // TargetResult is the outcome of installing one skill onto one adapter+scope.
 type TargetResult struct {
-	Skill    string  `json:"skill"`
-	Platform string  `json:"platform"`
-	Scope    string  `json:"scope"`
-	Path     string  `json:"path"`
-	Outcome  Outcome `json:"outcome"`
+	Skill    string `json:"skill"`
+	Version  string `json:"version"`
+	Platform string `json:"platform"`
+	Scope    string `json:"scope"`
+	Path     string `json:"path"`
+	// StorePath is the canonical humblskills-owned directory Path symlinks
+	// to — the source-of-truth install location, shared across every
+	// platform/scope this run touched for this skill.
+	StorePath string  `json:"store_path,omitempty"`
+	Outcome   Outcome `json:"outcome"`
 }
 
 // Result aggregates every target outcome produced by one install run.
@@ -295,12 +300,13 @@ func (e *Engine) installOne(
 				Platform: pg.adapter.Name, Scope: pg.target.Scope,
 			})
 			skipped = append(skipped, TargetResult{
-				Skill: skill.Name, Platform: pg.adapter.Name, Scope: pg.target.Scope,
-				Path: pg.final, Outcome: OutcomeSkipped,
+				Skill: skill.Name, Version: skill.Version, Platform: pg.adapter.Name, Scope: pg.target.Scope,
+				Path: pg.final, StorePath: storePath, Outcome: OutcomeSkipped,
 			})
 			opts.OnEvent.emit(Event{
 				Phase: PhaseTargetDone, Skill: skill.Name, IsDep: step.IsDep,
 				Platform: pg.adapter.Name, Scope: pg.target.Scope, Outcome: OutcomeSkipped,
+				Path: pg.final, Version: skill.Version, StorePath: storePath,
 			})
 		case upToDate && opts.Force:
 			toWrite = append(toWrite, installPlanTarget{pending: pg, out: OutcomeForced, orphan: orphan, existingPath: existingPath})
@@ -397,16 +403,18 @@ func (e *Engine) installOne(
 			RegistryRef: skill.DirSHA,
 		})
 		results = append(results, TargetResult{
-			Skill:    skill.Name,
-			Platform: pt.pending.adapter.Name,
-			Scope:    pt.pending.target.Scope,
-			Path:     pt.pending.final,
-			Outcome:  pt.out,
+			Skill:     skill.Name,
+			Version:   skill.Version,
+			Platform:  pt.pending.adapter.Name,
+			Scope:     pt.pending.target.Scope,
+			Path:      pt.pending.final,
+			StorePath: storePath,
+			Outcome:   pt.out,
 		})
 		opts.OnEvent.emit(Event{
 			Phase: PhaseTargetDone, Skill: skill.Name, IsDep: step.IsDep,
 			Platform: pt.pending.adapter.Name, Scope: pt.pending.target.Scope,
-			Outcome: pt.out,
+			Outcome: pt.out, Path: pt.pending.final, Version: skill.Version, StorePath: storePath,
 		})
 	}
 	return results, nil

--- a/cli/internal/install/events.go
+++ b/cli/internal/install/events.go
@@ -29,7 +29,8 @@ const (
 
 // Event is a single progress notification emitted by the engine. Not every
 // field is populated for every Phase — Total is only meaningful on RunStart,
-// Outcome only on TargetDone, Err only on Error, Msg only on Warn.
+// Outcome/Path/Version/StorePath only on TargetDone, Err only on Error, Msg
+// only on Warn.
 type Event struct {
 	Phase    Phase
 	Skill    string
@@ -40,6 +41,14 @@ type Event struct {
 	Outcome  Outcome
 	Err      error
 	Msg      string
+	// Path is the platform-facing symlink target written for this triple.
+	Path string
+	// Version is the installed skill's version.
+	Version string
+	// StorePath is the canonical humblskills-owned directory this target
+	// symlinks to — the "source of truth" install location, shared across
+	// every platform/scope in the same run.
+	StorePath string
 }
 
 // EventSink receives engine progress events. Callers that don't care about

--- a/cli/internal/profile/profile.go
+++ b/cli/internal/profile/profile.go
@@ -16,6 +16,20 @@ import (
 
 const SchemaVersion = 1
 
+// Scope constants for Profile.DefaultScope. ScopeGlobal is the recommended
+// default: one canonical copy under ~/.humblskills/skills, symlinked to
+// every selected platform. ScopeAdapterDefault opts back into each
+// platform's own documented default scope (today: "user" for every
+// adapter) instead of a concrete scope — it only exists as an explicit,
+// profile-only escape hatch because it can't show a concrete location at
+// install time.
+const (
+	ScopeGlobal         = "global"
+	ScopeUser           = "user"
+	ScopeProject        = "project"
+	ScopeAdapterDefault = "adapter-default"
+)
+
 // Profile is the full on-disk document.
 type Profile struct {
 	SchemaVersion    int          `json:"schema_version"`
@@ -28,7 +42,7 @@ type Profile struct {
 // live here - they go through cli/internal/secrets which supports env +
 // OS keyring + 0600 file fallback.
 type EvalProfile struct {
-	Runner                 string `json:"runner,omitempty"`                   // claudecode|cursor-agent|codex|anthropic-api|openai-api|mock
+	Runner                 string `json:"runner,omitempty"` // claudecode|cursor-agent|codex|anthropic-api|openai-api|mock
 	ExecutorModel          string `json:"executor_model,omitempty"`
 	GraderModel            string `json:"grader_model,omitempty"`
 	RunsPerConfiguration   int    `json:"runs_per_configuration,omitempty"`
@@ -122,7 +136,24 @@ func FilterKnownPlatforms(platforms []string, known map[string]struct{}) (kept, 
 	return kept, dropped
 }
 
-// IsValidScope reports whether s is one of the accepted scope values.
+// IsValidScope reports whether s is one of the accepted scope values. "" is
+// accepted as shorthand for the unset/default state — see ResolvedScope.
 func IsValidScope(s string) bool {
-	return s == "" || s == "user" || s == "project"
+	switch s {
+	case "", ScopeGlobal, ScopeUser, ScopeProject, ScopeAdapterDefault:
+		return true
+	}
+	return false
+}
+
+// ResolvedScope returns the profile's effective default scope, treating an
+// unset DefaultScope ("") as ScopeGlobal — the recommended default of one
+// canonical store symlinked to every selected platform. Callers that need to
+// distinguish "explicitly global" from "unset" should read DefaultScope
+// directly instead.
+func (p *Profile) ResolvedScope() string {
+	if p == nil || p.DefaultScope == "" {
+		return ScopeGlobal
+	}
+	return p.DefaultScope
 }

--- a/cli/internal/profile/profile_test.go
+++ b/cli/internal/profile/profile_test.go
@@ -238,16 +238,37 @@ func TestDelete_ReturnsErrorWhenPathIsDirectory(t *testing.T) {
 
 func TestIsValidScope(t *testing.T) {
 	cases := map[string]bool{
-		"":        true,
-		"user":    true,
-		"project": true,
-		"global":  false,
-		"USER":    false,
-		" user":   false,
+		"":                true,
+		"user":            true,
+		"project":         true,
+		"global":          true,
+		"adapter-default": true,
+		"USER":            false,
+		" user":           false,
 	}
 	for in, want := range cases {
 		if got := profile.IsValidScope(in); got != want {
 			t.Errorf("IsValidScope(%q) = %v, want %v", in, got, want)
+		}
+	}
+}
+
+func TestResolvedScope(t *testing.T) {
+	cases := []struct {
+		name string
+		p    *profile.Profile
+		want string
+	}{
+		{"nil profile defaults to global", nil, profile.ScopeGlobal},
+		{"unset defaults to global", &profile.Profile{}, profile.ScopeGlobal},
+		{"explicit global", &profile.Profile{DefaultScope: profile.ScopeGlobal}, profile.ScopeGlobal},
+		{"explicit user", &profile.Profile{DefaultScope: profile.ScopeUser}, profile.ScopeUser},
+		{"explicit project", &profile.Profile{DefaultScope: profile.ScopeProject}, profile.ScopeProject},
+		{"explicit adapter-default", &profile.Profile{DefaultScope: profile.ScopeAdapterDefault}, profile.ScopeAdapterDefault},
+	}
+	for _, c := range cases {
+		if got := c.p.ResolvedScope(); got != c.want {
+			t.Errorf("%s: ResolvedScope() = %q, want %q", c.name, got, c.want)
 		}
 	}
 }

--- a/cli/internal/tui/install_modal.go
+++ b/cli/internal/tui/install_modal.go
@@ -29,23 +29,36 @@ func RunInstallPlatformModal(
 		p = &profile.Profile{}
 	}
 
+	// Recommended baseline: every detected platform, regardless of which
+	// scope ends up highlighted below — "global humblskills" is the default
+	// scope and its whole point is symlinking every detected platform. A
+	// saved profile platform list always overrides this.
 	selected := map[string]bool{}
-	for _, name := range adapters.PreferredDefaults(adapterList, detected, p.DefaultPlatforms) {
+	for _, name := range adapters.PreferredDefaults(adapterList, detected, p.DefaultPlatforms, true) {
 		selected[name] = true
 	}
 
+	// Only 3 concrete scopes are offered interactively — "adapter default"
+	// can't show a location at install time, so it's a profile-only setting
+	// (see RunProfileEditor). If that's what the profile resolved to, we
+	// still need a concrete starting point here: default to global and
+	// surface a note so the user understands why their profile pick isn't
+	// pre-selected.
 	scopes := []scopeOpt{
-		{label: "Global fanout", value: "global"},
-		{label: "adapter default", value: ""},
+		{label: "global humblskills", value: "global"},
 		{label: "user", value: "user"},
 		{label: "project", value: "project"},
 	}
+	resolvedScope := p.ResolvedScope()
 	scopeIdx := 0
-	for i, s := range scopes {
-		if s.value == p.DefaultScope {
-			scopeIdx = i
-			break
-		}
+	adapterDefaultNote := false
+	switch resolvedScope {
+	case profile.ScopeUser:
+		scopeIdx = 1
+	case profile.ScopeProject:
+		scopeIdx = 2
+	case profile.ScopeAdapterDefault:
+		adapterDefaultNote = true
 	}
 
 	actions := []actionOpt{
@@ -55,18 +68,19 @@ func RunInstallPlatformModal(
 	}
 
 	m := installModalModel{
-		theme:       theme,
-		skill:       skill,
-		adapters:    adapterList,
-		detected:    detected,
-		selected:    selected,
-		scopes:      scopes,
-		scopeIdx:    scopeIdx,
-		actions:     actions,
-		actionIdx:   0,
-		group:       groupPlatforms,
-		cursor:      0,
-		firstSelect: true,
+		theme:              theme,
+		skill:              skill,
+		adapters:           adapterList,
+		detected:           detected,
+		selected:           selected,
+		scopes:             scopes,
+		scopeIdx:           scopeIdx,
+		adapterDefaultNote: adapterDefaultNote,
+		actions:            actions,
+		actionIdx:          0,
+		group:              groupPlatforms,
+		cursor:             0,
+		firstSelect:        true,
 	}
 
 	out, err := Run(m)
@@ -97,11 +111,15 @@ type installModalModel struct {
 	adapters []adapters.Adapter
 	detected map[string]bool
 
-	selected  map[string]bool
-	scopes    []scopeOpt
-	scopeIdx  int
-	actions   []actionOpt
-	actionIdx int
+	selected map[string]bool
+	scopes   []scopeOpt
+	scopeIdx int
+	// adapterDefaultNote is true when the profile's saved default scope is
+	// "adapter default" — there's no concrete option for that here, so the
+	// scope group shows a note explaining why nothing started pre-selected.
+	adapterDefaultNote bool
+	actions            []actionOpt
+	actionIdx          int
 
 	group  modalGroup
 	cursor int
@@ -325,6 +343,10 @@ func (m installModalModel) renderLeftStacked(width int) string {
 	sb.WriteString(m.renderGroup(groupPlatforms, "PLATFORMS", m.platformRows(), width))
 	sb.WriteString("\n")
 	sb.WriteString(m.renderGroup(groupScope, "SCOPE", m.scopeRows(), width))
+	if m.adapterDefaultNote {
+		sb.WriteString("  " + th.Detail.Render(
+			"profile default is \"adapter default\" — pick a concrete scope for this install") + "\n")
+	}
 	sb.WriteString("\n")
 	sb.WriteString(m.renderGroup(groupAction, "ACTION", m.actionRows(), width))
 
@@ -370,19 +392,21 @@ func (m installModalModel) infoContent(width int) (heading, body string) {
 
 	switch {
 	case isGlobal:
-		heading = th.DetailTitle.Render("Global fanout")
+		heading = th.DetailTitle.Render("global humblskills")
 		body = wrap.Render(
 			"Installs one canonical copy in ~/.humblskills/skills and symlinks it " +
-				"to every selected detected platform target. Use this when all agents " +
-				"should share the same skill files.",
+				"to every selected platform target. Recommended default — every " +
+				"agent shares the same skill files.",
 		)
 	case hasClaude && hasCursor:
-		heading = th.Warn.Render("! Duplicate install")
+		heading = th.DetailTitle.Render("Note: redundant copy")
 		body = wrap.Render(
-			"Installing to both creates two copies of each skill that can drift. " +
-				"Cursor can read ~/.claude/skills directly — enable \"Include " +
-				"Third-Party Plugins, Skills and other configs\" in Cursor → Rules, " +
-				"Skills and Plugins, then deselect cursor here.",
+			"Both selected. If Cursor's \"Include Third-Party Plugins, Skills " +
+				"and other configs\" setting is on, it already reads " +
+				"~/.claude/skills directly, so this symlink is redundant today — " +
+				"but it keeps the skill available in Cursor if Claude Code is " +
+				"ever removed. Safe to keep both; deselect cursor if you'd " +
+				"rather avoid the duplicate listing.",
 		)
 	case hasClaude:
 		heading = th.DetailTitle.Render("Tip")

--- a/cli/internal/tui/install_modal_test.go
+++ b/cli/internal/tui/install_modal_test.go
@@ -27,12 +27,11 @@ func newTestModal(selected, detected map[string]bool) installModalModel {
 		detected: detected,
 		selected: selected,
 		scopes: []scopeOpt{
-			{label: "Global fanout", value: "global"},
-			{label: "adapter default", value: ""},
+			{label: "global humblskills", value: "global"},
 			{label: "user", value: "user"},
 			{label: "project", value: "project"},
 		},
-		scopeIdx: 1,
+		scopeIdx: 0,
 		actions: []actionOpt{
 			{label: "install", value: "install"},
 			{label: "cancel", value: "cancel"},
@@ -154,17 +153,21 @@ func TestInstallModal_Hints_ScopeGroup(t *testing.T) {
 	}
 }
 
-func TestInstallModal_InfoPane_BothSelected_Warning(t *testing.T) {
+func TestInstallModal_InfoPane_BothSelected_RedundantCopyNote(t *testing.T) {
 	m := newTestModal(
 		map[string]bool{"claude-code": true, "cursor": true},
 		map[string]bool{"claude-code": true, "cursor": true},
 	)
+	m.scopeIdx = 1 // non-global, so the claude/cursor-specific copy applies
 	heading, body := m.infoContent(40)
-	if !strings.Contains(heading, "Duplicate") {
-		t.Errorf("heading should warn about duplicates; got %q", heading)
+	if !strings.Contains(heading, "redundant") {
+		t.Errorf("heading should note the redundant copy; got %q", heading)
 	}
-	if !strings.Contains(body, "drift") {
-		t.Errorf("body should mention drift; got %q", body)
+	if !strings.Contains(body, "removed") {
+		t.Errorf("body should mention resilience if Claude Code is removed; got %q", body)
+	}
+	if strings.Contains(heading, "Duplicate") || strings.Contains(body, "drift") {
+		t.Errorf("copy should no longer discourage installing to both; got heading=%q body=%q", heading, body)
 	}
 }
 
@@ -173,6 +176,7 @@ func TestInstallModal_InfoPane_ClaudeOnly_Tip(t *testing.T) {
 		map[string]bool{"claude-code": true},
 		map[string]bool{"claude-code": true, "cursor": true},
 	)
+	m.scopeIdx = 1 // non-global
 	heading, body := m.infoContent(40)
 	if !strings.Contains(heading, "Tip") {
 		t.Errorf("heading should be a tip; got %q", heading)
@@ -187,6 +191,7 @@ func TestInstallModal_InfoPane_CursorOnly_Note(t *testing.T) {
 		map[string]bool{"cursor": true},
 		map[string]bool{"claude-code": true, "cursor": true},
 	)
+	m.scopeIdx = 1 // non-global
 	heading, body := m.infoContent(40)
 	if !strings.Contains(heading, "Note") {
 		t.Errorf("heading should be a note; got %q", heading)
@@ -201,6 +206,7 @@ func TestInstallModal_InfoPane_CursorOnly_ClaudeNotDetected(t *testing.T) {
 		map[string]bool{"cursor": true},
 		map[string]bool{"cursor": true},
 	)
+	m.scopeIdx = 1 // non-global
 	_, body := m.infoContent(40)
 	if !strings.Contains(body, "not detected") {
 		t.Errorf("body should note claude-code not detected; got %q", body)
@@ -209,6 +215,7 @@ func TestInstallModal_InfoPane_CursorOnly_ClaudeNotDetected(t *testing.T) {
 
 func TestInstallModal_InfoPane_NoneSelected_EmptyState(t *testing.T) {
 	m := newTestModal(nil, map[string]bool{"claude-code": true})
+	m.scopeIdx = 1 // non-global
 	heading, body := m.infoContent(40)
 	if heading != "" {
 		t.Errorf("empty state should have no heading; got %q", heading)
@@ -225,8 +232,8 @@ func TestInstallModal_InfoPane_GlobalFanout(t *testing.T) {
 	)
 	m.scopeIdx = 0
 	heading, body := m.infoContent(60)
-	if !strings.Contains(heading, "Global fanout") {
-		t.Errorf("heading should describe global fanout; got %q", heading)
+	if !strings.Contains(heading, "global humblskills") {
+		t.Errorf("heading should describe global humblskills; got %q", heading)
 	}
 	if !strings.Contains(body, ".humblskills") {
 		t.Errorf("body should mention canonical .humblskills store; got %q", body)
@@ -254,6 +261,24 @@ func TestInstallModal_WideTerminal_HasDivider(t *testing.T) {
 	body := m.renderBody()
 	if !strings.Contains(body, "│") {
 		t.Errorf("wide terminal should render divider; got:\n%s", body)
+	}
+}
+
+func TestInstallModal_AdapterDefaultNote_RendersInScopeGroup(t *testing.T) {
+	m := newTestModal(nil, nil)
+	m.adapterDefaultNote = true
+	body := m.renderLeftStacked(80)
+	if !strings.Contains(body, "adapter default") {
+		t.Errorf("expected adapter-default note in scope group; got:\n%s", body)
+	}
+}
+
+func TestInstallModal_NoAdapterDefaultNote_WhenNotSet(t *testing.T) {
+	m := newTestModal(nil, nil)
+	m.adapterDefaultNote = false
+	body := m.renderLeftStacked(80)
+	if strings.Contains(body, "pick a concrete scope") {
+		t.Errorf("should not render adapter-default note when unset; got:\n%s", body)
 	}
 }
 

--- a/cli/internal/tui/profile.go
+++ b/cli/internal/tui/profile.go
@@ -193,13 +193,24 @@ func (m profileModel) toggleCurrent() profileModel {
 		}
 		m.changed = true
 	case 1: // scope
-		values := []string{"", "user", "project"}
-		if m.valueIdx >= 0 && m.valueIdx < len(values) {
-			m.profile.DefaultScope = values[m.valueIdx]
+		if m.valueIdx >= 0 && m.valueIdx < len(scopeSettingOpts) {
+			m.profile.DefaultScope = scopeSettingOpts[m.valueIdx].value
 			m.changed = true
 		}
 	}
 	return m
+}
+
+// scopeSettingOpts is the profile's full scope picker — unlike the
+// per-install modal (3 concrete choices only), the profile also offers
+// "adapter default" as an explicit, deliberate opt-in: it can't show a
+// concrete location at install time, so it only belongs here, not in the
+// interactive install flow.
+var scopeSettingOpts = []struct{ label, value string }{
+	{"global humblskills (recommended)", profile.ScopeGlobal},
+	{"user", profile.ScopeUser},
+	{"project", profile.ScopeProject},
+	{"adapter default", profile.ScopeAdapterDefault},
 }
 
 // currentSelectionIndex returns the index in the right-pane options list that
@@ -210,11 +221,11 @@ func (m profileModel) currentSelectionIndex() int {
 	case 0:
 		return 0
 	case 1:
-		switch m.profile.DefaultScope {
-		case "user":
-			return 1
-		case "project":
-			return 2
+		resolved := m.profile.ResolvedScope()
+		for i, opt := range scopeSettingOpts {
+			if opt.value == resolved {
+				return i
+			}
 		}
 	}
 	return 0
@@ -225,7 +236,7 @@ func (m profileModel) valueCount() int {
 	case 0:
 		return len(m.adapters)
 	case 1:
-		return 3
+		return len(scopeSettingOpts)
 	}
 	return 0
 }
@@ -419,19 +430,17 @@ func (m profileModel) renderPlatformOptions(bar string, width int) []string {
 
 func (m profileModel) renderScopeOptions(bar string, width int) []string {
 	th := m.theme
-	opts := []struct{ label, value string }{
-		{"adapter default", ""},
-		{"user", "user"},
-		{"project", "project"},
-	}
-	rows := make([]string, 0, len(opts)+2)
+	resolved := m.profile.ResolvedScope()
+	rows := make([]string, 0, len(scopeSettingOpts)+4)
 	rows = append(rows, bar+" "+th.Detail.Render(
-		"Which scope to install into. Adapter default falls back to each adapter's own default (usually user)."))
+		"Which scope installs default to. Global humblskills installs one canonical "+
+			"copy and symlinks it to every selected platform — recommended for most "+
+			"setups. User/project pin a concrete platform-native location instead."))
 	rows = append(rows, bar)
 	rows = append(rows, bar+" "+th.SectionTitle.Render("OPTIONS"))
-	for i, opt := range opts {
+	for i, opt := range scopeSettingOpts {
 		cursorHere := i == m.valueIdx && m.focus == focusValue
-		isCurrent := m.profile.DefaultScope == opt.value
+		isCurrent := opt.value == resolved
 		marker := "( )"
 		if isCurrent {
 			marker = "(●)"
@@ -450,6 +459,14 @@ func (m profileModel) renderScopeOptions(bar string, width int) []string {
 			prefix = bar + " " + th.Bullet.Render("▸") + " "
 		}
 		rows = append(rows, prefix+styled)
+	}
+	if resolved == profile.ScopeAdapterDefault {
+		rows = append(rows, bar)
+		rows = append(rows, bar+" "+th.Detail.Render(
+			"Note: adapter default can't show a concrete location up front — "+
+				"every platform here happens to default to \"user\" today, but the "+
+				"install screen will still ask you to pick a scope since it can't "+
+				"display one for this setting."))
 	}
 	_ = width
 	return rows
@@ -477,20 +494,25 @@ func (m profileModel) settingBadge(key string) string {
 		return fmt.Sprintf("%d platform%s", len(m.profile.DefaultPlatforms),
 			plural2(len(m.profile.DefaultPlatforms)))
 	case "scope":
-		if m.profile.DefaultScope == "" {
+		switch resolved := m.profile.ResolvedScope(); resolved {
+		case profile.ScopeGlobal:
+			return "global humblskills"
+		case profile.ScopeAdapterDefault:
 			return "adapter default"
+		default:
+			return resolved
 		}
-		return m.profile.DefaultScope
 	}
 	return ""
 }
 
+// settingValueEmpty reports whether a setting has no meaningful value yet.
+// Scope is never "empty" — an unset DefaultScope already resolves to a
+// concrete, deliberate default (global humblskills) via ResolvedScope.
 func (m profileModel) settingValueEmpty(key string) bool {
 	switch key {
 	case "platforms":
 		return len(m.profile.DefaultPlatforms) == 0
-	case "scope":
-		return m.profile.DefaultScope == ""
 	}
 	return false
 }

--- a/cli/internal/tui/profile_test.go
+++ b/cli/internal/tui/profile_test.go
@@ -1,0 +1,113 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jjfantini/humblSKILLS/cli/internal/adapters"
+	"github.com/jjfantini/humblSKILLS/cli/internal/profile"
+	"github.com/jjfantini/humblSKILLS/cli/internal/ui"
+)
+
+func newTestProfileModel(p profile.Profile) profileModel {
+	return profileModel{
+		theme:    ui.DefaultTheme(),
+		adapters: []adapters.Adapter{{Name: "claude-code"}, {Name: "cursor"}},
+		profile:  p,
+		focus:    focusSettings,
+		width:    100,
+		height:   30,
+	}
+}
+
+func TestProfileModel_CurrentSelectionIndex_UnsetResolvesToGlobal(t *testing.T) {
+	m := newTestProfileModel(profile.Profile{})
+	m.settingIdx = 1
+	if got := m.currentSelectionIndex(); got != 0 {
+		t.Errorf("unset scope should select index 0 (global), got %d", got)
+	}
+}
+
+func TestProfileModel_CurrentSelectionIndex_ExplicitValues(t *testing.T) {
+	cases := []struct {
+		scope string
+		want  int
+	}{
+		{profile.ScopeGlobal, 0},
+		{profile.ScopeUser, 1},
+		{profile.ScopeProject, 2},
+		{profile.ScopeAdapterDefault, 3},
+	}
+	for _, c := range cases {
+		m := newTestProfileModel(profile.Profile{DefaultScope: c.scope})
+		m.settingIdx = 1
+		if got := m.currentSelectionIndex(); got != c.want {
+			t.Errorf("scope=%q: currentSelectionIndex() = %d, want %d", c.scope, got, c.want)
+		}
+	}
+}
+
+func TestProfileModel_ToggleCurrent_Scope_SetsExplicitValue(t *testing.T) {
+	m := newTestProfileModel(profile.Profile{})
+	m.settingIdx = 1
+	m.valueIdx = 2 // project
+	m = m.toggleCurrent()
+	if m.profile.DefaultScope != profile.ScopeProject {
+		t.Errorf("DefaultScope = %q, want %q", m.profile.DefaultScope, profile.ScopeProject)
+	}
+	if !m.changed {
+		t.Error("expected changed=true")
+	}
+}
+
+func TestProfileModel_ValueCount_ScopeHasFourOptions(t *testing.T) {
+	m := newTestProfileModel(profile.Profile{})
+	m.settingIdx = 1
+	if got := m.valueCount(); got != 4 {
+		t.Errorf("valueCount() = %d, want 4 (global/user/project/adapter-default)", got)
+	}
+}
+
+func TestProfileModel_SettingBadge_Scope(t *testing.T) {
+	cases := []struct {
+		scope string
+		want  string
+	}{
+		{"", "global humblskills"},
+		{profile.ScopeGlobal, "global humblskills"},
+		{profile.ScopeUser, "user"},
+		{profile.ScopeProject, "project"},
+		{profile.ScopeAdapterDefault, "adapter default"},
+	}
+	for _, c := range cases {
+		m := newTestProfileModel(profile.Profile{DefaultScope: c.scope})
+		if got := m.settingBadge("scope"); got != c.want {
+			t.Errorf("scope=%q: settingBadge = %q, want %q", c.scope, got, c.want)
+		}
+	}
+}
+
+func TestProfileModel_SettingValueEmpty_ScopeNeverEmpty(t *testing.T) {
+	m := newTestProfileModel(profile.Profile{})
+	if m.settingValueEmpty("scope") {
+		t.Error("scope should never report as empty — unset resolves to a concrete global default")
+	}
+}
+
+func TestProfileModel_RenderScopeOptions_AdapterDefaultShowsNote(t *testing.T) {
+	m := newTestProfileModel(profile.Profile{DefaultScope: profile.ScopeAdapterDefault})
+	rows := m.renderScopeOptions("│", 60)
+	joined := strings.Join(rows, "\n")
+	if !strings.Contains(joined, "can't show a concrete location") {
+		t.Errorf("expected adapter-default note in rows:\n%s", joined)
+	}
+}
+
+func TestProfileModel_RenderScopeOptions_GlobalHasNoNote(t *testing.T) {
+	m := newTestProfileModel(profile.Profile{DefaultScope: profile.ScopeGlobal})
+	rows := m.renderScopeOptions("│", 60)
+	joined := strings.Join(rows, "\n")
+	if strings.Contains(joined, "can't show a concrete location") {
+		t.Errorf("global scope should not show the adapter-default note:\n%s", joined)
+	}
+}

--- a/cli/internal/tui/progress.go
+++ b/cli/internal/tui/progress.go
@@ -70,6 +70,13 @@ type progressEntry struct {
 	outcome  install.Outcome
 	done     bool
 	errored  bool
+	// path is the platform-facing symlink target. version and storePath
+	// (the canonical "source of truth" location) are filled in on
+	// PhaseTargetDone — see applyEvent — and feed the grouped summary
+	// rendered once the run finishes successfully.
+	path      string
+	version   string
+	storePath string
 }
 
 func (p *progressEntry) key() string {
@@ -132,9 +139,16 @@ func (m ProgressModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, tea.Batch(cmds...)
 
 	case ProgressDoneMsg:
+		// Root cause of the "results flash by and vanish" bug: this used to
+		// return tea.Quit unconditionally, so the screen tore itself down
+		// the instant the engine finished — before the user could read
+		// anything, success or failure. Now it just flips to the done
+		// state (running=false) and stays on screen; the tea.KeyMsg case
+		// below is what actually dismisses it, matching the "enter/q to
+		// close" footer hint that was previously dead code.
 		m.err = msg.Err
 		m.running = false
-		return m, tea.Quit
+		return m, nil
 
 	case spinner.TickMsg:
 		var cmd tea.Cmd
@@ -173,14 +187,18 @@ func (m ProgressModel) View() string {
 	}
 	sb.WriteString("  " + m.bar.View() + "\n\n")
 
-	for _, it := range m.items {
-		active := m.running && m.current == it && !it.done && !it.errored
-		line := m.renderEntry(it, active)
-		prefix := "  "
-		if active {
-			prefix = th.Bullet.Render("▌") + " "
+	if !m.running && m.err == nil {
+		sb.WriteString(m.renderSummary())
+	} else {
+		for _, it := range m.items {
+			active := m.running && m.current == it && !it.done && !it.errored
+			line := m.renderEntry(it, active)
+			prefix := "  "
+			if active {
+				prefix = th.Bullet.Render("▌") + " "
+			}
+			sb.WriteString(prefix + line + "\n")
 		}
-		sb.WriteString(prefix + line + "\n")
 	}
 
 	if m.err != nil {
@@ -207,6 +225,9 @@ func (m *ProgressModel) applyEvent(ev install.Event) {
 		it := m.upsert(ev)
 		it.done = true
 		it.outcome = ev.Outcome
+		it.path = ev.Path
+		it.version = ev.Version
+		it.storePath = ev.StorePath
 		m.done++
 	case install.PhaseError:
 		if ev.Skill != "" {
@@ -259,6 +280,80 @@ func (m ProgressModel) renderEntry(it *progressEntry, active bool) string {
 	return fmt.Sprintf("%s %s %s %s", icon, name, where, label)
 }
 
+// skillSummaryGroup is every target this run touched for one skill, plus the
+// version and canonical store path shared across them.
+type skillSummaryGroup struct {
+	skill     string
+	version   string
+	storePath string
+	entries   []*progressEntry
+}
+
+// groupedBySkill buckets m.items by skill name, preserving first-seen order
+// (the engine emits every target for one skill consecutively, so this is
+// already a stable grouping, not just a sort).
+func (m ProgressModel) groupedBySkill() []skillSummaryGroup {
+	var groups []skillSummaryGroup
+	idx := map[string]int{}
+	for _, it := range m.items {
+		i, ok := idx[it.skill]
+		if !ok {
+			i = len(groups)
+			idx[it.skill] = i
+			groups = append(groups, skillSummaryGroup{skill: it.skill})
+		}
+		g := &groups[i]
+		if g.version == "" {
+			g.version = it.version
+		}
+		if g.storePath == "" {
+			g.storePath = it.storePath
+		}
+		g.entries = append(g.entries, it)
+	}
+	return groups
+}
+
+// renderSummary is the "what just happened" status screen shown once the run
+// finishes successfully: one block per skill with its version, the
+// canonical source-of-truth store location, and every platform symlink the
+// run touched — the detail that used to only exist as stdout lines the
+// dashboard loop immediately hid by re-entering the alt-screen.
+func (m ProgressModel) renderSummary() string {
+	th := m.theme
+	groups := m.groupedBySkill()
+	if len(groups) == 0 {
+		return "  " + th.Detail.Render("nothing to do — every target was already up-to-date") + "\n"
+	}
+	var sb strings.Builder
+	for i, g := range groups {
+		if i > 0 {
+			sb.WriteString("\n")
+		}
+		name := th.DetailTitle.Render(g.skill)
+		ver := ""
+		if g.version != "" {
+			ver = "  " + th.DetailSub.Render("v"+g.version)
+		}
+		sb.WriteString("  " + name + ver + "\n")
+		if g.storePath != "" {
+			sb.WriteString("    " + th.KVKey.Render("installed to") + "  " + th.KVValue.Render(g.storePath) + "\n")
+		}
+		sb.WriteString("    " + th.SectionTitle.Render("SYMLINKED PLATFORMS") + "\n")
+		for _, it := range g.entries {
+			icon := th.DotOK.Render("●")
+			label := th.Detail.Render(string(it.outcome))
+			if it.errored {
+				icon = th.DotNo.Render("●")
+				label = th.Error.Render("error")
+			}
+			where := th.Platform.Render(it.platform + "/" + it.scope)
+			sb.WriteString(fmt.Sprintf("      %s %s  %s  %s\n", icon, where, th.PathValue.Render(it.path), label))
+		}
+	}
+	return sb.String()
+}
+
 // ExecuteWithProgress runs fn in a goroutine while a ProgressModel UI shows
 // live engine progress. fn is expected to call engine.Execute (or equivalent)
 // with an EventSink that forwards onto events. fn's error becomes
@@ -285,4 +380,3 @@ func ExecuteWithProgress(theme *ui.Theme, command string, fn func(sink install.E
 	}
 	return nil
 }
-

--- a/cli/internal/tui/progress_test.go
+++ b/cli/internal/tui/progress_test.go
@@ -34,17 +34,89 @@ func TestProgressModel_ApplyEventLifecycle(t *testing.T) {
 	if m.current == nil || m.current.skill != "foo" {
 		t.Errorf("current = %+v", m.current)
 	}
-	// TargetDone → done incremented, outcome recorded.
+	// TargetDone → done incremented, outcome + path/version/store recorded.
 	m.applyEvent(install.Event{
-		Phase:    install.PhaseTargetDone,
-		Skill:    "foo", Platform: "claude-code", Scope: "user",
-		Outcome:  install.OutcomeInstalled,
+		Phase: install.PhaseTargetDone,
+		Skill: "foo", Platform: "claude-code", Scope: "user",
+		Outcome:   install.OutcomeInstalled,
+		Path:      "/home/u/.claude/skills/foo",
+		Version:   "1.2.3",
+		StorePath: "/home/u/.humblskills/skills/foo",
 	})
 	if m.done != 1 {
 		t.Errorf("done = %d", m.done)
 	}
 	if m.items[0].outcome != install.OutcomeInstalled {
 		t.Errorf("outcome not recorded: %+v", m.items[0])
+	}
+	if m.items[0].path != "/home/u/.claude/skills/foo" {
+		t.Errorf("path not recorded: %+v", m.items[0])
+	}
+	if m.items[0].version != "1.2.3" {
+		t.Errorf("version not recorded: %+v", m.items[0])
+	}
+	if m.items[0].storePath != "/home/u/.humblskills/skills/foo" {
+		t.Errorf("storePath not recorded: %+v", m.items[0])
+	}
+}
+
+func TestProgressModel_RenderSummary_GroupsBySkillAndShowsStorePath(t *testing.T) {
+	m := newTestProgress(t)
+	m.width = 100
+	m.running = false
+	m.err = nil
+	m.applyEvent(install.Event{Phase: install.PhaseRunStart, Total: 3})
+	m.applyEvent(install.Event{
+		Phase: install.PhaseTargetDone, Skill: "foo", Platform: "claude-code", Scope: "user",
+		Outcome: install.OutcomeInstalled, Path: "/home/u/.claude/skills/foo",
+		Version: "1.0.0", StorePath: "/home/u/.humblskills/skills/foo",
+	})
+	m.applyEvent(install.Event{
+		Phase: install.PhaseTargetDone, Skill: "foo", Platform: "cursor", Scope: "user",
+		Outcome: install.OutcomeInstalled, Path: "/home/u/.cursor/skills/foo",
+		Version: "1.0.0", StorePath: "/home/u/.humblskills/skills/foo",
+	})
+	m.applyEvent(install.Event{
+		Phase: install.PhaseTargetDone, Skill: "bar", Platform: "codex", Scope: "user",
+		Outcome: install.OutcomeSkipped, Path: "/home/u/.agents/skills/bar",
+		Version: "2.0.0", StorePath: "/home/u/.humblskills/skills/bar",
+	})
+
+	groups := m.groupedBySkill()
+	if len(groups) != 2 {
+		t.Fatalf("groups = %d, want 2: %+v", len(groups), groups)
+	}
+	if groups[0].skill != "foo" || len(groups[0].entries) != 2 {
+		t.Errorf("foo group malformed: %+v", groups[0])
+	}
+	if groups[0].version != "1.0.0" || groups[0].storePath != "/home/u/.humblskills/skills/foo" {
+		t.Errorf("foo group metadata wrong: %+v", groups[0])
+	}
+	if groups[1].skill != "bar" || len(groups[1].entries) != 1 {
+		t.Errorf("bar group malformed: %+v", groups[1])
+	}
+
+	view := m.View()
+	for _, want := range []string{
+		"foo", "v1.0.0", "/home/u/.humblskills/skills/foo",
+		"claude-code/user", "/home/u/.claude/skills/foo",
+		"cursor/user", "/home/u/.cursor/skills/foo",
+		"bar", "v2.0.0", "/home/u/.humblskills/skills/bar",
+	} {
+		if !strings.Contains(view, want) {
+			t.Errorf("summary view missing %q:\n%s", want, view)
+		}
+	}
+}
+
+func TestProgressModel_RenderSummary_EmptyWhenNothingInstalled(t *testing.T) {
+	m := newTestProgress(t)
+	m.width = 80
+	m.running = false
+	m.err = nil
+	view := m.View()
+	if !strings.Contains(view, "nothing to do") {
+		t.Errorf("expected empty-summary message, got:\n%s", view)
 	}
 }
 
@@ -67,7 +139,7 @@ func TestProgressModel_ErrorPhaseCapturesErr(t *testing.T) {
 	m.applyEvent(install.Event{
 		Phase: install.PhaseError,
 		Skill: "foo", Platform: "x", Scope: "user",
-		Err:   boom,
+		Err: boom,
 	})
 	if m.items[0].errored != true {
 		t.Error("expected errored=true")
@@ -146,6 +218,40 @@ func TestSubscribe_ReadsEventThenDone(t *testing.T) {
 	}
 	if done.Err == nil || done.Err.Error() != "final" {
 		t.Errorf("err = %v", done.Err)
+	}
+}
+
+func TestProgressModel_DoneMsg_DoesNotAutoQuit(t *testing.T) {
+	// Regression: ProgressDoneMsg used to return tea.Quit unconditionally,
+	// tearing the screen down the instant the engine finished — before the
+	// user could read the result. It must now stay on screen until an
+	// explicit keypress (see TestProgressModel_KeyMsgAfterDoneQuits).
+	m := newTestProgress(t)
+	m.running = true
+	out, cmd := m.Update(ProgressDoneMsg{Err: nil})
+	updated, ok := out.(ProgressModel)
+	if !ok {
+		t.Fatalf("Update returned %T, want ProgressModel", out)
+	}
+	if updated.running {
+		t.Error("running should flip to false on ProgressDoneMsg")
+	}
+	if cmd != nil {
+		t.Error("ProgressDoneMsg must not auto-quit — the screen should wait for a keypress")
+	}
+}
+
+func TestProgressModel_DoneMsg_WithError_DoesNotAutoQuit(t *testing.T) {
+	m := newTestProgress(t)
+	m.running = true
+	boom := errors.New("boom")
+	out, cmd := m.Update(ProgressDoneMsg{Err: boom})
+	updated := out.(ProgressModel)
+	if updated.err == nil || updated.err.Error() != "boom" {
+		t.Errorf("err = %v", updated.err)
+	}
+	if cmd != nil {
+		t.Error("ProgressDoneMsg must not auto-quit even on error")
 	}
 }
 

--- a/registry.json
+++ b/registry.json
@@ -1,10 +1,10 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-06-30T23:34:35Z",
+  "generated_at": "2026-07-01T00:08:40Z",
   "source": {
     "repo": "github.com/jjfantini/humblSKILLS",
-    "ref": "develop",
-    "sha": "5ec020b5adb4ed2f20dcd967e057d6f4a37c43b1"
+    "ref": "cursor/improve-install-list-ux-2f10",
+    "sha": "a22b6629f450827ba7c5499e38291b15fb64b4a3"
   },
   "skills": [
     {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Fix the real bug behind "install results flash by and vanish": `ProgressDoneMsg` unconditionally returned `tea.Quit`, tearing the alt-screen down the instant the engine finished — before the "enter/q to close" footer hint could ever apply. The progress screen now stays up and its done-state renders a grouped-by-skill summary (version, canonical store location, every symlinked platform) until dismissed.
- `install` now defaults to **global humblskills** scope (one canonical `~/.humblskills` copy symlinked to every detected platform) instead of the old adapter-default/single-platform behavior — for both the interactive modal and the scripted (`--yes`) path, which previously ignored the profile entirely.
- `--global` and `--platform` are no longer mutually exclusive — scope and platform selection are orthogonal ("pick scope, then pick platforms to symlink to"). `--scope` also accepts `global`/`adapter-default` as explicit values.
- Install modal trims scope to 3 concrete choices (global/user/project); "adapter default" moves to a profile-only setting since it can't show a concrete location up front.
- `list` (TUI detail + plain table) now shows the canonical store (source of truth) plus *every* platform a skill is symlinked to, instead of only the first manifest entry found.
- Profile editor exposes all 4 scope values, with global marked recommended/default and a note when adapter-default is picked.

## Testing

- ✅ `go -C cli vet ./...`
- ✅ `go -C cli test -race -count=1 ./...`
- ✅ `make registry-check`
- Manual terminal-driven walkthrough via tmux (sandboxed `$HOME`, 3 simulated platforms, real in-repo registry): installed a skill through the dashboard and confirmed the summary screen now stays up showing skill/version/canonical store/symlinked platforms ([install_summary_screen.txt](https://cursor.com/artifacts/c/art-12d8d912-2b57-4fa4-b959-7628bc1b5b02)), then confirmed `list`'s detail pane shows the same source-of-truth info ([list_detail_source_of_truth.txt](https://cursor.com/artifacts/c/art-a38dfae2-c1d1-460a-a14e-8c51032334ce)), then confirmed the profile editor's new scope options and adapter-default note ([profile_scope_options.txt](https://cursor.com/artifacts/c/art-0b12ef2e-96a2-468f-9a3a-80047e72221f)).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-13f6bd37-f2d6-44ba-8e8d-899054bc2f10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-13f6bd37-f2d6-44ba-8e8d-899054bc2f10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

