### PR TITLE
refactor(fsutil): unify copyTree implementations into internal/fsutil

### DIFF
--- a/cli/internal/eval/brain/brain.go
+++ b/cli/internal/eval/brain/brain.go
@@ -19,6 +19,8 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+
+	"github.com/jjfantini/humblSKILLS/cli/internal/fsutil"
 )
 
 // Files under references/ that are truncated to "shape only" when deriving a
@@ -41,7 +43,7 @@ func Snapshot(skillDir, dst string) error {
 	// subtree (wiki/, raw/). Scripts and SKILL.md are NOT part of the
 	// brain; the harness keeps the skill dir itself read-only so those
 	// never drift.
-	return copyTree(src, dst)
+	return fsutil.CopyTree(src, dst, fsutil.Options{})
 }
 
 // Restore copies a previously-taken snapshot back into the live skill
@@ -55,7 +57,7 @@ func Restore(src, skillDir string) error {
 	if err := os.MkdirAll(dst, 0o755); err != nil {
 		return err
 	}
-	return copyTree(src, dst)
+	return fsutil.CopyTree(src, dst, fsutil.Options{})
 }
 
 // DeriveFlat produces the flat_skill variant of src at dst. Keeps SKILL.md
@@ -81,7 +83,7 @@ func DeriveFlat(srcSkill, dst string) (string, error) {
 	// calls them.
 	srcScripts := filepath.Join(srcSkill, "scripts")
 	if _, err := os.Stat(srcScripts); err == nil {
-		if err := copyTree(srcScripts, filepath.Join(dst, "scripts")); err != nil {
+		if err := fsutil.CopyTree(srcScripts, filepath.Join(dst, "scripts"), fsutil.Options{}); err != nil {
 			return "", fmt.Errorf("copy scripts: %w", err)
 		}
 	}
@@ -130,7 +132,7 @@ func DeriveFlatWithWiki(srcSkill, dst string) (string, error) {
 	srcWiki := filepath.Join(srcSkill, "references", "wiki")
 	if _, err := os.Stat(srcWiki); err == nil {
 		dstWiki := filepath.Join(dst, "references", "wiki")
-		if err := copyTree(srcWiki, dstWiki); err != nil {
+		if err := fsutil.CopyTree(srcWiki, dstWiki, fsutil.Options{}); err != nil {
 			return "", fmt.Errorf("copy wiki: %w", err)
 		}
 	}
@@ -318,20 +320,6 @@ func ReadsFromBrain(transcript []byte) int {
 }
 
 // --- internal helpers -------------------------------------------------------
-
-func copyTree(src, dst string) error {
-	return filepath.WalkDir(src, func(p string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		rel, _ := filepath.Rel(src, p)
-		target := filepath.Join(dst, rel)
-		if d.IsDir() {
-			return os.MkdirAll(target, 0o755)
-		}
-		return copyFile(p, target)
-	})
-}
 
 func copyFile(src, dst string) error {
 	in, err := os.Open(src)

--- a/cli/internal/eval/harness/harness.go
+++ b/cli/internal/eval/harness/harness.go
@@ -27,6 +27,7 @@ import (
 	"github.com/jjfantini/humblSKILLS/cli/internal/eval/runner"
 	"github.com/jjfantini/humblSKILLS/cli/internal/eval/scenarios"
 	"github.com/jjfantini/humblSKILLS/cli/internal/eval/workspace"
+	"github.com/jjfantini/humblSKILLS/cli/internal/fsutil"
 )
 
 // Options controls one full eval invocation.
@@ -337,7 +338,7 @@ func (h *Harness) prepareSkillForArm(arm string) (skillPath string, cleanup func
 		// Copy the skill into a working dir so the harness can mutate
 		// references/ between sessions without touching the source.
 		dst := filepath.Join(h.iterDir, "smart-skill-working")
-		if err := copyTree(h.opts.SkillDir, dst); err != nil {
+		if err := fsutil.CopyTree(h.opts.SkillDir, dst, fsutil.Options{}); err != nil {
 			return "", nil, err
 		}
 		return dst, func() {}, nil
@@ -622,27 +623,3 @@ func writeJSON(path string, v any) error {
 	return os.Rename(tmp, path)
 }
 
-func copyTree(src, dst string) error {
-	return filepath.Walk(src, func(p string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-		rel, _ := filepath.Rel(src, p)
-		target := filepath.Join(dst, rel)
-		if info.IsDir() {
-			return os.MkdirAll(target, info.Mode())
-		}
-		data, err := os.ReadFile(p)
-		if err != nil {
-			return err
-		}
-		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
-			return err
-		}
-		if err := os.WriteFile(target, data, 0o644); err != nil {
-			return err
-		}
-		_ = os.Chmod(target, info.Mode())
-		return nil
-	})
-}

--- a/cli/internal/eval/runner/clitool/clitool.go
+++ b/cli/internal/eval/runner/clitool/clitool.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/jjfantini/humblSKILLS/cli/internal/eval/runner"
+	"github.com/jjfantini/humblSKILLS/cli/internal/fsutil"
 )
 
 // Driver abstracts over the specific CLI's command shape.
@@ -126,7 +127,7 @@ func (r *Runner) Execute(ctx context.Context, req runner.Request) (*runner.Resul
 	// Stage skill (claudecode et al read skill from a known subdir).
 	if req.SkillDir != "" {
 		dst := filepath.Join(scratch, "skill")
-		if err := copyTree(req.SkillDir, dst); err != nil {
+		if err := fsutil.CopyTree(req.SkillDir, dst, fsutil.Options{}); err != nil {
 			return nil, fmt.Errorf("stage skill: %w", err)
 		}
 	}
@@ -281,20 +282,6 @@ func collectScratchOutputs(scratch, dst string) ([]string, error) {
 	return out, err
 }
 
-func copyTree(src, dst string) error {
-	return filepath.Walk(src, func(p string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-		rel, _ := filepath.Rel(src, p)
-		target := filepath.Join(dst, rel)
-		if info.IsDir() {
-			return os.MkdirAll(target, info.Mode())
-		}
-		return copyFile(p, target)
-	})
-}
-
 // syncTree mirrors src into dst by replacing dst entirely. Used to sync
 // the agent-mutated `scratch/skill/references/` back to the harness's
 // persistent working copy so brain updates (patterns.md, log.md,
@@ -306,7 +293,7 @@ func syncTree(src, dst string) error {
 	if err := os.MkdirAll(dst, 0o755); err != nil {
 		return err
 	}
-	return copyTree(src, dst)
+	return fsutil.CopyTree(src, dst, fsutil.Options{})
 }
 
 func copyFile(src, dst string) error {

--- a/cli/internal/fsutil/fsutil.go
+++ b/cli/internal/fsutil/fsutil.go
@@ -1,0 +1,85 @@
+// Package fsutil holds small filesystem helpers shared across the CLI. It
+// exists to replace several near-identical private copyTree implementations
+// that had drifted apart (install staging, eval brain/harness/clitool).
+package fsutil
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+// Options tunes CopyTree.
+type Options struct {
+	// RejectSymlinks makes CopyTree fail when it encounters a symlink rather
+	// than copying the link target's contents. Install staging sets this so a
+	// crafted skill tarball can't smuggle a symlink into the canonical store.
+	RejectSymlinks bool
+}
+
+// CopyTree recursively copies the directory tree rooted at src into dst.
+//
+//   - File modes are preserved.
+//   - Directories are created owner-traversable (source mode | 0700) so a
+//     read-only source directory doesn't block the copy.
+//   - Symlinks: when Options.RejectSymlinks is set, encountering one is an
+//     error; otherwise the link target's contents are copied as a regular
+//     file (symlinks are followed, never recreated).
+//
+// src must be an existing directory.
+func CopyTree(src, dst string, opts Options) error {
+	info, err := os.Stat(src)
+	if err != nil {
+		return err
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("copytree: %s is not a directory", src)
+	}
+	return filepath.Walk(src, func(p string, fi os.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		rel, err := filepath.Rel(src, p)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(dst, rel)
+		if fi.IsDir() {
+			return os.MkdirAll(target, fi.Mode()&0o777|0o700)
+		}
+		if fi.Mode()&os.ModeSymlink != 0 && opts.RejectSymlinks {
+			return fmt.Errorf("copytree: refusing to copy symlink %s", p)
+		}
+		return copyFile(p, target)
+	})
+}
+
+// copyFile copies the regular file at src to dst (following symlinks),
+// creating parent directories and preserving the source file's permission
+// bits.
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return err
+	}
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		_ = out.Close()
+		return err
+	}
+	if err := out.Close(); err != nil {
+		return err
+	}
+	if fi, err := os.Stat(src); err == nil {
+		_ = os.Chmod(dst, fi.Mode()&0o777)
+	}
+	return nil
+}

--- a/cli/internal/fsutil/fsutil_test.go
+++ b/cli/internal/fsutil/fsutil_test.go
@@ -1,0 +1,99 @@
+package fsutil
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestCopyTree_NestedAndModes(t *testing.T) {
+	src := t.TempDir()
+	dst := filepath.Join(t.TempDir(), "out")
+
+	mustWrite(t, filepath.Join(src, "a.txt"), "alpha", 0o644)
+	mustWrite(t, filepath.Join(src, "nested", "b.sh"), "#!/bin/sh\n", 0o755)
+
+	if err := CopyTree(src, dst, Options{}); err != nil {
+		t.Fatal(err)
+	}
+	if got := readFile(t, filepath.Join(dst, "a.txt")); got != "alpha" {
+		t.Errorf("a.txt = %q", got)
+	}
+	if got := readFile(t, filepath.Join(dst, "nested", "b.sh")); got != "#!/bin/sh\n" {
+		t.Errorf("b.sh = %q", got)
+	}
+	// Executable bit preserved (skip on Windows where perms are emulated).
+	if runtime.GOOS != "windows" {
+		fi, err := os.Stat(filepath.Join(dst, "nested", "b.sh"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if fi.Mode()&0o111 == 0 {
+			t.Errorf("expected b.sh to stay executable, got %v", fi.Mode())
+		}
+	}
+}
+
+func TestCopyTree_NotADirectory(t *testing.T) {
+	src := t.TempDir()
+	file := filepath.Join(src, "f")
+	mustWrite(t, file, "x", 0o644)
+	if err := CopyTree(file, filepath.Join(t.TempDir(), "out"), Options{}); err == nil {
+		t.Error("expected error copying a non-directory src")
+	}
+}
+
+func TestCopyTree_SymlinkReject(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink semantics differ on Windows")
+	}
+	src := t.TempDir()
+	mustWrite(t, filepath.Join(src, "real.txt"), "data", 0o644)
+	if err := os.Symlink(filepath.Join(src, "real.txt"), filepath.Join(src, "link.txt")); err != nil {
+		t.Fatal(err)
+	}
+
+	// RejectSymlinks: error.
+	if err := CopyTree(src, filepath.Join(t.TempDir(), "reject"), Options{RejectSymlinks: true}); err == nil {
+		t.Error("expected error when RejectSymlinks is set and a symlink exists")
+	}
+
+	// Follow (default): the link target's contents are copied as a regular file.
+	dst := filepath.Join(t.TempDir(), "follow")
+	if err := CopyTree(src, dst, Options{}); err != nil {
+		t.Fatalf("follow copy: %v", err)
+	}
+	if got := readFile(t, filepath.Join(dst, "link.txt")); got != "data" {
+		t.Errorf("followed symlink content = %q, want data", got)
+	}
+	fi, err := os.Lstat(filepath.Join(dst, "link.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fi.Mode()&os.ModeSymlink != 0 {
+		t.Error("copied entry should be a regular file, not a symlink")
+	}
+}
+
+func mustWrite(t *testing.T, path, body string, mode os.FileMode) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(body), mode); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(path, mode); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(b)
+}

--- a/cli/internal/install/engine.go
+++ b/cli/internal/install/engine.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/jjfantini/humblSKILLS/cli/internal/adapters"
 	"github.com/jjfantini/humblSKILLS/cli/internal/fetch"
+	"github.com/jjfantini/humblSKILLS/cli/internal/fsutil"
 	"github.com/jjfantini/humblSKILLS/cli/internal/manifest"
 	"github.com/jjfantini/humblSKILLS/cli/internal/registry"
 )
@@ -354,9 +355,9 @@ func (e *Engine) installOne(
 				return nil, fmt.Errorf("clean store staging: %w", err)
 			}
 			defer os.RemoveAll(perStore)
-			if err := copyTree(staging, perStore); err != nil {
-				return nil, fmt.Errorf("copy store staging: %w", err)
-			}
+		if err := fsutil.CopyTree(staging, perStore, fsutil.Options{RejectSymlinks: true}); err != nil {
+			return nil, fmt.Errorf("copy store staging: %w", err)
+		}
 			if len(preserveList) > 0 {
 				if err := applyPreserve(preserveSource, perStore, preserveList); err != nil {
 					return nil, err
@@ -530,34 +531,7 @@ func replaceDir(src, dst string) error {
 	if err := os.RemoveAll(dst); err != nil {
 		return err
 	}
-	return copyTree(src, dst)
-}
-
-func copyTree(src, dst string) error {
-	info, err := os.Stat(src)
-	if err != nil {
-		return err
-	}
-	if !info.IsDir() {
-		return fmt.Errorf("copy: %s is not a directory", src)
-	}
-	return filepath.Walk(src, func(p string, fi os.FileInfo, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-		rel, err := filepath.Rel(src, p)
-		if err != nil {
-			return err
-		}
-		target := filepath.Join(dst, rel)
-		if fi.IsDir() {
-			return os.MkdirAll(target, fi.Mode()&0o777|0o700)
-		}
-		if fi.Mode()&os.ModeSymlink != 0 {
-			return fmt.Errorf("symlink in staging tree: %s", p)
-		}
-		return copyFile(p, target, fi.Mode()&0o777)
-	})
+	return fsutil.CopyTree(src, dst, fsutil.Options{RejectSymlinks: true})
 }
 
 func copyFile(src, dst string, mode os.FileMode) error {

--- a/registry.json
+++ b/registry.json
@@ -1,10 +1,10 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-07-01T03:20:46Z",
+  "generated_at": "2026-07-01T04:14:42Z",
   "source": {
     "repo": "github.com/jjfantini/humblSKILLS",
-    "ref": "develop",
-    "sha": "3d0af4b161975be7b41ee8ee9891f125befa67c2"
+    "ref": "cursor/refactor-fsutil-copytree-edb2",
+    "sha": "3e7c98638c318d93572b1c0aedd21593e1b9b389"
   },
   "skills": [
     {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Category: internal simplification (no functionality change)

### What
Four near-identical private `copyTree` helpers had drifted apart:
- `internal/install/engine.go` (staging → store; rejected symlinks)
- `internal/eval/brain/brain.go`
- `internal/eval/harness/harness.go`
- `internal/eval/runner/clitool/clitool.go`

They all recursively copied a directory and preserved file modes, but each re-derived the walk/mode logic slightly differently. This adds `internal/fsutil.CopyTree(src, dst, Options)` as the single implementation and repoints all four.

### The one real difference, made explicit
Install staging must reject symlinks (so a crafted tarball can't smuggle a link into the canonical store). That's now `Options{RejectSymlinks: true}`; the eval callers follow symlinks (copy target contents) as before via `Options{}`.

Directories are created owner-traversable (`mode | 0700`) and file permission bits preserved — matching prior behavior. Each package's own `copyFile` (used independently elsewhere) is left in place; only the duplicated `copyTree` is removed.

### Risk
Low-to-moderate: touches the install hot path. Mitigated by the full existing install + eval suites (including the 1480-line `engine_test.go` and the brain/harness/clitool tests) all passing, plus new `internal/fsutil` unit tests covering nested trees, mode preservation, non-directory src, and symlink reject-vs-follow.

### Testing
- `make build`, `go -C cli vet ./...`, `go -C cli test ./...` (all pass)
- New: `internal/fsutil/fsutil_test.go`

---
*Draft from the backlog. Confirm to keep or scrap.*
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1bb3-3368-7e27-b650-cd1478cbedb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1bb3-3368-7e27-b650-cd1478cbedb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

