### PR TITLE
fix(upgrade): run brew update before brew upgrade humblskills

### DIFF
--- a/cli/cmd/humblskills/upgrade.go
+++ b/cli/cmd/humblskills/upgrade.go
@@ -30,12 +30,14 @@ var (
 	brewRunner   selfupdate.Runner
 )
 
-// applyPhaseSteps maps internal/selfupdate's download/verify/install
+// applyPhaseSteps maps internal/selfupdate's download/verify/install/brew
 // phases onto the upgrade command's own themed step list.
 var applyPhaseSteps = map[selfupdate.Phase]tui.UpgradeStep{
-	selfupdate.PhaseDownloading:  tui.UpgradeStepDownloading,
-	selfupdate.PhaseVerifyingSum: tui.UpgradeStepVerifyingChecksum,
-	selfupdate.PhaseInstalling:   tui.UpgradeStepInstalling,
+	selfupdate.PhaseDownloading:   tui.UpgradeStepDownloading,
+	selfupdate.PhaseVerifyingSum:  tui.UpgradeStepVerifyingChecksum,
+	selfupdate.PhaseInstalling:    tui.UpgradeStepInstalling,
+	selfupdate.PhaseBrewUpdating:  tui.UpgradeStepBrewUpdating,
+	selfupdate.PhaseBrewUpgrading: tui.UpgradeStepBrewUpgrading,
 }
 
 type upgradeFlags struct {
@@ -176,21 +178,24 @@ func applyHomebrewUpgrade(app *App, plan *selfupdate.Plan, exePath string) (stri
 		return "", errUpgradeSkipped
 	}
 
-	steps := []tui.UpgradeStep{tui.UpgradeStepBrewUpgrading, tui.UpgradeStepVerifyingInstall}
+	steps := []tui.UpgradeStep{tui.UpgradeStepBrewUpdating, tui.UpgradeStepBrewUpgrading, tui.UpgradeStepVerifyingInstall}
 	useTUI := tui.ShouldUseTUI(app.Config.JSON, app.Config.Quiet, app.Config.Yes)
 
 	var installed string
 	run := func(sink func(tui.UpgradeEvent)) error {
-		sink(tui.UpgradeEvent{Step: tui.UpgradeStepBrewUpgrading})
-
 		var stdout, stderr io.Writer = app.UI.Out(), app.UI.Err()
 		if useTUI {
 			// brew's own progress output would corrupt our alt-screen.
 			stdout, stderr = io.Discard, io.Discard
 		}
-		if err := selfupdate.Upgrade(context.Background(), brewRunner, stdout, stderr); err != nil {
+		brewSink := func(ev selfupdate.Event) {
+			if step, ok := applyPhaseSteps[ev.Phase]; ok {
+				sink(tui.UpgradeEvent{Step: step})
+			}
+		}
+		if err := selfupdate.Upgrade(context.Background(), brewRunner, stdout, stderr, brewSink); err != nil {
 			if errors.Is(err, selfupdate.ErrBrewNotFound) {
-				return fmt.Errorf("brew not found on PATH — run `brew upgrade humblskills` yourself: %w", err)
+				return fmt.Errorf("brew not found on PATH — run `brew update && brew upgrade humblskills` yourself: %w", err)
 			}
 			return fmt.Errorf("brew upgrade humblskills: %w", err)
 		}

--- a/cli/cmd/humblskills/upgrade_test.go
+++ b/cli/cmd/humblskills/upgrade_test.go
@@ -259,12 +259,12 @@ func TestUpgrade_HomebrewManaged_RunsBrewAndVerifies(t *testing.T) {
 
 	startFakeReleaseAPI(t, latest, "irrelevant for the homebrew path")
 
-	var invoked bool
+	var invocations [][]string
 	prevRunner := brewRunner
 	brewRunner = func(ctx context.Context, name string, args ...string) *exec.Cmd {
-		invoked = true
-		if name != "brew" || len(args) != 2 || args[0] != "upgrade" || args[1] != "humblskills" {
-			t.Errorf("unexpected brew invocation: %s %v", name, args)
+		invocations = append(invocations, append([]string{}, args...))
+		if name != "brew" {
+			t.Errorf("unexpected runner name: %s", name)
 		}
 		return exec.CommandContext(ctx, "true")
 	}
@@ -274,8 +274,17 @@ func TestUpgrade_HomebrewManaged_RunsBrewAndVerifies(t *testing.T) {
 	if res.RunErr != nil {
 		t.Fatalf("run: %v\nerr: %s", res.RunErr, res.Err)
 	}
-	if !invoked {
-		t.Error("expected the stubbed brew runner to be invoked")
+	// Must run `brew update` before `brew upgrade humblskills` — Homebrew
+	// throttles its own tap refresh, so skipping this step is what let
+	// `brew upgrade` silently no-op against a stale tap in production.
+	if len(invocations) != 2 {
+		t.Fatalf("brew invocations = %v, want 2 calls (update, then upgrade)", invocations)
+	}
+	if len(invocations[0]) != 1 || invocations[0][0] != "update" {
+		t.Errorf("first brew call = %v, want [update]", invocations[0])
+	}
+	if len(invocations[1]) != 2 || invocations[1][0] != "upgrade" || invocations[1][1] != "humblskills" {
+		t.Errorf("second brew call = %v, want [upgrade humblskills]", invocations[1])
 	}
 
 	var got upgradeResult

--- a/cli/internal/selfupdate/homebrew.go
+++ b/cli/internal/selfupdate/homebrew.go
@@ -32,21 +32,53 @@ func IsHomebrewManaged(exePath string) bool {
 // `brew` binary. Defaults to exec.CommandContext.
 type Runner func(ctx context.Context, name string, args ...string) *exec.Cmd
 
-// Upgrade runs `brew upgrade humblskills`, streaming its own output to
+// Upgrade refreshes Homebrew's local tap metadata (`brew update`) and then
+// runs `brew upgrade humblskills`, streaming both commands' own output to
 // stdout/stderr live so the user sees Homebrew's real progress instead of a
 // reimplementation of it. run defaults to exec.CommandContext when nil.
-func Upgrade(ctx context.Context, run Runner, stdout, stderr io.Writer) error {
+//
+// The `brew update` step exists because Homebrew throttles its own
+// opportunistic tap refresh (HOMEBREW_AUTO_UPDATE_SECS, 24h by default) —
+// without it, `brew upgrade` can silently no-op against a stale tap and
+// still exit 0, leaving the caller believing an upgrade happened when
+// nothing changed. A `brew update` failure is logged to stderr but not
+// treated as fatal on its own: `brew upgrade` still runs, and the caller's
+// own post-upgrade version check (VerifyInstalledVersion) is what actually
+// decides whether the upgrade succeeded.
+func Upgrade(ctx context.Context, run Runner, stdout, stderr io.Writer, sink EventSink) error {
 	if run == nil {
 		run = exec.CommandContext
 	}
-	cmd := run(ctx, "brew", "upgrade", "humblskills")
+
+	sink.emit(Event{Phase: PhaseBrewUpdating})
+	if err := runBrew(ctx, run, stdout, stderr, "update"); err != nil {
+		if errors.Is(err, ErrBrewNotFound) {
+			sink.emit(Event{Phase: PhaseError, Err: err})
+			return err
+		}
+		fmt.Fprintf(stderr, "warning: brew update failed, continuing with brew upgrade anyway: %v\n", err)
+	}
+
+	sink.emit(Event{Phase: PhaseBrewUpgrading})
+	if err := runBrew(ctx, run, stdout, stderr, "upgrade", "humblskills"); err != nil {
+		sink.emit(Event{Phase: PhaseError, Err: err})
+		return err
+	}
+	return nil
+}
+
+// runBrew runs one `brew <args...>` invocation via run, streaming its
+// output to stdout/stderr and normalizing a missing `brew` binary to
+// ErrBrewNotFound.
+func runBrew(ctx context.Context, run Runner, stdout, stderr io.Writer, args ...string) error {
+	cmd := run(ctx, "brew", args...)
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr
 	if err := cmd.Run(); err != nil {
 		if errors.Is(err, exec.ErrNotFound) {
 			return ErrBrewNotFound
 		}
-		return fmt.Errorf("brew upgrade humblskills: %w", err)
+		return fmt.Errorf("brew %s: %w", strings.Join(args, " "), err)
 	}
 	return nil
 }

--- a/cli/internal/selfupdate/homebrew_test.go
+++ b/cli/internal/selfupdate/homebrew_test.go
@@ -30,14 +30,59 @@ func TestIsHomebrewManaged(t *testing.T) {
 	}
 }
 
-func TestUpgrade_InvokesBrewWithExpectedArgs(t *testing.T) {
-	var capturedName string
-	var capturedArgs []string
+// stubBrewRunner returns a Runner that always succeeds (or always fails,
+// per succeed) regardless of args, recording every invocation's args in
+// order.
+func stubBrewRunner(t *testing.T, invocations *[][]string, succeed bool) Runner {
+	t.Helper()
+	return func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		*invocations = append(*invocations, append([]string{}, args...))
+		if succeed {
+			if runtime.GOOS == "windows" {
+				return exec.CommandContext(ctx, "cmd", "/c", "exit 0")
+			}
+			return exec.CommandContext(ctx, "true")
+		}
+		if runtime.GOOS == "windows" {
+			return exec.CommandContext(ctx, "cmd", "/c", "exit 1")
+		}
+		return exec.CommandContext(ctx, "false")
+	}
+}
+
+func TestUpgrade_RunsBrewUpdateBeforeUpgrade(t *testing.T) {
+	var invocations [][]string
+	runner := stubBrewRunner(t, &invocations, true)
+
+	var stdout, stderr bytes.Buffer
+	if err := Upgrade(context.Background(), runner, &stdout, &stderr, nil); err != nil {
+		t.Fatalf("Upgrade: %v", err)
+	}
+
+	if len(invocations) != 2 {
+		t.Fatalf("invocations = %v, want 2 calls", invocations)
+	}
+	if len(invocations[0]) != 1 || invocations[0][0] != "update" {
+		t.Errorf("first call = %v, want [update]", invocations[0])
+	}
+	if len(invocations[1]) != 2 || invocations[1][0] != "upgrade" || invocations[1][1] != "humblskills" {
+		t.Errorf("second call = %v, want [upgrade humblskills]", invocations[1])
+	}
+}
+
+func TestUpgrade_BrewUpdateFailureDoesNotBlockUpgrade(t *testing.T) {
+	var invocations [][]string
+	callN := 0
 	runner := func(ctx context.Context, name string, args ...string) *exec.Cmd {
-		capturedName = name
-		capturedArgs = append([]string{}, args...)
-		// Substitute a real, always-succeeding command so .Run() doesn't
-		// actually need a `brew` binary in the test environment.
+		invocations = append(invocations, append([]string{}, args...))
+		callN++
+		// Only the first call (brew update) fails; brew upgrade succeeds.
+		if callN == 1 {
+			if runtime.GOOS == "windows" {
+				return exec.CommandContext(ctx, "cmd", "/c", "exit 1")
+			}
+			return exec.CommandContext(ctx, "false")
+		}
 		if runtime.GOOS == "windows" {
 			return exec.CommandContext(ctx, "cmd", "/c", "exit 0")
 		}
@@ -45,15 +90,29 @@ func TestUpgrade_InvokesBrewWithExpectedArgs(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	if err := Upgrade(context.Background(), runner, &stdout, &stderr); err != nil {
+	if err := Upgrade(context.Background(), runner, &stdout, &stderr, nil); err != nil {
+		t.Fatalf("Upgrade should not fail when only brew update fails: %v", err)
+	}
+	if len(invocations) != 2 {
+		t.Fatalf("invocations = %v, want 2 calls (upgrade must still run)", invocations)
+	}
+	if stderr.Len() == 0 {
+		t.Error("expected a warning written to stderr about the failed brew update")
+	}
+}
+
+func TestUpgrade_EmitsBrewUpdatingThenBrewUpgradingPhases(t *testing.T) {
+	var invocations [][]string
+	runner := stubBrewRunner(t, &invocations, true)
+
+	var phases []Phase
+	sink := EventSink(func(ev Event) { phases = append(phases, ev.Phase) })
+
+	if err := Upgrade(context.Background(), runner, &bytes.Buffer{}, &bytes.Buffer{}, sink); err != nil {
 		t.Fatalf("Upgrade: %v", err)
 	}
-	if capturedName != "brew" {
-		t.Errorf("runner called with name = %q, want brew", capturedName)
-	}
-	want := []string{"upgrade", "humblskills"}
-	if len(capturedArgs) != len(want) || capturedArgs[0] != want[0] || capturedArgs[1] != want[1] {
-		t.Errorf("runner called with args = %v, want %v", capturedArgs, want)
+	if len(phases) != 2 || phases[0] != PhaseBrewUpdating || phases[1] != PhaseBrewUpgrading {
+		t.Errorf("phases = %v, want [%s %s]", phases, PhaseBrewUpdating, PhaseBrewUpgrading)
 	}
 }
 
@@ -66,7 +125,7 @@ func TestUpgrade_BrewNotFound(t *testing.T) {
 		return exec.CommandContext(ctx, "definitely-not-a-real-binary-xyz")
 	}
 
-	err := Upgrade(context.Background(), runner, &bytes.Buffer{}, &bytes.Buffer{})
+	err := Upgrade(context.Background(), runner, &bytes.Buffer{}, &bytes.Buffer{}, nil)
 	if !errors.Is(err, ErrBrewNotFound) {
 		t.Errorf("expected ErrBrewNotFound, got %v", err)
 	}
@@ -80,7 +139,9 @@ func TestUpgrade_NonZeroExit(t *testing.T) {
 		return exec.CommandContext(ctx, "false")
 	}
 
-	err := Upgrade(context.Background(), runner, &bytes.Buffer{}, &bytes.Buffer{})
+	// Both brew update and brew upgrade fail here, so the overall call must
+	// still surface the (second, fatal) failure.
+	err := Upgrade(context.Background(), runner, &bytes.Buffer{}, &bytes.Buffer{}, nil)
 	if err == nil {
 		t.Fatal("expected error for non-zero brew exit code")
 	}

--- a/cli/internal/selfupdate/run.go
+++ b/cli/internal/selfupdate/run.go
@@ -18,7 +18,12 @@ const (
 	PhaseDownloading    Phase = "downloading"
 	PhaseVerifyingSum   Phase = "verifying_checksum"
 	PhaseInstalling     Phase = "installing"
-	PhaseError          Phase = "error"
+	// PhaseBrewUpdating fires while refreshing Homebrew's local tap
+	// metadata (`brew update`), before PhaseBrewUpgrading.
+	PhaseBrewUpdating Phase = "brew_updating"
+	// PhaseBrewUpgrading fires while running `brew upgrade humblskills`.
+	PhaseBrewUpgrading Phase = "brew_upgrading"
+	PhaseError         Phase = "error"
 )
 
 // Event is a single progress notification emitted while running

--- a/cli/internal/tui/upgrade.go
+++ b/cli/internal/tui/upgrade.go
@@ -21,6 +21,7 @@ type UpgradeStep string
 
 const (
 	UpgradeStepCheckingLatest    UpgradeStep = "checking_latest"
+	UpgradeStepBrewUpdating      UpgradeStep = "brew_updating"
 	UpgradeStepBrewUpgrading     UpgradeStep = "brew_upgrading"
 	UpgradeStepDownloading       UpgradeStep = "downloading"
 	UpgradeStepVerifyingChecksum UpgradeStep = "verifying_checksum"
@@ -30,9 +31,11 @@ const (
 
 // upgradeStepLabels is the display label for every step that could appear.
 // A given run only walks a subset — the Homebrew path skips
-// download/verify/install in favour of UpgradeStepBrewUpgrading.
+// download/verify/install in favour of UpgradeStepBrewUpdating +
+// UpgradeStepBrewUpgrading.
 var upgradeStepLabels = map[UpgradeStep]string{
 	UpgradeStepCheckingLatest:    "checking latest release",
+	UpgradeStepBrewUpdating:      "running brew update",
 	UpgradeStepBrewUpgrading:     "running brew upgrade humblskills",
 	UpgradeStepDownloading:       "downloading release archive",
 	UpgradeStepVerifyingChecksum: "verifying checksum",

--- a/registry.json
+++ b/registry.json
@@ -1,10 +1,10 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-07-01T00:12:42Z",
+  "generated_at": "2026-07-01T00:57:25Z",
   "source": {
     "repo": "github.com/jjfantini/humblSKILLS",
-    "ref": "develop",
-    "sha": "d128f8697cfd1fb54bb91a5edb0afecc7328cd45"
+    "ref": "cursor/fix-brew-upgrade-stale-tap-2f10",
+    "sha": "2eabf9e24b0e22ae05e651f13a5886c64625b2b3"
   },
   "skills": [
     {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Bug

Reported by a user running `humblskills upgrade` on a real Homebrew-managed install:

```
humblskills upgrade
Homebrew-managed install detected — upgrading via `brew upgrade humblskills`
humblskills: brew reported success but installed version is v2.18.0, expected v2.19.0
```

`selfupdate.Upgrade` only ran `brew upgrade humblskills`. Homebrew throttles its own opportunistic tap refresh (`HOMEBREW_AUTO_UPDATE_SECS`, 24h by default), so `brew upgrade` alone can silently no-op against a stale local tap and still exit 0 — the exact scenario the user hit.

## Fix

`selfupdate.Upgrade` now runs `brew update` before `brew upgrade humblskills`, streaming both commands' output live. A `brew update` failure is logged but not fatal on its own — `brew upgrade` still runs, and the existing post-upgrade version check (`VerifyInstalledVersion`) remains the actual source of truth for success/failure. The TUI upgrade screen shows both steps (`running brew update` → `running brew upgrade humblskills` → `verifying installed version`).

## Testing

- ✅ `go -C cli vet ./...`
- ✅ `go -C cli test -race -count=1 ./...`
- ✅ `make registry-check`
- Manual repro: built a fake `brew` script that only actually swaps the installed binary if `update` ran first (reproducing "stale tap, upgrade silently no-ops but exits 0"). The pre-fix binary reproduced the user's exact error message; the fixed binary resolved it end-to-end (verified `currentVersion: 2.18.0` → `installedVersion: 2.19.0`, `applied: true`).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-13f6bd37-f2d6-44ba-8e8d-899054bc2f10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-13f6bd37-f2d6-44ba-8e8d-899054bc2f10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

