### PR TITLE
refactor(tui): remove unused dashboard greeting scaffolding

### DIFF
--- a/cli/internal/tui/dashboard.go
+++ b/cli/internal/tui/dashboard.go
@@ -2,8 +2,6 @@ package tui
 
 import (
 	"fmt"
-	"os"
-	"os/user"
 	"strings"
 
 	"github.com/charmbracelet/bubbles/viewport"
@@ -32,16 +30,6 @@ type DashboardTile struct {
 	Aliases []string // additional fuzzy-search keywords
 }
 
-// DashboardGreeting is retained for API compatibility but is no longer
-// rendered in the dashboard body — the top header already shows the status
-// line, so a duplicate greeting row was redundant noise.
-type DashboardGreeting struct {
-	User     string
-	Updates  int
-	Cwd      string
-	LastScan string
-}
-
 // DashboardStatus feeds the header's right-anchored summary
 // (● healthy · N platforms · M skills). This is also what every sub-screen
 // echoes in its own header so the layout is consistent across screens.
@@ -53,11 +41,10 @@ type DashboardStatus struct {
 
 // DashboardConfig bundles everything RunDashboard needs.
 type DashboardConfig struct {
-	Theme    *ui.Theme
-	Version  string
-	Greeting DashboardGreeting
-	Status   DashboardStatus
-	Tiles    []DashboardTile
+	Theme   *ui.Theme
+	Version string
+	Status  DashboardStatus
+	Tiles   []DashboardTile
 }
 
 // RunDashboard opens the full-screen launcher (bubbletea alt-screen) and
@@ -98,31 +85,6 @@ func DefaultDashboardTiles() []DashboardTile {
 		{Command: "version", Label: "version", Hotkey: "V", Desc: "show build info", Sub: "version · commit", Aliases: []string{"about", "ver"}},
 		{Command: "upgrade", Label: "upgrade", Hotkey: "U", Desc: "upgrade the humblskills CLI itself", Sub: "github releases · checksum verified", Aliases: []string{"self-update"}},
 	}
-}
-
-// BuildDashboardGreeting fills the defaults the dashboard banner needs.
-// Kept for API compatibility — callers may still pass this, but it isn't
-// rendered. (See DashboardGreeting.)
-func BuildDashboardGreeting(updates int) DashboardGreeting {
-	g := DashboardGreeting{Updates: updates}
-	if u, err := user.Current(); err == nil && u.Username != "" {
-		g.User = u.Username
-	}
-	if cwd, err := os.Getwd(); err == nil {
-		g.Cwd = compactPath(cwd)
-	}
-	return g
-}
-
-func compactPath(p string) string {
-	home, err := os.UserHomeDir()
-	if err != nil || home == "" {
-		return p
-	}
-	if strings.HasPrefix(p, home) {
-		return "~" + strings.TrimPrefix(p, home)
-	}
-	return p
 }
 
 // dashboardModel is the bubbletea model for the launcher.

--- a/cli/internal/tui/dashboard_test.go
+++ b/cli/internal/tui/dashboard_test.go
@@ -1,8 +1,6 @@
 package tui
 
 import (
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 
@@ -39,38 +37,6 @@ func TestDefaultDashboardTiles_Shape(t *testing.T) {
 		if !commands[want] {
 			t.Errorf("missing dashboard command %q", want)
 		}
-	}
-}
-
-func TestBuildDashboardGreeting_PopulatesFields(t *testing.T) {
-	g := BuildDashboardGreeting(5)
-	if g.Updates != 5 {
-		t.Errorf("Updates = %d", g.Updates)
-	}
-	// User & Cwd may be empty in sandboxed CI — just sanity-check types.
-	_ = g.User
-	_ = g.Cwd
-}
-
-func TestCompactPath(t *testing.T) {
-	// Use a real tempdir as the "home" so the path separators match
-	// whatever the OS natively produces. Point both HOME and
-	// USERPROFILE at it — Unix reads $HOME, Windows reads %USERPROFILE%.
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	t.Setenv("USERPROFILE", home)
-
-	inside := filepath.Join(home, "work", "x")
-	if got := compactPath(inside); !strings.HasPrefix(got, "~") {
-		t.Errorf("compactPath should prefix ~: %q", got)
-	}
-
-	// A path unrelated to home passes through unchanged. Use the OS's
-	// temp dir root so we get an actually-unrelated absolute path on
-	// every platform.
-	unrelated := filepath.Join(os.TempDir(), "definitely-not-home-"+filepath.Base(home))
-	if got := compactPath(unrelated); got != unrelated {
-		t.Errorf("unrelated path changed: got %q want %q", got, unrelated)
 	}
 }
 

--- a/registry.json
+++ b/registry.json
@@ -1,10 +1,10 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-07-01T03:20:46Z",
+  "generated_at": "2026-07-01T03:36:43Z",
   "source": {
     "repo": "github.com/jjfantini/humblSKILLS",
-    "ref": "develop",
-    "sha": "3d0af4b161975be7b41ee8ee9891f125befa67c2"
+    "ref": "cursor/refactor-remove-dead-dashboard-greeting-edb2",
+    "sha": "5ba6045a9c5cf76f74908bd5c879b35674cdb7e3"
   },
   "skills": [
     {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Category: cleanup / internal simplification (no functionality change)

### What
Removes dead code in `internal/tui/dashboard.go`:
- `DashboardGreeting` struct
- `BuildDashboardGreeting()` constructor
- `compactPath()` helper
- `DashboardConfig.Greeting` field
- the two tests that only exercised the above

### Why
The code carried a comment saying it was "retained for API compatibility but is no longer rendered." But this all lives in an **internal** package (`internal/tui`), so there is no external API to preserve, and nothing sets `cfg.Greeting` (`start.go` builds `DashboardConfig` without it). It was pure dead weight plus two tests testing unused code.

Grep confirms the only references outside `dashboard.go` were in `dashboard_test.go`.

### Risk
Very low. No behavior change; the greeting was never drawn. Build, `go vet`, and `internal/tui` tests pass.

### Testing
- `make build`
- `go -C cli vet ./internal/tui/`
- `go -C cli test ./internal/tui/`

---
*Draft proposal from a codebase-improvement research pass. Confirm to keep or scrap.*
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1bb3-3368-7e27-b650-cd1478cbedb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1bb3-3368-7e27-b650-cd1478cbedb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

