### PR TITLE
feat(list): surface available updates in list output

### DIFF
--- a/cli/cmd/humblskills/list.go
+++ b/cli/cmd/humblskills/list.go
@@ -31,8 +31,14 @@ func runList(app *App, fromDashboard bool) error {
 	if err != nil {
 		return err
 	}
+
+	// Best-effort, offline-only drift lookup: `list` reports the last-known
+	// registry state without forcing a network fetch, so it stays fast and
+	// works offline. `update` / `registry refresh` are what refill the cache.
+	avail := availableUpdates(app, m)
+
 	if app.Config.JSON {
-		return app.UI.JSON(m)
+		return app.UI.JSON(buildListView(m, avail))
 	}
 	if len(m.Installations) == 0 {
 		app.UI.Info("no skills installed — try 'humblskills install <name>'")
@@ -52,27 +58,100 @@ func runList(app *App, fromDashboard bool) error {
 	if tui.ShouldUseTUI(app.Config.JSON, app.Config.Quiet, app.Config.Yes) {
 		return runListTUI(app, m, fromDashboard)
 	}
-	renderListTable(app, installs)
+	renderListTable(app, installs, avail)
 	return nil
+}
+
+// availableUpdates maps a manifest installation key to the newer registry
+// version it can upgrade to. Only drifted installations appear in the map. The
+// registry is read from the local cache only (never fetched); if no cached
+// registry is available the map is nil and callers show no drift.
+func availableUpdates(app *App, m *manifest.Manifest) map[string]string {
+	reg, ok := registry.NewFetcher(app.Config.RegistryURL, app.Config.CacheDir).LoadCached()
+	if !ok || reg == nil {
+		return nil
+	}
+	idx := make(map[string]registry.Skill, len(reg.Skills))
+	for _, s := range reg.Skills {
+		idx[s.Name] = s
+	}
+	out := map[string]string{}
+	for _, inst := range m.Installations {
+		rs, found := idx[inst.Skill]
+		if !found {
+			continue
+		}
+		// Drift signals mirror install.PlanUpdates: version or per-skill
+		// DirSHA (RegistryRef) differs. The repo-wide Source.SHA is ignored.
+		if inst.Version != rs.Version || inst.RegistryRef != rs.DirSHA {
+			out[installKey(inst)] = rs.Version
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// installKey uniquely identifies one manifest installation row.
+func installKey(inst manifest.Installation) string {
+	return inst.Skill + "\x00" + inst.Platform + "\x00" + inst.Scope
+}
+
+// listInstallation is a manifest installation enriched with the newer registry
+// version, if any. The embedded Installation's fields are promoted so the JSON
+// shape stays backward-compatible; available_update is purely additive.
+type listInstallation struct {
+	manifest.Installation
+	AvailableUpdate string `json:"available_update,omitempty"`
+}
+
+// listView is the --json document for `list`: identical to the manifest plus
+// the additive per-row available_update field.
+type listView struct {
+	SchemaVersion int                `json:"schema_version"`
+	Installations []listInstallation `json:"installations"`
+}
+
+func buildListView(m *manifest.Manifest, avail map[string]string) listView {
+	v := listView{SchemaVersion: m.SchemaVersion}
+	v.Installations = make([]listInstallation, 0, len(m.Installations))
+	for _, inst := range m.Installations {
+		v.Installations = append(v.Installations, listInstallation{
+			Installation:    inst,
+			AvailableUpdate: avail[installKey(inst)],
+		})
+	}
+	return v
 }
 
 // renderListTable prints installs as a bordered table using the shared theme.
 // Used in non-TTY / piped paths. "Source" is the canonical humblskills store
 // every row's Path symlinks to — the source of truth — so scripted/piped
 // output reflects the real install location, not just the platform copy.
-func renderListTable(app *App, installs []manifest.Installation) {
+func renderListTable(app *App, installs []manifest.Installation, avail map[string]string) {
 	th := app.UI.Theme()
 	app.UI.Header("list")
 
+	outdated := 0
 	rows := make([][]string, 0, len(installs))
 	for _, inst := range installs {
 		source := inst.StorePath
 		if source == "" {
 			source = "-"
 		}
+		// When a newer registry version is known, show the transition
+		// (v1.0.0 → v1.0.2) right in the Version cell instead of adding a
+		// whole extra column to an already-wide table.
+		version := th.Version.Render("v" + inst.Version)
+		if to := avail[installKey(inst)]; to != "" && to != inst.Version {
+			outdated++
+			version = th.DotWarn.Render("↑ ") + th.Version.Render("v"+inst.Version) +
+				th.Detail.Render(" → ") + th.DotWarn.Render("v"+to)
+		}
 		rows = append(rows, []string{
 			th.Name.Render(inst.Skill),
-			th.Version.Render("v" + inst.Version),
+			version,
 			th.Platform.Render(inst.Platform),
 			th.Label.Render(inst.Scope),
 			th.Detail.Render(inst.Path),
@@ -93,6 +172,10 @@ func renderListTable(app *App, installs []manifest.Installation) {
 	fmt.Fprintln(app.UI.Out(), tbl.Render())
 	fmt.Fprintln(app.UI.Out(), "  "+th.Crumb.Render(fmt.Sprintf(
 		"%d install%s total", len(installs), plural(len(installs)))))
+	if outdated > 0 {
+		app.UI.Warn("%d install%s can be updated — run 'humblskills update'",
+			outdated, plural(outdated))
+	}
 }
 
 // runListTUI opens the shared two-pane browser in installed-only mode so list

--- a/cli/cmd/humblskills/list_test.go
+++ b/cli/cmd/humblskills/list_test.go
@@ -130,6 +130,88 @@ func TestList_TextOutput_ShowsSourceColumn(t *testing.T) {
 	}
 }
 
+func TestList_ShowsAvailableUpdate_JSON(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	_ = installFoo(t, s) // foo 1.0.0 installed + manifest written
+
+	// Advance the registry so foo drifts 1.0.0 -> 1.0.1.
+	newBody := strings.Replace(sampleSkillMD, "version: 1.0.0", "version: 1.0.1", 1)
+	regURL := bumpRegistryVersion(t, s, newBody)
+
+	res := runCLIWithStdoutCapture(t,
+		"list",
+		"--manifest", s.ManifestPath,
+		"--cache-dir", s.CacheDir,
+		"--registry", regURL,
+		"--json",
+	)
+	if res.RunErr != nil {
+		t.Fatalf("list: %v\n%s", res.RunErr, res.Err)
+	}
+	idx := strings.Index(res.Out, "{")
+	var got struct {
+		Installations []struct {
+			Skill           string `json:"skill"`
+			Version         string `json:"version"`
+			AvailableUpdate string `json:"available_update"`
+		} `json:"installations"`
+	}
+	if err := json.Unmarshal([]byte(res.Out[idx:]), &got); err != nil {
+		t.Fatalf("parse: %v\n%s", err, res.Out)
+	}
+	if len(got.Installations) != 1 {
+		t.Fatalf("installations = %d, want 1", len(got.Installations))
+	}
+	if got.Installations[0].AvailableUpdate != "1.0.1" {
+		t.Errorf("available_update = %q, want 1.0.1", got.Installations[0].AvailableUpdate)
+	}
+}
+
+func TestList_ShowsAvailableUpdate_Text(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	_ = installFoo(t, s)
+
+	newBody := strings.Replace(sampleSkillMD, "version: 1.0.0", "version: 1.0.1", 1)
+	regURL := bumpRegistryVersion(t, s, newBody)
+
+	res := runCLIWithStdoutCapture(t,
+		"list",
+		"--manifest", s.ManifestPath,
+		"--cache-dir", s.CacheDir,
+		"--registry", regURL,
+		"--yes",
+	)
+	if res.RunErr != nil {
+		t.Fatalf("list: %v\n%s", res.RunErr, res.Err)
+	}
+	out := res.Out + res.Err
+	if !strings.Contains(out, "v1.0.1") {
+		t.Errorf("table should show the newer version v1.0.1:\n%s", out)
+	}
+	if !strings.Contains(out, "can be updated") {
+		t.Errorf("expected an 'N install(s) can be updated' note:\n%s", out)
+	}
+}
+
+func TestList_UpToDate_NoUpdateNote(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	regURL := installFoo(t, s) // same registry -> no drift
+
+	res := runCLIWithStdoutCapture(t,
+		"list",
+		"--manifest", s.ManifestPath,
+		"--cache-dir", s.CacheDir,
+		"--registry", regURL,
+		"--yes",
+	)
+	if res.RunErr != nil {
+		t.Fatalf("list: %v\n%s", res.RunErr, res.Err)
+	}
+	if strings.Contains(res.Out+res.Err, "can be updated") {
+		t.Errorf("up-to-date install must not show an update note:\n%s", res.Out)
+	}
+}
+
 func TestList_EmptyManifest_TextOutputHint(t *testing.T) {
 	s := testutil.NewSandbox(t)
 

--- a/cli/internal/registry/fetcher.go
+++ b/cli/internal/registry/fetcher.go
@@ -94,6 +94,37 @@ func (f *Fetcher) Refresh() (*Registry, Origin, error) {
 	return r, OriginNetwork, nil
 }
 
+// LoadCached returns the registry from local sources only, never hitting the
+// network. A file:// URL (or bare path) is read directly; an http(s) URL is
+// served from the on-disk cache if present, ignoring the TTL. ok is false when
+// no local copy is available.
+//
+// This is for read-only views (e.g. `list`) that must stay fast and
+// offline-friendly and should not trigger a fetch. Freshness is a separate
+// concern: `registry refresh`, `update`, and `search` refill the cache.
+func (f *Fetcher) LoadCached() (*Registry, bool) {
+	if isLocal(f.URL) {
+		r, err := f.loadLocal()
+		if err != nil {
+			return nil, false
+		}
+		return r, true
+	}
+	m, err := f.readMeta()
+	if err != nil || m.URL != f.URL {
+		return nil, false
+	}
+	data, err := os.ReadFile(f.bodyPath())
+	if err != nil {
+		return nil, false
+	}
+	r, err := parseRegistry(data)
+	if err != nil {
+		return nil, false
+	}
+	return r, true
+}
+
 // Inspect reports on-disk cache state without triggering a fetch.
 func (f *Fetcher) Inspect() CacheInfo {
 	info := CacheInfo{URL: f.URL, Path: f.bodyPath()}

--- a/cli/internal/registry/fetcher_test.go
+++ b/cli/internal/registry/fetcher_test.go
@@ -59,6 +59,59 @@ func TestLoad_FromNetworkAndCache(t *testing.T) {
 	}
 }
 
+func TestLoadCached_NeverFetches(t *testing.T) {
+	body := testRegistryBody(t)
+
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		w.Write(body)
+	}))
+	defer srv.Close()
+
+	cache := t.TempDir()
+	f := NewFetcher(srv.URL, cache)
+
+	// Cold cache: no local copy, and crucially no network hit.
+	if _, ok := f.LoadCached(); ok {
+		t.Errorf("cold cache should report ok=false")
+	}
+	if atomic.LoadInt32(&hits) != 0 {
+		t.Errorf("LoadCached must not hit the network, got %d hits", hits)
+	}
+
+	// Warm the cache via a normal Load, then LoadCached should serve it.
+	if _, _, err := f.Load(); err != nil {
+		t.Fatal(err)
+	}
+	r, ok := f.LoadCached()
+	if !ok || r == nil {
+		t.Fatalf("warm cache should report ok=true with a registry")
+	}
+	if len(r.Skills) != 1 || r.Skills[0].Name != "a" {
+		t.Errorf("unexpected cached registry: %+v", r)
+	}
+	if atomic.LoadInt32(&hits) != 1 {
+		t.Errorf("expected exactly 1 network hit total, got %d", hits)
+	}
+}
+
+func TestLoadCached_LocalFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "registry.json")
+	if err := os.WriteFile(path, testRegistryBody(t), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	f := NewFetcher("file://"+path, t.TempDir())
+	r, ok := f.LoadCached()
+	if !ok || r == nil {
+		t.Fatalf("file:// registry should load, ok=%v", ok)
+	}
+	if len(r.Skills) != 1 {
+		t.Errorf("skills = %d, want 1", len(r.Skills))
+	}
+}
+
 func TestLoad_CacheMiss_WhenTTLExpired(t *testing.T) {
 	body := testRegistryBody(t)
 

--- a/registry.json
+++ b/registry.json
@@ -1,10 +1,10 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-07-01T03:20:46Z",
+  "generated_at": "2026-07-01T03:52:26Z",
   "source": {
     "repo": "github.com/jjfantini/humblSKILLS",
-    "ref": "develop",
-    "sha": "3d0af4b161975be7b41ee8ee9891f125befa67c2"
+    "ref": "cursor/feat-list-show-updates-edb2",
+    "sha": "7447b182739cba03ca3a115e6797c49b48703fbe"
   },
   "skills": [
     {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Category: UX improvement across workflows

### Problem
`humblskills doctor` and the interactive `list` TUI both tell you when an installed skill has drifted from the registry, but the **static / non-TTY `list` table** and **`list --json`** don't. So a scripted or piped `list` (the exact context where you can't get the TUI) silently hides the one thing you most want to know: "is anything out of date?"

### Change
`list` now surfaces drift in every output mode:
- **Table**: the Version cell becomes `↑ v1.0.0 → v1.0.2` (up-arrow, warning color) for drifted rows, and a footer note prints `N installs can be updated — run 'humblskills update'`.
- **`--json`**: each installation gains an additive `available_update` field (the newer registry version). All existing fields/shape are unchanged, so existing consumers keep working.

![list showing v1.0.0 to v1.0.2 update available](https://cursor.com/artifacts/c/art-1caf9026-0a13-4096-b13a-22c8ad89e799)

### Offline-safe by design
Drift is read from the **local registry cache only** via a new `registry.Fetcher.LoadCached()` — `list` never triggers a network fetch, so it stays fast and works offline (and unit tests never hit the network). `update` / `registry refresh` / `search` remain responsible for refilling the cache. If no cached registry exists, `list` behaves exactly as before (no drift shown).

Drift signals mirror `install.PlanUpdates` (version or per-skill `DirSHA`), so `list` and `update` agree.

### Testing
- `make build`, `go -C cli vet ./...`, `go -C cli test ./...`
- New tests: `TestList_ShowsAvailableUpdate_JSON`, `TestList_ShowsAvailableUpdate_Text`, `TestList_UpToDate_NoUpdateNote`, `TestLoadCached_NeverFetches`, `TestLoadCached_LocalFile`
- Manually verified against the in-repo registry (screenshot above): `use-smart-commit` shows `v1.0.0 → v1.0.2` + the update note; `--json` emits `"available_update": "1.0.2"`.

---
*Draft proposal from a codebase-improvement research pass. Confirm to keep or scrap.*
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1bb3-3368-7e27-b650-cd1478cbedb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1bb3-3368-7e27-b650-cd1478cbedb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

