### PR TITLE
fix(skills): support codex on every skill's platform target

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1,10 +1,10 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-07-01T01:32:01Z",
+  "generated_at": "2026-07-01T01:43:31Z",
   "source": {
     "repo": "github.com/jjfantini/humblSKILLS",
     "ref": "cursor/skills-support-all-platforms-2f10",
-    "sha": "976a25ed40611ca128c0751b6214901b0b4bd882"
+    "sha": "e3482149aeaaf761a092b0b9195a0ad34d0887f6"
   },
   "skills": [
     {

--- a/registry.json
+++ b/registry.json
@@ -1,15 +1,15 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-07-01T01:31:34Z",
+  "generated_at": "2026-07-01T01:32:01Z",
   "source": {
     "repo": "github.com/jjfantini/humblSKILLS",
-    "ref": "develop",
-    "sha": "5c4133cd63fc7d886a987cb7389db14e14dfe26c"
+    "ref": "cursor/skills-support-all-platforms-2f10",
+    "sha": "976a25ed40611ca128c0751b6214901b0b4bd882"
   },
   "skills": [
     {
       "name": "analyze-ml-system-design",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "description": "Drive an ML system design from an ambiguous prompt to a production-minded solution with a 6-step framework (problem framing, high-level design, data and features, modeling, inference and evaluation, deep dives). Use for an ML system design interview or any \"design X\" ML prompt - recommendation systems, fraud or bot detection, content moderation, ranking, search, personalization - or whenever the core problem is choosing data, features, a model, and an evaluation strategy. For infra or non-ML system design (URL shortener, chat, rate limiter, file sync), use analyze-system-design instead.",
       "tags": [
         "ml-system-design",
@@ -18,7 +18,8 @@
       ],
       "platforms": [
         "claude-code",
-        "cursor"
+        "cursor",
+        "codex"
       ],
       "preserve": [
         "references/decisions.md",
@@ -26,11 +27,11 @@
         "references/patterns.md"
       ],
       "path": "skills/analyze-ml-system-design",
-      "dir_sha": "58be24e2d637b09d32782ad785bd6466153d0be3d80a8309f43b6b50e44f8efb"
+      "dir_sha": "08c1ab46134db683a2aa0fa9a3e87654f92094b5378225993a43d895b1b7e8dc"
     },
     {
       "name": "analyze-system-design",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "description": "Drive a system design interview from a blank prompt to a simple, complete, defensible design using a 6-step framework (requirements, core entities, API, optional data flow, high-level design, deep dives). Use it for system design interviews, \"design X system\" prompts, high-level design and architecture sketches, deep dives, scaling and data-modeling questions, and choosing technologies (Redis, Kafka, Cassandra, DynamoDB, Postgres). For ML-centric problems (recommendations, fraud or bot detection, ranking, content moderation) use analyze-ml-system-design instead.",
       "tags": [
         "system-design",
@@ -39,7 +40,8 @@
       ],
       "platforms": [
         "claude-code",
-        "cursor"
+        "cursor",
+        "codex"
       ],
       "preserve": [
         "references/decisions.md",
@@ -47,11 +49,11 @@
         "references/patterns.md"
       ],
       "path": "skills/analyze-system-design",
-      "dir_sha": "c15e5aad6142aa2501fc9ae0dbc0c375e9bb665c08edbf847a9fce52409869e6"
+      "dir_sha": "5e5c58d3a06d98866d359b0e6e6ba2c78e03195eea88f49ab4ce8de71b6a6f91"
     },
     {
       "name": "create-scroll-animation",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "description": "Generates a production-grade React/Next.js scroll-driven canvas hero from an MP4. Extracts frames via FFmpeg, batch-converts to WebP, emits a single .tsx that scrubs frames against scroll progress using Framer Motion's useScroll + useMotionValueEvent. Mobile-first, LCP target under 1.2s, JS budget under 100KB. Trigger on \"scroll-stop build\", \"scroll animation website\", \"scroll-driven video\", \"Apple-style scroll animation\", \"video on scroll\", or when the user provides an MP4 and asks for a scroll-scrubbed React hero. Do NOT use for HTML-only sites (use scroll-stop-builder), two-frame transitions (use create-video-transition), or non-scroll canvas animations.\n",
       "tags": [
         "scroll",
@@ -67,7 +69,8 @@
       ],
       "platforms": [
         "claude-code",
-        "cursor"
+        "cursor",
+        "codex"
       ],
       "preserve": [
         "references/decisions.md",
@@ -75,11 +78,11 @@
         "references/patterns.md"
       ],
       "path": "skills/create-scroll-animation",
-      "dir_sha": "89ef63803695be84d2f6dc1778f4e7190887743abce3b3cfe4f370611f2e6e71"
+      "dir_sha": "e47502bf2990628c3190a5d2d2df62b91ba44490b23037d3951b4ceaf3df86c0"
     },
     {
       "name": "create-video-transition",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "description": "Generates the prompts needed to produce a video transition between two frames: Prompt A (start image), Prompt B (end image), and Prompt C (video transition, decomposed into exact 2-second blocks). Detects which prompts to produce based on whether the user uploaded a start image, an end image, both, or neither. Prompt C interpolates $VIDEO_LENGTH, $VIDEO_ASPECT_RATIO, $VIDEO_AUDIO, $VIDEO_FPS. Delivers an HTML page with tabbed A/B/C copy buttons and a settings modal for live variable swaps. Trigger when the user says \"video transition prompt\", \"start frame to end frame\", \"animate between these images\", \"transition video from image to image\", or uploads a reference image and asks for a transition. Do NOT use for standalone image prompts (use scroll-stop-prompter) or for writing Runway/Kling UI copy.\n",
       "tags": [
         "video",
@@ -91,7 +94,8 @@
       ],
       "platforms": [
         "claude-code",
-        "cursor"
+        "cursor",
+        "codex"
       ],
       "preserve": [
         "references/decisions.md",
@@ -99,11 +103,11 @@
         "references/patterns.md"
       ],
       "path": "skills/create-video-transition",
-      "dir_sha": "ddcaa44dda982e72a61ccb8b753f8f1d21055dc79e2a5f497f795f9242c256d5"
+      "dir_sha": "5fd78496ca10213c915a92696e731a2f9ff682477d6257e0966232562cf5351f"
     },
     {
       "name": "smart-claude-init",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "description": "Interview the user relentlessly, one question at a time with a recommended answer for each, to produce a clean iterated CLAUDE.md for a new project. Detects code vs non-code projects and fills a standard 8-section template (project intent, architecture, engineering preferences, code quality, testing, performance, bug protocol, task management and core principles). Use when the user says \"init CLAUDE.md\", \"set up CLAUDE.md\", \"grill me about my project\", \"smart-claude-init\", or wants a guided CLAUDE.md for a new repo. Do NOT use to mechanically document an existing codebase (use the built-in init skill), or to edit an already-good CLAUDE.md.\n",
       "tags": [
         "claude-md",
@@ -114,7 +118,8 @@
       ],
       "platforms": [
         "claude-code",
-        "cursor"
+        "cursor",
+        "codex"
       ],
       "preserve": [
         "references/decisions.md",
@@ -122,11 +127,11 @@
         "references/patterns.md"
       ],
       "path": "skills/smart-claude-init",
-      "dir_sha": "34faf4aa9a71c2a7edb0c8b42dd863a7a7c7b6038500c6471dd1494e51be913c"
+      "dir_sha": "bba278513a622f50d797186cafbe513b32e470fe96b4d666038bfd6380c76a91"
     },
     {
       "name": "smart-frontend-design",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "description": "Create distinctive, production-grade frontend interfaces with a synthesized design system and one style-defining intake question. Use when the user asks to build or redesign web components, pages, apps, dashboards, landing pages, UI flows, React/Vue/HTML/CSS interfaces, or \"make this look better\". Avoids generic AI aesthetics by discovering the existing frontend style before coding. Do NOT use for backend-only work, copy-only edits, or pure design critique where no frontend implementation is requested.\n",
       "tags": [
         "frontend",
@@ -139,7 +144,8 @@
       ],
       "platforms": [
         "claude-code",
-        "cursor"
+        "cursor",
+        "codex"
       ],
       "preserve": [
         "references/decisions.md",
@@ -147,11 +153,11 @@
         "references/patterns.md"
       ],
       "path": "skills/smart-frontend-design",
-      "dir_sha": "ad9a927a80140d58ea98b59e5b5ebe520b8fcc150b4263f9aab89de66a919b6d"
+      "dir_sha": "21de90a8640c7eae15cb8d5c9ef80054e8eae86e475626724ccd94bde5236055"
     },
     {
       "name": "use-smart-commit",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "description": "Inspect the working tree, group pending changes into atomic related buckets, and author one conventional commit per bucket. Every message covers what changed, why, and the impact (what it resolves or unblocks). Use when the user says \"commit\", \"commit my changes\", \"make a commit\", \"stage and commit\", or after finishing a unit of work and wanting to land it. Do NOT use for squashing existing history, rebasing, force-pushing, or writing PR descriptions.\n",
       "tags": [
         "git",
@@ -162,7 +168,8 @@
       ],
       "platforms": [
         "claude-code",
-        "cursor"
+        "cursor",
+        "codex"
       ],
       "preserve": [
         "references/decisions.md",
@@ -170,23 +177,28 @@
         "references/patterns.md"
       ],
       "path": "skills/use-smart-commit",
-      "dir_sha": "6c49b807c54a8ec929eacda3c4ffbce061378d2248236791afce7701f8bd0546"
+      "dir_sha": "0f4a355a556548073524064572ea8fa5f326d6be27f621f33015ae0f76810f79"
     },
     {
       "name": "use-smart-humanize-text",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "description": "Strip AI-generated writing patterns from text to make it sound authentically human. Use when writing or editing any content that must not read as AI-generated - outreach, blog posts, applications, social posts, emails, marketing copy. Detects and fixes AI vocabulary, structural tells, soulless tone, filler, hedging, and formatting artifacts. Based on Wikipedia's \"Signs of AI writing\" guide and associated research.\n",
+      "platforms": [
+        "claude-code",
+        "cursor",
+        "codex"
+      ],
       "preserve": [
         "references/decisions.md",
         "references/log.md",
         "references/patterns.md"
       ],
       "path": "skills/use-smart-humanize-text",
-      "dir_sha": "6386add08f8ba015f28beadd9e5fcf9851a4bc41613ff71711266f4802e14096"
+      "dir_sha": "dec55c238b532060a7394d289a8d41d267376753c7eefff9e521cce68a05adb5"
     },
     {
       "name": "use-smart-skill",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "description": "Scaffold production-grade humblSKILLS with progressive disclosure, self-learning memory (patterns/decisions/session log), and lint tooling. Use when creating a new humblSKILL (also known as a smart skill), scaffolding a SKILL.md, migrating a flat skill to a smart skill, refactoring a skill that exceeds ~300 lines, or adding memory/patterns tracking to an existing skill. Do NOT use for editing skill content after scaffold - use the skill directly. Uses CCCCC layering internally (Core/Context/Category/Concept/Command).\n",
       "tags": [
         "meta",
@@ -197,7 +209,8 @@
       ],
       "platforms": [
         "claude-code",
-        "cursor"
+        "cursor",
+        "codex"
       ],
       "preserve": [
         "references/decisions.md",
@@ -205,11 +218,11 @@
         "references/patterns.md"
       ],
       "path": "skills/use-smart-skill",
-      "dir_sha": "7247d01c81262cd407092ab54ece41b9f935761a0c354899b81ffdd0e6140ef0"
+      "dir_sha": "5d396b0425d98db4650ededa01ab818d2d23748d65a099f18cfde4ad221d5673"
     },
     {
       "name": "use-upload-thing",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "description": "Drive the UploadThing REST API end-to-end from the shell: authenticate with an API key, upload files (v7 prepareUpload + ingest PUT), download by key or URL, and list, delete, rename, set ACLs, or read usage. Use when the user wants to upload/download/manage files on UploadThing, mentions UploadThing, ufs.sh, prepareUpload, an sk_live key, or \"put this file on UploadThing\". Also guides first-time API-key setup. Do NOT use for building an app's File Router / React upload components (that is the TS SDK), or for non-UploadThing storage (S3, GCS).\n",
       "tags": [
         "uploadthing",
@@ -221,7 +234,8 @@
       ],
       "platforms": [
         "claude-code",
-        "cursor"
+        "cursor",
+        "codex"
       ],
       "preserve": [
         "references/decisions.md",
@@ -229,11 +243,11 @@
         "references/patterns.md"
       ],
       "path": "skills/use-upload-thing",
-      "dir_sha": "5bf64bcd1c2e313cc14261cb1eb18816493008fc9e715cdc4d6047166d077246"
+      "dir_sha": "6d1cd72ded7355b78b8a869f51a726229dbf872b380adaccf989faa58f970bb4"
     },
     {
       "name": "use-worktree-flow",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "description": "Run a worktree-first development workflow from intent gathering through feature PR, develop merge, main merge, release PR, brew verification, and cleanup. Use when the user says \"worktree flow\", \"start a feature\", \"ship this feature\", \"PR into develop\", \"full dev workflow\", or wants a feature isolated from parallel agents. Do NOT use for atomic commit authoring (use use-smart-commit) or merge-conflict repair.\n",
       "tags": [
         "git",
@@ -245,7 +259,8 @@
       ],
       "platforms": [
         "claude-code",
-        "cursor"
+        "cursor",
+        "codex"
       ],
       "preserve": [
         "references/decisions.md",
@@ -253,7 +268,7 @@
         "references/patterns.md"
       ],
       "path": "skills/use-worktree-flow",
-      "dir_sha": "83ae98852f839ff423edacfd33f48596866ad9b8afb6d161678f4f45fa1f472c"
+      "dir_sha": "4aaf93a15aa55f4d94006bb06615d3aae6855b7f476acb88c9c304fafbc3fb73"
     }
   ]
 }

--- a/skills/analyze-ml-system-design/SKILL.md
+++ b/skills/analyze-ml-system-design/SKILL.md
@@ -4,9 +4,9 @@ description: Drive an ML system design from an ambiguous prompt to a production-
 license: MIT
 metadata:
   author: Jennings Fantini
-  version: "2.0.0"
+  version: "2.0.1"
   tags: [ml-system-design, interviews, machine-learning]
-  platforms: [claude-code, cursor]
+  platforms: [claude-code, cursor, codex]
   preserve:
     - references/decisions.md
     - references/log.md

--- a/skills/analyze-system-design/SKILL.md
+++ b/skills/analyze-system-design/SKILL.md
@@ -4,9 +4,9 @@ description: Drive a system design interview from a blank prompt to a simple, co
 license: MIT
 metadata:
   author: Jennings Fantini
-  version: "2.0.0"
+  version: "2.0.1"
   tags: [system-design, interviews, architecture]
-  platforms: [claude-code, cursor]
+  platforms: [claude-code, cursor, codex]
   preserve:
     - references/decisions.md
     - references/log.md

--- a/skills/create-scroll-animation/SKILL.md
+++ b/skills/create-scroll-animation/SKILL.md
@@ -16,9 +16,9 @@ compatibility: Requires ffmpeg and ffprobe on PATH; bash; Node 18+; a React 18+ 
 allowed-tools: "Read Write Edit Glob Grep Bash(ffmpeg:*) Bash(ffprobe:*) Bash(cwebp:*) Bash(bash:*) Bash(mkdir:*) Bash(cp:*) Bash(ls:*)"
 metadata:
   author: jjfantini
-  version: "0.1.0"
+  version: "0.1.1"
   tags: [scroll, canvas, framer-motion, nextjs, react, ffmpeg, webp, apple-style, hero, humblskill]
-  platforms: [claude-code, cursor]
+  platforms: [claude-code, cursor, codex]
   preserve:
     - references/decisions.md
     - references/log.md

--- a/skills/create-video-transition/SKILL.md
+++ b/skills/create-video-transition/SKILL.md
@@ -18,9 +18,9 @@ compatibility: Requires a modern browser to open the HTML deliverable; an AI ima
 allowed-tools: "Read Write Edit Glob Grep Bash(open:*) Bash(xdg-open:*) Bash(bash:*) Bash(mkdir:*) Bash(ls:*)"
 metadata:
   author: jjfantini
-  version: "1.0.0"
+  version: "1.0.1"
   tags: [video, prompt, transition, image-generation, commercial-director, humblskill]
-  platforms: [claude-code, cursor]
+  platforms: [claude-code, cursor, codex]
   preserve:
     - references/decisions.md
     - references/log.md

--- a/skills/smart-claude-init/SKILL.md
+++ b/skills/smart-claude-init/SKILL.md
@@ -15,9 +15,9 @@ compatibility: Requires bash and POSIX utilities (grep, sed) plus python3 for sc
 allowed-tools: "Bash(bash:*) Read Write Edit Glob Grep"
 metadata:
   author: jjfantini
-  version: "0.1.0"
+  version: "0.1.1"
   tags: [claude-md, onboarding, interview, project-setup, humblskill]
-  platforms: [claude-code, cursor]
+  platforms: [claude-code, cursor, codex]
   preserve:
     - references/decisions.md
     - references/log.md

--- a/skills/smart-frontend-design/SKILL.md
+++ b/skills/smart-frontend-design/SKILL.md
@@ -12,9 +12,9 @@ license: MIT
 compatibility: "Requires python3 only for scripts/lint.sh. Frontend implementation uses whatever stack exists in the target repo."
 metadata:
   author: jjfantini
-  version: "1.0.0"
+  version: "1.0.1"
   tags: [frontend, design, ui, ux, react, css, humblskill]
-  platforms: [claude-code, cursor]
+  platforms: [claude-code, cursor, codex]
   preserve:
     - references/decisions.md
     - references/log.md

--- a/skills/use-smart-commit/SKILL.md
+++ b/skills/use-smart-commit/SKILL.md
@@ -11,9 +11,9 @@ description: >
 license: MIT
 metadata:
   author: jjfantini
-  version: "1.0.0"
+  version: "1.0.1"
   tags: [git, commits, conventional-commits, workflow, humblskill]
-  platforms: [claude-code, cursor]
+  platforms: [claude-code, cursor, codex]
   preserve:
     - references/decisions.md
     - references/log.md

--- a/skills/use-smart-humanize-text/SKILL.md
+++ b/skills/use-smart-humanize-text/SKILL.md
@@ -10,7 +10,8 @@ description: >
 license: MIT
 metadata:
   author: jjfantini
-  version: 2.0.0
+  version: 2.0.1
+  platforms: [claude-code, cursor, codex]
   preserve:
     - references/decisions.md
     - references/log.md

--- a/skills/use-smart-skill/SKILL.md
+++ b/skills/use-smart-skill/SKILL.md
@@ -14,9 +14,9 @@ compatibility: Requires bash, POSIX utilities (awk, sed, find, grep), python3, w
 allowed-tools: "Bash(bash:*) Bash(sh:*) Read Write Edit Glob Grep"
 metadata:
   author: jjfantini
-  version: 1.1.0
+  version: 1.1.1
   tags: [meta, skill-authoring, smart-skill, scaffolding, humblskill]
-  platforms: [claude-code, cursor]
+  platforms: [claude-code, cursor, codex]
   preserve:
     - references/decisions.md
     - references/log.md

--- a/skills/use-upload-thing/SKILL.md
+++ b/skills/use-upload-thing/SKILL.md
@@ -12,9 +12,9 @@ license: MIT
 compatibility: "Requires bash, curl, jq, and network access to api.uploadthing.com. Needs an UploadThing API key via UPLOADTHING_API_KEY (or UPLOADTHING_TOKEN), or run scripts/auth.sh --save."
 metadata:
   author: jjfantini
-  version: "1.0.0"
+  version: "1.0.1"
   tags: [uploadthing, file-upload, storage, rest-api, ufs, humblskill]
-  platforms: [claude-code, cursor]
+  platforms: [claude-code, cursor, codex]
   preserve:
     - references/decisions.md
     - references/log.md

--- a/skills/use-worktree-flow/SKILL.md
+++ b/skills/use-worktree-flow/SKILL.md
@@ -11,9 +11,9 @@ license: MIT
 compatibility: "Requires git 2.5+, GitHub CLI (`gh`) for PR/check operations, and network access for remote sync, CI, releases, and Homebrew verification."
 metadata:
   author: jjfantini
-  version: "1.0.0"
+  version: "1.0.1"
   tags: [git, worktree, pull-requests, release, workflow, humblskill]
-  platforms: [claude-code, cursor]
+  platforms: [claude-code, cursor, codex]
   preserve:
     - references/decisions.md
     - references/log.md


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
10 of 11 skills declared `metadata.platforms: [claude-code, cursor]`, silently excluding codex (`use-smart-humanize-text` had no restriction at all). Under global-fanout (the new default), this doesn't matter — global mode ignores the per-skill allow-list and symlinks every selected platform. But it silently no-ops an install when a user explicitly requests `--platform codex` (or sets it as a profile default) for one of these 10 skills: the engine finds no matching pending target and returns without installing or erroring.

All 11 skills now declare `platforms: [claude-code, cursor, codex]`. Bumped each skill's patch version since the package content changed; regenerated `registry.json`.

## Testing
- ✅ `make registry-check`
- ✅ `go -C cli vet ./...`
- ✅ `go -C cli test -race -count=1 ./...`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-13f6bd37-f2d6-44ba-8e8d-899054bc2f10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-13f6bd37-f2d6-44ba-8e8d-899054bc2f10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

