### PR TITLE
refactor: centralize plural / first-non-empty helpers in internal/textutil

### DIFF
--- a/cli/cmd/build-registry/main.go
+++ b/cli/cmd/build-registry/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/jjfantini/humblSKILLS/cli/internal/frontmatter"
 	"github.com/jjfantini/humblSKILLS/cli/internal/registry"
 	"github.com/jjfantini/humblSKILLS/cli/internal/resolver"
+	"github.com/jjfantini/humblSKILLS/cli/internal/textutil"
 )
 
 const defaultRepo = "github.com/jjfantini/humblSKILLS"
@@ -117,10 +118,10 @@ func run(skillsDir, outFile, repo, ref, sha string, check bool) error {
 	sort.Slice(skills, func(i, j int) bool { return skills[i].Name < skills[j].Name })
 
 	if ref == "" {
-		ref = firstNonEmpty(os.Getenv("GITHUB_REF_NAME"), gitBranch(), "main")
+		ref = textutil.FirstNonEmpty(os.Getenv("GITHUB_REF_NAME"), gitBranch(), "main")
 	}
 	if sha == "" {
-		sha = firstNonEmpty(os.Getenv("GITHUB_SHA"), gitHeadSHA())
+		sha = textutil.FirstNonEmpty(os.Getenv("GITHUB_SHA"), gitHeadSHA())
 	}
 	generatedAt := commitTime()
 	if generatedAt == "" {
@@ -260,15 +261,6 @@ func writeAtomic(path string, data []byte) error {
 		return err
 	}
 	return nil
-}
-
-func firstNonEmpty(vals ...string) string {
-	for _, v := range vals {
-		if v != "" {
-			return v
-		}
-	}
-	return ""
 }
 
 func gitHeadSHA() string {

--- a/cli/cmd/build-registry/main_test.go
+++ b/cli/cmd/build-registry/main_test.go
@@ -227,15 +227,6 @@ func TestMarshalStable_NoHTMLEscape(t *testing.T) {
 	}
 }
 
-func TestFirstNonEmpty(t *testing.T) {
-	if got := firstNonEmpty("", "b"); got != "b" {
-		t.Errorf("got %q", got)
-	}
-	if got := firstNonEmpty(); got != "" {
-		t.Errorf("got %q", got)
-	}
-}
-
 func TestSemanticDiff_IgnoresSourceAndGeneratedAt(t *testing.T) {
 	a := []byte(`{"schema_version":1,"generated_at":"t1","source":{"repo":"x","ref":"main","sha":"a"},"skills":[]}`)
 	b := []byte(`{"schema_version":1,"generated_at":"t2","source":{"repo":"x","ref":"main","sha":"b"},"skills":[]}`)

--- a/cli/cmd/humblskills/browse_skills.go
+++ b/cli/cmd/humblskills/browse_skills.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/jjfantini/humblSKILLS/cli/internal/manifest"
 	"github.com/jjfantini/humblSKILLS/cli/internal/registry"
+	"github.com/jjfantini/humblSKILLS/cli/internal/textutil"
 	"github.com/jjfantini/humblSKILLS/cli/internal/tui"
 	"github.com/jjfantini/humblSKILLS/cli/internal/ui"
 )
@@ -243,7 +244,7 @@ func runSkillBrowser(app *App, section string, skills []skillItem, mode skillsBr
 		}
 	}
 	localMeta := func(items []tui.Item, _ int) string {
-		parts := []string{fmt.Sprintf("%d skill%s", len(items), plural(len(items)))}
+		parts := []string{fmt.Sprintf("%d skill%s", len(items), textutil.Plural(len(items)))}
 		if installedCount > 0 {
 			parts = append(parts, fmt.Sprintf("%d installed", installedCount))
 		}

--- a/cli/cmd/humblskills/doctor.go
+++ b/cli/cmd/humblskills/doctor.go
@@ -19,6 +19,7 @@ import (
 	"github.com/jjfantini/humblSKILLS/cli/internal/manifest"
 	"github.com/jjfantini/humblSKILLS/cli/internal/registry"
 	"github.com/jjfantini/humblSKILLS/cli/internal/secrets"
+	"github.com/jjfantini/humblSKILLS/cli/internal/textutil"
 	"github.com/jjfantini/humblSKILLS/cli/internal/tui"
 	"github.com/jjfantini/humblSKILLS/cli/internal/ui"
 )
@@ -362,7 +363,7 @@ func runDoctorTUI(app *App, r doctorReport) (bool, error) {
 			parts = append(parts, "registry error")
 		}
 		if r.Updates.Count > 0 {
-			parts = append(parts, fmt.Sprintf("%d update%s", r.Updates.Count, plural(r.Updates.Count)))
+			parts = append(parts, fmt.Sprintf("%d update%s", r.Updates.Count, textutil.Plural(r.Updates.Count)))
 		}
 		return strings.Join(parts, " · ")
 	}
@@ -608,7 +609,7 @@ func (i evalItem) Detail(th *ui.Theme, width int) string {
 	if i.e.Workspace.Exists {
 		sb.WriteString(kvRow(th, "size",
 			th.KVValue.Render(fmt.Sprintf("%d iteration%s · %s",
-				i.e.Workspace.IterationCount, plural(i.e.Workspace.IterationCount),
+				i.e.Workspace.IterationCount, textutil.Plural(i.e.Workspace.IterationCount),
 				workspace.HumanSize(i.e.Workspace.SizeBytes)))))
 	}
 	sb.WriteString(kvRow(th, "default", th.KVValue.Render(nonEmptyOrDash(i.e.DefaultRunner))))
@@ -622,7 +623,7 @@ func (i evalItem) Detail(th *ui.Theme, width int) string {
 			status = th.Error.Render("missing")
 		}
 		sb.WriteString(fmt.Sprintf("  %s %s  %s  %s\n",
-			dot, th.Name.Render(padRight(r.Name, 14)), status, th.Detail.Render(firstNonEmptyStr(r.Version, r.Reason))))
+			dot, th.Name.Render(padRight(r.Name, 14)), status, th.Detail.Render(textutil.FirstNonBlank(r.Version, r.Reason))))
 		if !r.Available && r.Fix != "" {
 			sb.WriteString("    " + th.Detail.Render("fix: "+r.Fix) + "\n")
 		}
@@ -765,7 +766,7 @@ func printDoctorStatic(app *App, r doctorReport) {
 	if _, err := os.Stat(r.Manifest.Path); err == nil {
 		app.UI.Info("  %s %s",
 			th.Name.Render(r.Manifest.Path),
-			th.Detail.Render(fmt.Sprintf("(%d install%s)", r.Manifest.Installs, plural(r.Manifest.Installs))),
+			th.Detail.Render(fmt.Sprintf("(%d install%s)", r.Manifest.Installs, textutil.Plural(r.Manifest.Installs))),
 		)
 	} else {
 		app.UI.Detail("  %s (not yet created)", r.Manifest.Path)
@@ -776,7 +777,7 @@ func printDoctorStatic(app *App, r doctorReport) {
 	if r.Registry.Error != "" {
 		app.UI.Error("registry unreachable: %s", r.Registry.Error)
 	} else {
-		app.UI.Success("%d skill%s available (via %s)", r.Registry.Skills, plural(r.Registry.Skills), r.Registry.Source)
+		app.UI.Success("%d skill%s available (via %s)", r.Registry.Skills, textutil.Plural(r.Registry.Skills), r.Registry.Source)
 		if r.Registry.Cached {
 			app.UI.Detail("  cache fetched %s ago", r.Registry.Age.Round(time.Second))
 		}
@@ -787,7 +788,7 @@ func printDoctorStatic(app *App, r doctorReport) {
 
 	if r.Updates.Count > 0 {
 		app.UI.Section("Updates")
-		app.UI.Warn("%d skill%s can be updated — run 'humblskills update'", r.Updates.Count, plural(r.Updates.Count))
+		app.UI.Warn("%d skill%s can be updated — run 'humblskills update'", r.Updates.Count, textutil.Plural(r.Updates.Count))
 		for _, name := range r.Updates.Skills {
 			app.UI.Detail("  • %s", name)
 		}
@@ -848,11 +849,4 @@ func printEvalStatic(app *App, e evalReport) {
 	} else {
 		app.UI.Detail("  default runner: %s", e.DefaultRunner)
 	}
-}
-
-func plural(n int) string {
-	if n == 1 {
-		return ""
-	}
-	return "s"
 }

--- a/cli/cmd/humblskills/eval.go
+++ b/cli/cmd/humblskills/eval.go
@@ -27,6 +27,7 @@ import (
 	"github.com/jjfantini/humblSKILLS/cli/internal/manifest"
 	"github.com/jjfantini/humblSKILLS/cli/internal/profile"
 	"github.com/jjfantini/humblSKILLS/cli/internal/secrets"
+	"github.com/jjfantini/humblSKILLS/cli/internal/textutil"
 	"github.com/jjfantini/humblSKILLS/cli/internal/tui"
 )
 
@@ -473,7 +474,7 @@ func runEvalRunners(app *App) error {
 		if r.Check.Available {
 			status = "ready"
 		}
-		app.UI.Info("  %-16s %s  %s", r.Name, status, firstNonEmptyStr(r.Check.Version, r.Check.Reason))
+		app.UI.Info("  %-16s %s  %s", r.Name, status, textutil.FirstNonBlank(r.Check.Version, r.Check.Reason))
 		if !r.Check.Available && r.Check.Fix != "" {
 			app.UI.Detail("    fix: %s", r.Check.Fix)
 		}
@@ -894,15 +895,6 @@ func knownProviders() []string {
 		out = append(out, p.Name)
 	}
 	return out
-}
-
-func firstNonEmptyStr(vs ...string) string {
-	for _, v := range vs {
-		if strings.TrimSpace(v) != "" {
-			return v
-		}
-	}
-	return ""
 }
 
 func abbreviate(s string, max int) string {

--- a/cli/cmd/humblskills/install.go
+++ b/cli/cmd/humblskills/install.go
@@ -11,6 +11,7 @@ import (
 	"github.com/jjfantini/humblSKILLS/cli/internal/manifest"
 	"github.com/jjfantini/humblSKILLS/cli/internal/profile"
 	"github.com/jjfantini/humblSKILLS/cli/internal/registry"
+	"github.com/jjfantini/humblSKILLS/cli/internal/textutil"
 	"github.com/jjfantini/humblSKILLS/cli/internal/tui"
 )
 
@@ -281,7 +282,7 @@ func printInstall(app *App, r install.Result) {
 		app.UI.Detail("already up-to-date: %s [%s/%s]", t.Skill, t.Platform, t.Scope)
 	}
 	if len(installed)+len(replaced)+len(forced) == 0 {
-		app.UI.Info("%d target%s already up-to-date (use --force to reinstall)", len(skipped), plural(len(skipped)))
+		app.UI.Info("%d target%s already up-to-date (use --force to reinstall)", len(skipped), textutil.Plural(len(skipped)))
 	}
 }
 

--- a/cli/cmd/humblskills/list.go
+++ b/cli/cmd/humblskills/list.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/jjfantini/humblSKILLS/cli/internal/manifest"
 	"github.com/jjfantini/humblSKILLS/cli/internal/registry"
+	"github.com/jjfantini/humblSKILLS/cli/internal/textutil"
 	"github.com/jjfantini/humblSKILLS/cli/internal/tui"
 )
 
@@ -92,7 +93,7 @@ func renderListTable(app *App, installs []manifest.Installation) {
 		})
 	fmt.Fprintln(app.UI.Out(), tbl.Render())
 	fmt.Fprintln(app.UI.Out(), "  "+th.Crumb.Render(fmt.Sprintf(
-		"%d install%s total", len(installs), plural(len(installs)))))
+		"%d install%s total", len(installs), textutil.Plural(len(installs)))))
 }
 
 // runListTUI opens the shared two-pane browser in installed-only mode so list

--- a/cli/cmd/humblskills/registry.go
+++ b/cli/cmd/humblskills/registry.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/jjfantini/humblSKILLS/cli/internal/profile"
 	"github.com/jjfantini/humblSKILLS/cli/internal/registry"
+	"github.com/jjfantini/humblSKILLS/cli/internal/textutil"
 	"github.com/jjfantini/humblSKILLS/cli/internal/tui"
 )
 
@@ -68,7 +69,7 @@ func runRegistryRefresh(app *App) error {
 					return tui.StatusResult{}, err
 				}
 				return tui.StatusResult{
-					Headline: fmt.Sprintf("registry refreshed: %d skill%s from %s", res.Skills, plural(res.Skills), res.Source),
+					Headline: fmt.Sprintf("registry refreshed: %d skill%s from %s", res.Skills, textutil.Plural(res.Skills), res.Source),
 					Lines:    []string{"cache: " + res.CachePath},
 				}, nil
 			})
@@ -87,7 +88,7 @@ func runRegistryRefresh(app *App) error {
 	if app.Config.JSON {
 		return app.UI.JSON(res)
 	}
-	app.UI.Success("registry refreshed: %d skill%s from %s", res.Skills, plural(res.Skills), res.Source)
+	app.UI.Success("registry refreshed: %d skill%s from %s", res.Skills, textutil.Plural(res.Skills), res.Source)
 	app.UI.Detail("  cache: %s", res.CachePath)
 	return nil
 }

--- a/cli/cmd/humblskills/root.go
+++ b/cli/cmd/humblskills/root.go
@@ -13,6 +13,7 @@ import (
 	"github.com/jjfantini/humblSKILLS/cli/internal/manifest"
 	"github.com/jjfantini/humblSKILLS/cli/internal/profile"
 	"github.com/jjfantini/humblSKILLS/cli/internal/registry"
+	"github.com/jjfantini/humblSKILLS/cli/internal/textutil"
 	"github.com/jjfantini/humblSKILLS/cli/internal/tui"
 	"github.com/jjfantini/humblSKILLS/cli/internal/ui"
 )
@@ -149,7 +150,7 @@ func configureApp(_ *cobra.Command, app *App, g globalFlags) error {
 	}
 
 	cfg := Config{
-		RegistryURL: firstNonEmpty(g.registry, os.Getenv("HUMBLSKILLS_REGISTRY"), registry.DefaultURL),
+		RegistryURL: textutil.FirstNonEmpty(g.registry, os.Getenv("HUMBLSKILLS_REGISTRY"), registry.DefaultURL),
 		JSON:        g.json,
 		NoColor:     g.noColor,
 		Verbose:     g.verbose,
@@ -158,19 +159,19 @@ func configureApp(_ *cobra.Command, app *App, g globalFlags) error {
 		Fullscreen:  g.fullscreen,
 	}
 
-	cacheDir, err := resolveCacheDir(firstNonEmpty(g.cacheDir, os.Getenv("HUMBLSKILLS_CACHE_DIR")))
+	cacheDir, err := resolveCacheDir(textutil.FirstNonEmpty(g.cacheDir, os.Getenv("HUMBLSKILLS_CACHE_DIR")))
 	if err != nil {
 		return err
 	}
 	cfg.CacheDir = cacheDir
 
-	manifestPath, err := resolveManifestPath(firstNonEmpty(g.manifest, os.Getenv("HUMBLSKILLS_MANIFEST")))
+	manifestPath, err := resolveManifestPath(textutil.FirstNonEmpty(g.manifest, os.Getenv("HUMBLSKILLS_MANIFEST")))
 	if err != nil {
 		return err
 	}
 	cfg.ManifestPath = manifestPath
 
-	profilePath, err := resolveProfilePath(firstNonEmpty(g.profile, os.Getenv("HUMBLSKILLS_PROFILE")))
+	profilePath, err := resolveProfilePath(textutil.FirstNonEmpty(g.profile, os.Getenv("HUMBLSKILLS_PROFILE")))
 	if err != nil {
 		return err
 	}
@@ -208,13 +209,4 @@ func resolveProfilePath(override string) (string, error) {
 		return override, nil
 	}
 	return profile.DefaultPath()
-}
-
-func firstNonEmpty(vs ...string) string {
-	for _, v := range vs {
-		if v != "" {
-			return v
-		}
-	}
-	return ""
 }

--- a/cli/cmd/humblskills/root_test.go
+++ b/cli/cmd/humblskills/root_test.go
@@ -46,18 +46,6 @@ func TestRoot_UnknownCommandErrors(t *testing.T) {
 	}
 }
 
-func TestFirstNonEmpty(t *testing.T) {
-	if got := firstNonEmpty("", "", "c", "d"); got != "c" {
-		t.Errorf("got %q", got)
-	}
-	if got := firstNonEmpty("", ""); got != "" {
-		t.Errorf("got %q", got)
-	}
-	if got := firstNonEmpty("a"); got != "a" {
-		t.Errorf("got %q", got)
-	}
-}
-
 func TestResolveCacheDir_Override(t *testing.T) {
 	got, err := resolveCacheDir("/tmp/override")
 	if err != nil {

--- a/cli/cmd/humblskills/uninstall.go
+++ b/cli/cmd/humblskills/uninstall.go
@@ -8,6 +8,7 @@ import (
 	"github.com/jjfantini/humblSKILLS/cli/internal/install"
 	"github.com/jjfantini/humblSKILLS/cli/internal/manifest"
 	"github.com/jjfantini/humblSKILLS/cli/internal/registry"
+	"github.com/jjfantini/humblSKILLS/cli/internal/textutil"
 	"github.com/jjfantini/humblSKILLS/cli/internal/tui"
 )
 
@@ -98,7 +99,7 @@ func runUninstall(app *App, skill string) error {
 		got, err := tui.ConfirmWithSummary(
 			theme,
 			fmt.Sprintf("Uninstall %s", skill),
-			fmt.Sprintf("Remove %d target%s?", len(entries), plural(len(entries))),
+			fmt.Sprintf("Remove %d target%s?", len(entries), textutil.Plural(len(entries))),
 			lines,
 			true,
 			app.Prompt.Interactive,

--- a/cli/cmd/humblskills/update.go
+++ b/cli/cmd/humblskills/update.go
@@ -12,6 +12,7 @@ import (
 	"github.com/jjfantini/humblSKILLS/cli/internal/manifest"
 	"github.com/jjfantini/humblSKILLS/cli/internal/profile"
 	"github.com/jjfantini/humblSKILLS/cli/internal/registry"
+	"github.com/jjfantini/humblSKILLS/cli/internal/textutil"
 	"github.com/jjfantini/humblSKILLS/cli/internal/tui"
 	"github.com/jjfantini/humblSKILLS/cli/internal/ui"
 )
@@ -259,7 +260,7 @@ func (u updatePlanItem) FilterValue() string {
 }
 func (u updatePlanItem) NaturalWidth(th *ui.Theme) int {
 	ver := u.p.FromVersion + " → " + u.p.ToVersion
-	badge := tui.Badge(th, tui.BadgeRO, fmt.Sprintf("%d target%s", len(u.p.Targets), plural(len(u.p.Targets))))
+	badge := tui.Badge(th, tui.BadgeRO, fmt.Sprintf("%d target%s", len(u.p.Targets), textutil.Plural(len(u.p.Targets))))
 	// 1 (arrow) + 1 (space) + skill + 2 (gap) + version + 2 (gap) + badge.
 	return 1 + 1 + lipgloss.Width(u.p.Skill) + 2 + lipgloss.Width(ver) + 2 + lipgloss.Width(badge)
 }
@@ -267,7 +268,7 @@ func (u updatePlanItem) Row(th *ui.Theme, width int, selected bool) string {
 	arrow := th.DotWarn.Render("↑")
 	name := rowName(th, u.p.Skill, selected, true)
 	ver := th.Version.Render(u.p.FromVersion + " → " + u.p.ToVersion)
-	badge := tui.Badge(th, tui.BadgeRO, fmt.Sprintf("%d target%s", len(u.p.Targets), plural(len(u.p.Targets))))
+	badge := tui.Badge(th, tui.BadgeRO, fmt.Sprintf("%d target%s", len(u.p.Targets), textutil.Plural(len(u.p.Targets))))
 	return rowWithTrailingBadge(arrow+" "+name+"  "+ver, badge, width)
 }
 func (u updatePlanItem) Detail(th *ui.Theme, width int) string {
@@ -303,10 +304,10 @@ func printUpdateCheck(app *App, plans []install.UpdatePlan) error {
 		app.UI.Info("all skills are up-to-date")
 		return nil
 	}
-	app.UI.Info("%d skill%s can be updated:", len(plans), plural(len(plans)))
+	app.UI.Info("%d skill%s can be updated:", len(plans), textutil.Plural(len(plans)))
 	for _, p := range plans {
 		app.UI.Detail("  %s  %s → %s  (%d target%s)",
-			p.Skill, p.FromVersion, p.ToVersion, len(p.Targets), plural(len(p.Targets)))
+			p.Skill, p.FromVersion, p.ToVersion, len(p.Targets), textutil.Plural(len(p.Targets)))
 	}
 	return nil
 }

--- a/cli/internal/textutil/textutil.go
+++ b/cli/internal/textutil/textutil.go
@@ -1,0 +1,39 @@
+// Package textutil holds tiny string/formatting helpers shared across the CLI
+// and TUI. They previously existed as near-identical private copies in several
+// packages (plural/pluralDash/plural2, firstNonEmpty/firstNonEmptyStr); this
+// package is the single source of truth.
+package textutil
+
+import "strings"
+
+// Plural returns the English plural suffix for a count: "" for exactly one,
+// "s" otherwise. Use as fmt.Sprintf("%d skill%s", n, textutil.Plural(n)).
+func Plural(n int) string {
+	if n == 1 {
+		return ""
+	}
+	return "s"
+}
+
+// FirstNonEmpty returns the first argument that is not the empty string, or ""
+// if every argument is empty. Whitespace-only strings count as non-empty.
+func FirstNonEmpty(vs ...string) string {
+	for _, v := range vs {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// FirstNonBlank returns the first argument that contains a non-whitespace
+// character, or "" if none do. Unlike FirstNonEmpty, a value that is only
+// whitespace is skipped. The returned value is the original (untrimmed) string.
+func FirstNonBlank(vs ...string) string {
+	for _, v := range vs {
+		if strings.TrimSpace(v) != "" {
+			return v
+		}
+	}
+	return ""
+}

--- a/cli/internal/textutil/textutil_test.go
+++ b/cli/internal/textutil/textutil_test.go
@@ -1,0 +1,35 @@
+package textutil
+
+import "testing"
+
+func TestPlural(t *testing.T) {
+	cases := map[int]string{0: "s", 1: "", 2: "s", -1: "s", 100: "s"}
+	for n, want := range cases {
+		if got := Plural(n); got != want {
+			t.Errorf("Plural(%d) = %q, want %q", n, got, want)
+		}
+	}
+}
+
+func TestFirstNonEmpty(t *testing.T) {
+	if got := FirstNonEmpty("", "", "a", "b"); got != "a" {
+		t.Errorf("got %q, want a", got)
+	}
+	if got := FirstNonEmpty("", ""); got != "" {
+		t.Errorf("got %q, want empty", got)
+	}
+	// Whitespace counts as non-empty for FirstNonEmpty.
+	if got := FirstNonEmpty("", "  ", "x"); got != "  " {
+		t.Errorf("got %q, want two spaces", got)
+	}
+}
+
+func TestFirstNonBlank(t *testing.T) {
+	// Whitespace-only values are skipped; the original (untrimmed) value wins.
+	if got := FirstNonBlank("", "  ", "  hi ", "x"); got != "  hi " {
+		t.Errorf("got %q, want '  hi '", got)
+	}
+	if got := FirstNonBlank("", "   "); got != "" {
+		t.Errorf("got %q, want empty", got)
+	}
+}

--- a/cli/internal/tui/dashboard.go
+++ b/cli/internal/tui/dashboard.go
@@ -11,6 +11,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/sahilm/fuzzy"
 
+	"github.com/jjfantini/humblSKILLS/cli/internal/textutil"
 	"github.com/jjfantini/humblSKILLS/cli/internal/ui"
 )
 
@@ -458,8 +459,8 @@ func RenderStatusMeta(theme *ui.Theme, status DashboardStatus) string {
 	}
 	sep := theme.Crumb.Render(" · ")
 	return dot.Render("●") + " " + theme.Detail.Render(label) +
-		sep + theme.Detail.Render(fmt.Sprintf("%d platform%s", status.Platforms, pluralDash(status.Platforms))) +
-		sep + theme.Detail.Render(fmt.Sprintf("%d skill%s", status.Skills, pluralDash(status.Skills)))
+		sep + theme.Detail.Render(fmt.Sprintf("%d platform%s", status.Platforms, textutil.Plural(status.Platforms))) +
+		sep + theme.Detail.Render(fmt.Sprintf("%d skill%s", status.Skills, textutil.Plural(status.Skills)))
 }
 
 // bodyWidth is the usable width between left/right margins. Every body
@@ -666,11 +667,4 @@ func truncateDisplay(s string, width int) string {
 		runes = runes[:len(runes)-1]
 	}
 	return string(runes) + "…"
-}
-
-func pluralDash(n int) string {
-	if n == 1 {
-		return ""
-	}
-	return "s"
 }

--- a/cli/internal/tui/dashboard_test.go
+++ b/cli/internal/tui/dashboard_test.go
@@ -207,8 +207,8 @@ func TestDashboardModel_EnterLaunchesCursor(t *testing.T) {
 
 func TestTruncateDisplay(t *testing.T) {
 	cases := map[string]int{
-		"hello":                       10,
-		"this is a very long string":  10,
+		"hello":                      10,
+		"this is a very long string": 10,
 	}
 	for in, width := range cases {
 		got := truncateDisplay(in, width)
@@ -226,15 +226,6 @@ func TestIndentBlock_AddsLeadingSpaces(t *testing.T) {
 		if !strings.HasPrefix(line, "    ") {
 			t.Errorf("line not indented: %q", line)
 		}
-	}
-}
-
-func TestPluralDash(t *testing.T) {
-	if pluralDash(1) != "" {
-		t.Errorf("1 should not pluralize: %q", pluralDash(1))
-	}
-	if pluralDash(2) != "s" {
-		t.Errorf("2 should pluralize: %q", pluralDash(2))
 	}
 }
 

--- a/cli/internal/tui/listdetail.go
+++ b/cli/internal/tui/listdetail.go
@@ -9,6 +9,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 
+	"github.com/jjfantini/humblSKILLS/cli/internal/textutil"
 	"github.com/jjfantini/humblSKILLS/cli/internal/ui"
 )
 
@@ -89,18 +90,18 @@ type Result struct {
 
 // Model is the shared two-pane bubbletea model.
 type Model struct {
-	cfg      Config
-	items    []Item // filtered view (equal to cfg.Items when filter is empty)
-	cursor   int
-	width    int
-	height   int
-	preview  viewport.Model
-	filter   textinput.Model
-	filtOn   bool
-	result   Result
-	keys     Keys
-	actions  map[string]ActionSpec // keyed by ActionSpec.Key
-	done     bool
+	cfg     Config
+	items   []Item // filtered view (equal to cfg.Items when filter is empty)
+	cursor  int
+	width   int
+	height  int
+	preview viewport.Model
+	filter  textinput.Model
+	filtOn  bool
+	result  Result
+	keys    Keys
+	actions map[string]ActionSpec // keyed by ActionSpec.Key
+	done    bool
 }
 
 // NewListDetail builds a Model ready for Run.
@@ -462,7 +463,7 @@ func (m Model) renderLeft(width int) string {
 	}
 
 	if len(m.items) == 0 {
-		empty := "  " + th.Detail.Render(firstNonEmpty(m.cfg.EmptyMsg, "— no items —"))
+		empty := "  " + th.Detail.Render(textutil.FirstNonEmpty(m.cfg.EmptyMsg, "— no items —"))
 		return pad(title) + "\n\n" + pad(empty)
 	}
 
@@ -590,13 +591,4 @@ func padLeft(s string, width int) string {
 		return s
 	}
 	return s + strings.Repeat(" ", width-w)
-}
-
-func firstNonEmpty(vs ...string) string {
-	for _, v := range vs {
-		if v != "" {
-			return v
-		}
-	}
-	return ""
 }

--- a/cli/internal/tui/profile.go
+++ b/cli/internal/tui/profile.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/jjfantini/humblSKILLS/cli/internal/adapters"
 	"github.com/jjfantini/humblSKILLS/cli/internal/profile"
+	"github.com/jjfantini/humblSKILLS/cli/internal/textutil"
 	"github.com/jjfantini/humblSKILLS/cli/internal/ui"
 )
 
@@ -578,7 +579,7 @@ func (m profileModel) settingBadge(key string) string {
 			return "all detected"
 		}
 		return fmt.Sprintf("%d platform%s", len(m.profile.DefaultPlatforms),
-			plural2(len(m.profile.DefaultPlatforms)))
+			textutil.Plural(len(m.profile.DefaultPlatforms)))
 	case "scope":
 		switch resolved := m.profile.ResolvedScope(); resolved {
 		case profile.ScopeGlobal:
@@ -641,13 +642,6 @@ func (m profileModel) hints() []KeyHint {
 		{Keys: "esc", Label: "back"},
 		{Keys: "q", Label: "quit"},
 	}
-}
-
-func plural2(n int) string {
-	if n == 1 {
-		return ""
-	}
-	return "s"
 }
 
 // --- per-install modal (moved) ----------------------------------------------

--- a/registry.json
+++ b/registry.json
@@ -1,10 +1,10 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-07-01T03:20:46Z",
+  "generated_at": "2026-07-01T03:46:48Z",
   "source": {
     "repo": "github.com/jjfantini/humblSKILLS",
-    "ref": "develop",
-    "sha": "3d0af4b161975be7b41ee8ee9891f125befa67c2"
+    "ref": "cursor/refactor-textutil-dedupe-edb2",
+    "sha": "e0e73650c2127498e842719b60991d7b932e5430"
   },
   "skills": [
     {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Category: internal simplification (no functionality change)

### What
Adds a small `internal/textutil` package as the single source of truth for tiny string/format helpers, and removes the scattered private copies.

Before, the same trivial logic was reimplemented in several places:
- `plural(n)` in `cmd/humblskills/doctor.go`
- `pluralDash(n)` **and** `plural2(n)` in `internal/tui` (two identical copies in one package)
- `firstNonEmpty(...)` in `cmd/humblskills/root.go`, `internal/tui/listdetail.go`, and `cmd/build-registry/main.go`
- `firstNonEmptyStr(...)` in `cmd/humblskills/eval.go` (a trim-aware variant)

Now everything calls:
- `textutil.Plural(n)` -> `""` / `"s"`
- `textutil.FirstNonEmpty(...)` -> first non-`""` value (whitespace counts as non-empty)
- `textutil.FirstNonBlank(...)` -> first value with a non-whitespace char (matches the old `*Str` semantics)

### Why
Removes duplicated logic and the confusing `plural` vs `pluralDash` vs `plural2` naming. The two distinct whitespace semantics are deliberately preserved as two functions so no call site changes behavior.

### Risk
Low. Pure mechanical refactor; the two behavioral variants are kept separate. Redundant per-package unit tests were removed and replaced by `internal/textutil/textutil_test.go`. To keep the diff focused I intentionally did **not** run `gofmt` across pre-existing unformatted files (the repo has several).

### Testing
- `make build`
- `go -C cli vet ./...`
- `go -C cli test ./...` (all packages pass, incl. new `internal/textutil`)
- Spot-checked rendered output: `list` -> "1 install total", `doctor` -> "11 skills available", "1 skill can be updated"

---
*Draft proposal from a codebase-improvement research pass. Confirm to keep or scrap.*
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1bb3-3368-7e27-b650-cd1478cbedb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1bb3-3368-7e27-b650-cd1478cbedb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

