### PR TITLE
fix(skills): preserve wiki/ and raw/ content across updates

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1,15 +1,15 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-07-01T01:46:26Z",
+  "generated_at": "2026-07-01T01:46:48Z",
   "source": {
     "repo": "github.com/jjfantini/humblSKILLS",
-    "ref": "develop",
-    "sha": "01a67add8261f34c192beeaf33cfaf6b7af87110"
+    "ref": "cursor/preserve-wiki-raw-content-2f10",
+    "sha": "2570d2ad622e91a4f188a9ac226c6313a4f4c543"
   },
   "skills": [
     {
       "name": "analyze-ml-system-design",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "description": "Drive an ML system design from an ambiguous prompt to a production-minded solution with a 6-step framework (problem framing, high-level design, data and features, modeling, inference and evaluation, deep dives). Use for an ML system design interview or any \"design X\" ML prompt - recommendation systems, fraud or bot detection, content moderation, ranking, search, personalization - or whenever the core problem is choosing data, features, a model, and an evaluation strategy. For infra or non-ML system design (URL shortener, chat, rate limiter, file sync), use analyze-system-design instead.",
       "tags": [
         "ml-system-design",
@@ -22,16 +22,18 @@
         "codex"
       ],
       "preserve": [
+        "references/raw/",
+        "references/wiki/",
         "references/decisions.md",
         "references/log.md",
         "references/patterns.md"
       ],
       "path": "skills/analyze-ml-system-design",
-      "dir_sha": "08c1ab46134db683a2aa0fa9a3e87654f92094b5378225993a43d895b1b7e8dc"
+      "dir_sha": "b672f905bdce5ccd03fdf7c7fcabeafe2ea4f0c3e083fb942af9c334455a9760"
     },
     {
       "name": "analyze-system-design",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "description": "Drive a system design interview from a blank prompt to a simple, complete, defensible design using a 6-step framework (requirements, core entities, API, optional data flow, high-level design, deep dives). Use it for system design interviews, \"design X system\" prompts, high-level design and architecture sketches, deep dives, scaling and data-modeling questions, and choosing technologies (Redis, Kafka, Cassandra, DynamoDB, Postgres). For ML-centric problems (recommendations, fraud or bot detection, ranking, content moderation) use analyze-ml-system-design instead.",
       "tags": [
         "system-design",
@@ -44,16 +46,18 @@
         "codex"
       ],
       "preserve": [
+        "references/raw/",
+        "references/wiki/",
         "references/decisions.md",
         "references/log.md",
         "references/patterns.md"
       ],
       "path": "skills/analyze-system-design",
-      "dir_sha": "5e5c58d3a06d98866d359b0e6e6ba2c78e03195eea88f49ab4ce8de71b6a6f91"
+      "dir_sha": "d0f17c1655b7a1b7946d61f5d4588aee24c3c73b407a78bdd2a9ffb95dba504c"
     },
     {
       "name": "create-scroll-animation",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "description": "Generates a production-grade React/Next.js scroll-driven canvas hero from an MP4. Extracts frames via FFmpeg, batch-converts to WebP, emits a single .tsx that scrubs frames against scroll progress using Framer Motion's useScroll + useMotionValueEvent. Mobile-first, LCP target under 1.2s, JS budget under 100KB. Trigger on \"scroll-stop build\", \"scroll animation website\", \"scroll-driven video\", \"Apple-style scroll animation\", \"video on scroll\", or when the user provides an MP4 and asks for a scroll-scrubbed React hero. Do NOT use for HTML-only sites (use scroll-stop-builder), two-frame transitions (use create-video-transition), or non-scroll canvas animations.\n",
       "tags": [
         "scroll",
@@ -73,16 +77,18 @@
         "codex"
       ],
       "preserve": [
+        "references/raw/",
+        "references/wiki/",
         "references/decisions.md",
         "references/log.md",
         "references/patterns.md"
       ],
       "path": "skills/create-scroll-animation",
-      "dir_sha": "e47502bf2990628c3190a5d2d2df62b91ba44490b23037d3951b4ceaf3df86c0"
+      "dir_sha": "bee7053d358d3901c6189b4b074a494e77905835815edc52a32eeab92cc0fb30"
     },
     {
       "name": "create-video-transition",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "description": "Generates the prompts needed to produce a video transition between two frames: Prompt A (start image), Prompt B (end image), and Prompt C (video transition, decomposed into exact 2-second blocks). Detects which prompts to produce based on whether the user uploaded a start image, an end image, both, or neither. Prompt C interpolates $VIDEO_LENGTH, $VIDEO_ASPECT_RATIO, $VIDEO_AUDIO, $VIDEO_FPS. Delivers an HTML page with tabbed A/B/C copy buttons and a settings modal for live variable swaps. Trigger when the user says \"video transition prompt\", \"start frame to end frame\", \"animate between these images\", \"transition video from image to image\", or uploads a reference image and asks for a transition. Do NOT use for standalone image prompts (use scroll-stop-prompter) or for writing Runway/Kling UI copy.\n",
       "tags": [
         "video",
@@ -98,16 +104,18 @@
         "codex"
       ],
       "preserve": [
+        "references/raw/",
+        "references/wiki/",
         "references/decisions.md",
         "references/log.md",
         "references/patterns.md"
       ],
       "path": "skills/create-video-transition",
-      "dir_sha": "5fd78496ca10213c915a92696e731a2f9ff682477d6257e0966232562cf5351f"
+      "dir_sha": "7d773cff062e373fb31ccd558dcb50d1461239cb6a366e3f1ae5568a466231da"
     },
     {
       "name": "smart-claude-init",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "description": "Interview the user relentlessly, one question at a time with a recommended answer for each, to produce a clean iterated CLAUDE.md for a new project. Detects code vs non-code projects and fills a standard 8-section template (project intent, architecture, engineering preferences, code quality, testing, performance, bug protocol, task management and core principles). Use when the user says \"init CLAUDE.md\", \"set up CLAUDE.md\", \"grill me about my project\", \"smart-claude-init\", or wants a guided CLAUDE.md for a new repo. Do NOT use to mechanically document an existing codebase (use the built-in init skill), or to edit an already-good CLAUDE.md.\n",
       "tags": [
         "claude-md",
@@ -122,16 +130,18 @@
         "codex"
       ],
       "preserve": [
+        "references/raw/",
+        "references/wiki/",
         "references/decisions.md",
         "references/log.md",
         "references/patterns.md"
       ],
       "path": "skills/smart-claude-init",
-      "dir_sha": "bba278513a622f50d797186cafbe513b32e470fe96b4d666038bfd6380c76a91"
+      "dir_sha": "cb6a5fa0c3cff0dde4224f5480d7d340f4ede01cfd0380ff1a80bd69523e4199"
     },
     {
       "name": "smart-frontend-design",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "description": "Create distinctive, production-grade frontend interfaces with a synthesized design system and one style-defining intake question. Use when the user asks to build or redesign web components, pages, apps, dashboards, landing pages, UI flows, React/Vue/HTML/CSS interfaces, or \"make this look better\". Avoids generic AI aesthetics by discovering the existing frontend style before coding. Do NOT use for backend-only work, copy-only edits, or pure design critique where no frontend implementation is requested.\n",
       "tags": [
         "frontend",
@@ -148,16 +158,18 @@
         "codex"
       ],
       "preserve": [
+        "references/raw/",
+        "references/wiki/",
         "references/decisions.md",
         "references/log.md",
         "references/patterns.md"
       ],
       "path": "skills/smart-frontend-design",
-      "dir_sha": "21de90a8640c7eae15cb8d5c9ef80054e8eae86e475626724ccd94bde5236055"
+      "dir_sha": "e1950fe0bdd73effaef6432673bcbd86965322e88004fecb89a088d0e4164271"
     },
     {
       "name": "use-smart-commit",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "description": "Inspect the working tree, group pending changes into atomic related buckets, and author one conventional commit per bucket. Every message covers what changed, why, and the impact (what it resolves or unblocks). Use when the user says \"commit\", \"commit my changes\", \"make a commit\", \"stage and commit\", or after finishing a unit of work and wanting to land it. Do NOT use for squashing existing history, rebasing, force-pushing, or writing PR descriptions.\n",
       "tags": [
         "git",
@@ -172,16 +184,18 @@
         "codex"
       ],
       "preserve": [
+        "references/raw/",
+        "references/wiki/",
         "references/decisions.md",
         "references/log.md",
         "references/patterns.md"
       ],
       "path": "skills/use-smart-commit",
-      "dir_sha": "0f4a355a556548073524064572ea8fa5f326d6be27f621f33015ae0f76810f79"
+      "dir_sha": "e13f043316274e8a440e8cff2bea34cdf669151c19edc45221d8dbb2b9873614"
     },
     {
       "name": "use-smart-humanize-text",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "description": "Strip AI-generated writing patterns from text to make it sound authentically human. Use when writing or editing any content that must not read as AI-generated - outreach, blog posts, applications, social posts, emails, marketing copy. Detects and fixes AI vocabulary, structural tells, soulless tone, filler, hedging, and formatting artifacts. Based on Wikipedia's \"Signs of AI writing\" guide and associated research.\n",
       "platforms": [
         "claude-code",
@@ -189,16 +203,18 @@
         "codex"
       ],
       "preserve": [
+        "references/raw/",
+        "references/wiki/",
         "references/decisions.md",
         "references/log.md",
         "references/patterns.md"
       ],
       "path": "skills/use-smart-humanize-text",
-      "dir_sha": "dec55c238b532060a7394d289a8d41d267376753c7eefff9e521cce68a05adb5"
+      "dir_sha": "fe52b548bc7effa69d4075c3e7d66e2a440c1cb499c0b361deebee726c469830"
     },
     {
       "name": "use-smart-skill",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "description": "Scaffold production-grade humblSKILLS with progressive disclosure, self-learning memory (patterns/decisions/session log), and lint tooling. Use when creating a new humblSKILL (also known as a smart skill), scaffolding a SKILL.md, migrating a flat skill to a smart skill, refactoring a skill that exceeds ~300 lines, or adding memory/patterns tracking to an existing skill. Do NOT use for editing skill content after scaffold - use the skill directly. Uses CCCCC layering internally (Core/Context/Category/Concept/Command).\n",
       "tags": [
         "meta",
@@ -213,16 +229,18 @@
         "codex"
       ],
       "preserve": [
+        "references/raw/",
+        "references/wiki/",
         "references/decisions.md",
         "references/log.md",
         "references/patterns.md"
       ],
       "path": "skills/use-smart-skill",
-      "dir_sha": "5d396b0425d98db4650ededa01ab818d2d23748d65a099f18cfde4ad221d5673"
+      "dir_sha": "2e03a387029903a75f018970113d516cba566c4d68a5a1c51b03c2dc2a322a5a"
     },
     {
       "name": "use-upload-thing",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "description": "Drive the UploadThing REST API end-to-end from the shell: authenticate with an API key, upload files (v7 prepareUpload + ingest PUT), download by key or URL, and list, delete, rename, set ACLs, or read usage. Use when the user wants to upload/download/manage files on UploadThing, mentions UploadThing, ufs.sh, prepareUpload, an sk_live key, or \"put this file on UploadThing\". Also guides first-time API-key setup. Do NOT use for building an app's File Router / React upload components (that is the TS SDK), or for non-UploadThing storage (S3, GCS).\n",
       "tags": [
         "uploadthing",
@@ -238,16 +256,18 @@
         "codex"
       ],
       "preserve": [
+        "references/raw/",
+        "references/wiki/",
         "references/decisions.md",
         "references/log.md",
         "references/patterns.md"
       ],
       "path": "skills/use-upload-thing",
-      "dir_sha": "6d1cd72ded7355b78b8a869f51a726229dbf872b380adaccf989faa58f970bb4"
+      "dir_sha": "797402522983d5d2347fd3865af85dbfc45cd2aa05bb75fc8c120eabd8575801"
     },
     {
       "name": "use-worktree-flow",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "description": "Run a worktree-first development workflow from intent gathering through feature PR, develop merge, main merge, release PR, brew verification, and cleanup. Use when the user says \"worktree flow\", \"start a feature\", \"ship this feature\", \"PR into develop\", \"full dev workflow\", or wants a feature isolated from parallel agents. Do NOT use for atomic commit authoring (use use-smart-commit) or merge-conflict repair.\n",
       "tags": [
         "git",
@@ -263,12 +283,14 @@
         "codex"
       ],
       "preserve": [
+        "references/raw/",
+        "references/wiki/",
         "references/decisions.md",
         "references/log.md",
         "references/patterns.md"
       ],
       "path": "skills/use-worktree-flow",
-      "dir_sha": "4aaf93a15aa55f4d94006bb06615d3aae6855b7f476acb88c9c304fafbc3fb73"
+      "dir_sha": "9e6216a4d41cf260872b9317382c15be095f168075e4ebdf8657674cf252c3a8"
     }
   ]
 }

--- a/registry.json
+++ b/registry.json
@@ -1,10 +1,10 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-07-01T01:46:48Z",
+  "generated_at": "2026-07-01T02:26:44Z",
   "source": {
     "repo": "github.com/jjfantini/humblSKILLS",
     "ref": "cursor/preserve-wiki-raw-content-2f10",
-    "sha": "2570d2ad622e91a4f188a9ac226c6313a4f4c543"
+    "sha": "bd047a6c21166114be073cc97223934915382aa3"
   },
   "skills": [
     {

--- a/skills/analyze-ml-system-design/SKILL.md
+++ b/skills/analyze-ml-system-design/SKILL.md
@@ -4,10 +4,12 @@ description: Drive an ML system design from an ambiguous prompt to a production-
 license: MIT
 metadata:
   author: Jennings Fantini
-  version: "2.0.1"
+  version: "2.0.2"
   tags: [ml-system-design, interviews, machine-learning]
   platforms: [claude-code, cursor, codex]
   preserve:
+    - references/raw/
+    - references/wiki/
     - references/decisions.md
     - references/log.md
     - references/patterns.md

--- a/skills/analyze-system-design/SKILL.md
+++ b/skills/analyze-system-design/SKILL.md
@@ -4,10 +4,12 @@ description: Drive a system design interview from a blank prompt to a simple, co
 license: MIT
 metadata:
   author: Jennings Fantini
-  version: "2.0.1"
+  version: "2.0.2"
   tags: [system-design, interviews, architecture]
   platforms: [claude-code, cursor, codex]
   preserve:
+    - references/raw/
+    - references/wiki/
     - references/decisions.md
     - references/log.md
     - references/patterns.md

--- a/skills/create-scroll-animation/SKILL.md
+++ b/skills/create-scroll-animation/SKILL.md
@@ -16,10 +16,12 @@ compatibility: Requires ffmpeg and ffprobe on PATH; bash; Node 18+; a React 18+ 
 allowed-tools: "Read Write Edit Glob Grep Bash(ffmpeg:*) Bash(ffprobe:*) Bash(cwebp:*) Bash(bash:*) Bash(mkdir:*) Bash(cp:*) Bash(ls:*)"
 metadata:
   author: jjfantini
-  version: "0.1.1"
+  version: "0.1.2"
   tags: [scroll, canvas, framer-motion, nextjs, react, ffmpeg, webp, apple-style, hero, humblskill]
   platforms: [claude-code, cursor, codex]
   preserve:
+    - references/raw/
+    - references/wiki/
     - references/decisions.md
     - references/log.md
     - references/patterns.md

--- a/skills/create-video-transition/SKILL.md
+++ b/skills/create-video-transition/SKILL.md
@@ -18,10 +18,12 @@ compatibility: Requires a modern browser to open the HTML deliverable; an AI ima
 allowed-tools: "Read Write Edit Glob Grep Bash(open:*) Bash(xdg-open:*) Bash(bash:*) Bash(mkdir:*) Bash(ls:*)"
 metadata:
   author: jjfantini
-  version: "1.0.1"
+  version: "1.0.2"
   tags: [video, prompt, transition, image-generation, commercial-director, humblskill]
   platforms: [claude-code, cursor, codex]
   preserve:
+    - references/raw/
+    - references/wiki/
     - references/decisions.md
     - references/log.md
     - references/patterns.md

--- a/skills/smart-claude-init/SKILL.md
+++ b/skills/smart-claude-init/SKILL.md
@@ -15,10 +15,12 @@ compatibility: Requires bash and POSIX utilities (grep, sed) plus python3 for sc
 allowed-tools: "Bash(bash:*) Read Write Edit Glob Grep"
 metadata:
   author: jjfantini
-  version: "0.1.1"
+  version: "0.1.2"
   tags: [claude-md, onboarding, interview, project-setup, humblskill]
   platforms: [claude-code, cursor, codex]
   preserve:
+    - references/raw/
+    - references/wiki/
     - references/decisions.md
     - references/log.md
     - references/patterns.md

--- a/skills/smart-frontend-design/SKILL.md
+++ b/skills/smart-frontend-design/SKILL.md
@@ -12,10 +12,12 @@ license: MIT
 compatibility: "Requires python3 only for scripts/lint.sh. Frontend implementation uses whatever stack exists in the target repo."
 metadata:
   author: jjfantini
-  version: "1.0.1"
+  version: "1.0.2"
   tags: [frontend, design, ui, ux, react, css, humblskill]
   platforms: [claude-code, cursor, codex]
   preserve:
+    - references/raw/
+    - references/wiki/
     - references/decisions.md
     - references/log.md
     - references/patterns.md

--- a/skills/use-smart-commit/SKILL.md
+++ b/skills/use-smart-commit/SKILL.md
@@ -11,10 +11,12 @@ description: >
 license: MIT
 metadata:
   author: jjfantini
-  version: "1.0.1"
+  version: "1.0.2"
   tags: [git, commits, conventional-commits, workflow, humblskill]
   platforms: [claude-code, cursor, codex]
   preserve:
+    - references/raw/
+    - references/wiki/
     - references/decisions.md
     - references/log.md
     - references/patterns.md

--- a/skills/use-smart-humanize-text/SKILL.md
+++ b/skills/use-smart-humanize-text/SKILL.md
@@ -10,9 +10,11 @@ description: >
 license: MIT
 metadata:
   author: jjfantini
-  version: 2.0.1
+  version: 2.0.2
   platforms: [claude-code, cursor, codex]
   preserve:
+    - references/raw/
+    - references/wiki/
     - references/decisions.md
     - references/log.md
     - references/patterns.md

--- a/skills/use-smart-skill/SKILL.md
+++ b/skills/use-smart-skill/SKILL.md
@@ -14,10 +14,12 @@ compatibility: Requires bash, POSIX utilities (awk, sed, find, grep), python3, w
 allowed-tools: "Bash(bash:*) Bash(sh:*) Read Write Edit Glob Grep"
 metadata:
   author: jjfantini
-  version: 1.1.1
+  version: 1.1.2
   tags: [meta, skill-authoring, smart-skill, scaffolding, humblskill]
   platforms: [claude-code, cursor, codex]
   preserve:
+    - references/raw/
+    - references/wiki/
     - references/decisions.md
     - references/log.md
     - references/patterns.md

--- a/skills/use-upload-thing/SKILL.md
+++ b/skills/use-upload-thing/SKILL.md
@@ -12,10 +12,12 @@ license: MIT
 compatibility: "Requires bash, curl, jq, and network access to api.uploadthing.com. Needs an UploadThing API key via UPLOADTHING_API_KEY (or UPLOADTHING_TOKEN), or run scripts/auth.sh --save."
 metadata:
   author: jjfantini
-  version: "1.0.1"
+  version: "1.0.2"
   tags: [uploadthing, file-upload, storage, rest-api, ufs, humblskill]
   platforms: [claude-code, cursor, codex]
   preserve:
+    - references/raw/
+    - references/wiki/
     - references/decisions.md
     - references/log.md
     - references/patterns.md

--- a/skills/use-worktree-flow/SKILL.md
+++ b/skills/use-worktree-flow/SKILL.md
@@ -11,10 +11,12 @@ license: MIT
 compatibility: "Requires git 2.5+, GitHub CLI (`gh`) for PR/check operations, and network access for remote sync, CI, releases, and Homebrew verification."
 metadata:
   author: jjfantini
-  version: "1.0.1"
+  version: "1.0.2"
   tags: [git, worktree, pull-requests, release, workflow, humblskill]
   platforms: [claude-code, cursor, codex]
   preserve:
+    - references/raw/
+    - references/wiki/
     - references/decisions.md
     - references/log.md
     - references/patterns.md


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Every skill's own `references/_brain.md` spec (Territory table) defines `references/raw/` as **Human**-owned and `references/wiki/` as **LLM**-owned — both actively grow during real usage (the agent distills new wiki concepts and drops new raw sources per the Brain Protocol), exactly like `decisions.md`/`log.md`/`patterns.md`. Neither was in any skill's `preserve:` list, so `humblskills update` was silently deleting any wiki concepts the agent had learned or raw sources the user had added, on every update.

Added `references/raw/` and `references/wiki/` (directory entries → deep-merge semantics: upstream still wins on files that exist in both, but user/agent-added files survive) to all 11 skills' preserve lists. Bumped each skill's patch version; regenerated `registry.json`.

## Testing
- ✅ `make registry-check`
- ✅ `go -C cli vet ./...`
- ✅ `go -C cli test -race -count=1 ./...`
- Manual end-to-end verification via the real `humblskills install`/`update` commands (fake tarball pre-seeded at the fetcher's cache path, no network): shipped v1 with one wiki concept + one raw source, grew the local install with a new agent-authored wiki concept + a new user-provided raw source, then updated to a v2 that both improves the existing wiki concept and ships a brand-new one. Result: upstream's improvement applied, the new upstream concept appeared, AND both user/agent-added files survived untouched.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-13f6bd37-f2d6-44ba-8e8d-899054bc2f10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-13f6bd37-f2d6-44ba-8e8d-899054bc2f10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

