### PR TITLE
docs(agents): require Conventional Commits for release-please

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,3 +39,28 @@ so **no backend/database/network services are required** to build, test, or run 
 - Needs Python venv tooling (`python3.12-venv`). Build with the venv at `~/.venvs/humblskills-docs`:
   `~/.venvs/humblskills-docs/bin/mkdocs build --strict` (config: `mkdocs.yml`). `mkdocs serve` for preview.
   Note `mkdocs build` drops a `docs/__pycache__/` (not gitignored) — remove it after building.
+
+### Commit messages MUST be Conventional Commits (non-negotiable)
+`release-please-config.json` sets `release-type: "go"`, which cuts releases **only** from commits that
+follow [Conventional Commits](https://www.conventionalcommits.org) syntax on `main`. A commit that doesn't
+match is silently invisible to release-please — no changelog entry, no version bump, no release, and
+`humblskills upgrade` never sees the change. This already happened once (commits like `profile:`,
+`adapters:`, `install:`, `tui:` merged to `main` with zero release effect) and had to be fixed forward with
+an extra empty `feat:` commit — don't repeat it.
+
+Every commit message, on every branch that will reach `main` (not just the PR title), must be:
+
+```
+<type>[(optional-scope)]: <description>
+```
+
+- `feat` → minor bump. `fix` / `perf` → patch bump. Add `!` after the type/scope (`feat!:`) or a
+  `BREAKING CHANGE:` footer for a major bump.
+- `chore`, `docs`, `refactor`, `test`, `build`, `ci`, `style`, `revert` are valid types but do **not**
+  trigger a release on their own — use them for exactly what they mean, don't reach for `feat`/`fix` just to
+  force a release.
+- The scope is the affected area, in parentheses, e.g. `feat(install):`, `fix(tui):`, `chore(registry):`.
+  Never use the area name as the type itself (`install: ...`, `tui: ...` are invalid — that's the mistake
+  that caused the missed release).
+- If a PR/branch has no `feat`/`fix`/`perf` commit but ships a user-visible change, add one (or make the
+  final merge commit one) — don't rely on non-conventional prose to describe user-facing work.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Codifies a hard rule in `AGENTS.md`: every commit reaching `main` must follow Conventional Commits syntax (`type(scope): description`), never using the affected area as the type itself (`install:`, `tui:`, `profile:`, etc.).

This is a direct fix-forward from this session: several commits used non-conventional types, `release-please` silently ignored them, and no release was cut until an extra `feat:` commit was added to trigger one. This should prevent recurrence.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-13f6bd37-f2d6-44ba-8e8d-899054bc2f10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-13f6bd37-f2d6-44ba-8e8d-899054bc2f10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

