### PR TITLE
fix(tui): profile multi-select only toggles on space, not enter

### DIFF
--- a/cli/internal/tui/profile.go
+++ b/cli/internal/tui/profile.go
@@ -158,13 +158,16 @@ func (m profileModel) updateValue(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case " ", "x":
 		m = m.toggleCurrent()
 	case "enter":
-		m = m.toggleCurrent()
-		// For radio-style settings (scope), enter commits and returns to
-		// the settings pane; for multi-select (platforms) it stays in the
-		// right pane so the user can toggle more.
+		// Space is the only toggle key, consistent with every other
+		// multi-select surface in the TUI (e.g. the install platform
+		// modal). For radio-style settings (scope), enter commits the
+		// highlighted option and returns to the settings pane; for
+		// multi-select (platforms) it never toggles — it just returns,
+		// same as esc.
 		if profileSettings[m.settingIdx].kind == settingRadio {
-			m.focus = focusSettings
+			m = m.toggleCurrent()
 		}
+		m.focus = focusSettings
 	}
 	return m, nil
 }
@@ -373,7 +376,7 @@ func (m profileModel) renderRight(width int) string {
 	if m.focus == focusSettings {
 		hint = "press enter to edit"
 	} else if setting.kind == settingMulti {
-		hint = "space to toggle · enter to toggle · esc to return"
+		hint = "space to toggle · enter/esc to return"
 	} else {
 		hint = "enter to select · esc to return"
 	}

--- a/cli/internal/tui/profile_test.go
+++ b/cli/internal/tui/profile_test.go
@@ -4,6 +4,8 @@ import (
 	"strings"
 	"testing"
 
+	tea "github.com/charmbracelet/bubbletea"
+
 	"github.com/jjfantini/humblSKILLS/cli/internal/adapters"
 	"github.com/jjfantini/humblSKILLS/cli/internal/profile"
 	"github.com/jjfantini/humblSKILLS/cli/internal/ui"
@@ -109,5 +111,69 @@ func TestProfileModel_RenderScopeOptions_GlobalHasNoNote(t *testing.T) {
 	joined := strings.Join(rows, "\n")
 	if strings.Contains(joined, "can't show a concrete location") {
 		t.Errorf("global scope should not show the adapter-default note:\n%s", joined)
+	}
+}
+
+// --- enter vs space key semantics ------------------------------------------
+//
+// Regression coverage: multi-select values (platforms) must only toggle on
+// space, matching every other multi-select surface in the TUI (e.g. the
+// install platform modal). Enter previously also toggled here, which was
+// inconsistent and easy to trigger by accident while navigating.
+
+func TestProfileModel_MultiSelect_EnterDoesNotToggle_JustReturns(t *testing.T) {
+	m := newTestProfileModel(profile.Profile{})
+	m.settingIdx = 0 // platforms
+	m.focus = focusValue
+	m.valueIdx = 0 // claude-code
+
+	out, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updated := out.(profileModel)
+
+	if len(updated.profile.DefaultPlatforms) != 0 {
+		t.Errorf("enter must not toggle a platform on; DefaultPlatforms = %v", updated.profile.DefaultPlatforms)
+	}
+	if updated.changed {
+		t.Error("enter must not mark the profile as changed when it doesn't toggle anything")
+	}
+	if updated.focus != focusSettings {
+		t.Errorf("enter should return focus to the settings pane, got %v", updated.focus)
+	}
+}
+
+func TestProfileModel_MultiSelect_SpaceStillToggles_AndStaysInValuePane(t *testing.T) {
+	m := newTestProfileModel(profile.Profile{})
+	m.settingIdx = 0 // platforms
+	m.focus = focusValue
+	m.valueIdx = 0 // claude-code
+
+	out, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{' '}})
+	updated := out.(profileModel)
+
+	if len(updated.profile.DefaultPlatforms) != 1 || updated.profile.DefaultPlatforms[0] != "claude-code" {
+		t.Errorf("space should toggle claude-code on; DefaultPlatforms = %v", updated.profile.DefaultPlatforms)
+	}
+	if !updated.changed {
+		t.Error("expected changed=true after toggling")
+	}
+	if updated.focus != focusValue {
+		t.Errorf("space should not leave the value pane, got focus=%v", updated.focus)
+	}
+}
+
+func TestProfileModel_Radio_EnterTogglesAndReturns(t *testing.T) {
+	m := newTestProfileModel(profile.Profile{})
+	m.settingIdx = 1 // scope (radio)
+	m.focus = focusValue
+	m.valueIdx = 2 // project
+
+	out, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updated := out.(profileModel)
+
+	if updated.profile.DefaultScope != profile.ScopeProject {
+		t.Errorf("enter should commit the highlighted radio option; DefaultScope = %q", updated.profile.DefaultScope)
+	}
+	if updated.focus != focusSettings {
+		t.Errorf("enter should return focus to the settings pane, got %v", updated.focus)
 	}
 }

--- a/registry.json
+++ b/registry.json
@@ -1,10 +1,10 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-07-01T01:00:19Z",
+  "generated_at": "2026-07-01T01:27:57Z",
   "source": {
     "repo": "github.com/jjfantini/humblSKILLS",
-    "ref": "develop",
-    "sha": "b2d7638c07fa4be4d39a49ef486489dda7a3f0f7"
+    "ref": "cursor/fix-profile-enter-toggle-2f10",
+    "sha": "2411b1884e8b0c89bf00e782e210ccce06a07177"
   },
   "skills": [
     {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
In the profile editor's "default platforms" value pane, Enter also toggled the highlighted checkbox — inconsistent with every other multi-select surface in the TUI (e.g. the install platform modal), where Enter only advances/confirms and Space is the sole toggle key.

Enter on a multi-select value now just returns to the settings pane (same as Esc) without toggling. Radio values (scope) are unchanged — Enter still commits the highlighted option and returns.

[Space still toggles, stays in the value pane](https://cursor.com/artifacts/c/art-66ac1831-fc12-4eae-9214-4d85712445d6)

## Testing
- ✅ `go -C cli vet ./...`
- ✅ `go -C cli test -race -count=1 ./...`
- ✅ `make registry-check`
- ✅ Manual TUI walkthrough (tmux): confirmed Enter on a platform checkbox no longer toggles it and returns to the settings pane; confirmed Space still toggles and stays in the value pane.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-13f6bd37-f2d6-44ba-8e8d-899054bc2f10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-13f6bd37-f2d6-44ba-8e8d-899054bc2f10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

