### PR TITLE
refactor(eval,tui): dedupe writeJSON and clamp helpers

### DIFF
--- a/cli/internal/eval/harness/harness.go
+++ b/cli/internal/eval/harness/harness.go
@@ -27,6 +27,7 @@ import (
 	"github.com/jjfantini/humblSKILLS/cli/internal/eval/runner"
 	"github.com/jjfantini/humblSKILLS/cli/internal/eval/scenarios"
 	"github.com/jjfantini/humblSKILLS/cli/internal/eval/workspace"
+	"github.com/jjfantini/humblSKILLS/cli/internal/jsonutil"
 )
 
 // Options controls one full eval invocation.
@@ -408,7 +409,7 @@ func (h *Harness) runSession(
 	}
 
 	// Persist timing / transcript / metrics sidecars.
-	_ = writeJSON(filepath.Join(sessDir, "timing.json"), map[string]any{
+	_ = jsonutil.WriteFile(filepath.Join(sessDir, "timing.json"), map[string]any{
 		"total_tokens":      res.TotalTokens,
 		"prompt_tokens":     res.PromptTokens,
 		"completion_tokens": res.CompletionTokens,
@@ -418,7 +419,7 @@ func (h *Harness) runSession(
 	if len(res.Transcript) > 0 {
 		_ = os.WriteFile(filepath.Join(sessDir, "transcript.txt"), res.Transcript, 0o644)
 	}
-	_ = writeJSON(filepath.Join(sessDir, "metrics.json"), map[string]any{
+	_ = jsonutil.WriteFile(filepath.Join(sessDir, "metrics.json"), map[string]any{
 		"tool_calls":      res.ToolCalls,
 		"brain_reads":     brain.ReadsFromBrain(res.Transcript),
 		"output_files":    res.OutputFiles,
@@ -430,7 +431,7 @@ func (h *Harness) runSession(
 		snapAfter = filepath.Join(sessDir, "brain-snapshot-after")
 		_ = brain.Snapshot(skillPath, snapAfter)
 		if g, err := brain.ComputeGrowth(snapBefore, snapAfter); err == nil {
-			_ = writeJSON(filepath.Join(sessDir, "growth.json"), g)
+			_ = jsonutil.WriteFile(filepath.Join(sessDir, "growth.json"), g)
 		}
 	}
 
@@ -604,22 +605,6 @@ func totalToolCalls(m map[string]int) int {
 		n += v
 	}
 	return n
-}
-
-func writeJSON(path string, v any) error {
-	data, err := json.MarshalIndent(v, "", "  ")
-	if err != nil {
-		return err
-	}
-	data = append(data, '\n')
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return err
-	}
-	tmp := path + ".tmp"
-	if err := os.WriteFile(tmp, data, 0o644); err != nil {
-		return err
-	}
-	return os.Rename(tmp, path)
 }
 
 func copyTree(src, dst string) error {

--- a/cli/internal/eval/report/report.go
+++ b/cli/internal/eval/report/report.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"github.com/jjfantini/humblSKILLS/cli/internal/eval/metrics"
+	"github.com/jjfantini/humblSKILLS/cli/internal/jsonutil"
 )
 
 //go:embed assets/report.html.tmpl
@@ -514,23 +515,13 @@ func writeMarkdown(path string, b *Bundle) error {
 }
 
 func writeJSON(path string, b *Bundle) error {
-	out := map[string]any{
+	return jsonutil.WriteFile(path, map[string]any{
 		"skill":      b.SkillName,
 		"iteration":  b.Iteration,
 		"runner":     b.Runner,
 		"trajectory": b.Trajectory,
 		"benchmark":  b.Benchmark,
-	}
-	data, err := json.MarshalIndent(out, "", "  ")
-	if err != nil {
-		return err
-	}
-	data = append(data, '\n')
-	tmp := path + ".tmp"
-	if err := os.WriteFile(tmp, data, 0o644); err != nil {
-		return err
-	}
-	return os.Rename(tmp, path)
+	})
 }
 
 // --- ASCII sparkline --------------------------------------------------------

--- a/cli/internal/eval/runner/mock/mock.go
+++ b/cli/internal/eval/runner/mock/mock.go
@@ -9,7 +9,6 @@ package mock
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -17,6 +16,7 @@ import (
 	"time"
 
 	"github.com/jjfantini/humblSKILLS/cli/internal/eval/runner"
+	"github.com/jjfantini/humblSKILLS/cli/internal/jsonutil"
 )
 
 // Runner is the mock backend.
@@ -103,7 +103,7 @@ func (r *Runner) Execute(ctx context.Context, req runner.Request) (*runner.Resul
 		"tool_calls":  toolCalls,
 		"brain_reads": brainReads,
 	}
-	_ = writeJSON(filepath.Join(req.OutputDir, "metrics.json"), metrics)
+	_ = jsonutil.WriteFile(filepath.Join(req.OutputDir, "metrics.json"), metrics)
 
 	duration := time.Since(start)
 	if duration < 5*time.Millisecond {
@@ -130,11 +130,3 @@ func oneLine(s string, max int) string {
 	return s
 }
 
-func writeJSON(path string, v any) error {
-	data, err := json.MarshalIndent(v, "", "  ")
-	if err != nil {
-		return err
-	}
-	data = append(data, '\n')
-	return os.WriteFile(path, data, 0o644)
-}

--- a/cli/internal/jsonutil/jsonutil.go
+++ b/cli/internal/jsonutil/jsonutil.go
@@ -1,0 +1,29 @@
+// Package jsonutil holds small JSON I/O helpers shared across the CLI. It
+// replaces several private writeJSON copies that had drifted (some atomic,
+// some not; some created parent dirs, some didn't).
+package jsonutil
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+)
+
+// WriteFile marshals v as indented JSON (with a trailing newline) and writes
+// it to path atomically: it creates the parent directory, writes to a temp
+// file, then renames into place so a reader never sees a half-written file.
+func WriteFile(path string, v any) error {
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}

--- a/cli/internal/jsonutil/jsonutil_test.go
+++ b/cli/internal/jsonutil/jsonutil_test.go
@@ -1,0 +1,45 @@
+package jsonutil
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestWriteFile_CreatesDirsAndIndents(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nested", "out.json")
+	in := map[string]any{"b": 2, "a": 1}
+	if err := WriteFile(path, in); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasSuffix(string(raw), "\n") {
+		t.Error("expected trailing newline")
+	}
+	if !strings.Contains(string(raw), "  \"a\"") {
+		t.Errorf("expected two-space indentation, got:\n%s", raw)
+	}
+	var out map[string]int
+	if err := json.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("round-trip: %v", err)
+	}
+	if out["a"] != 1 || out["b"] != 2 {
+		t.Errorf("unexpected content: %+v", out)
+	}
+}
+
+func TestWriteFile_LeavesNoTempFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "x.json")
+	if err := WriteFile(path, []int{1, 2, 3}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(path + ".tmp"); !os.IsNotExist(err) {
+		t.Errorf("temp file should be renamed away, stat err = %v", err)
+	}
+}

--- a/cli/internal/tui/eval_config_modal.go
+++ b/cli/internal/tui/eval_config_modal.go
@@ -119,9 +119,9 @@ func (m evalConfigModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.group = cfgGroup((int(m.group) + 5) % 6)
 			m.cursor = m.cursorDefault()
 		case "up", "k":
-			m.cursor = clampInt(m.cursor-1, 0, m.groupLen()-1)
+			m.cursor = clamp(m.cursor-1, 0, m.groupLen()-1)
 		case "down", "j":
-			m.cursor = clampInt(m.cursor+1, 0, m.groupLen()-1)
+			m.cursor = clamp(m.cursor+1, 0, m.groupLen()-1)
 		case " ":
 			m.toggleCurrent()
 		case "enter":
@@ -420,16 +420,6 @@ func indexOfInt(xs []int, v, fallback int) int {
 		}
 	}
 	return fallback
-}
-
-func clampInt(v, lo, hi int) int {
-	if v < lo {
-		return lo
-	}
-	if v > hi {
-		return hi
-	}
-	return v
 }
 
 func groupLabel(g cfgGroup) string {

--- a/registry.json
+++ b/registry.json
@@ -1,10 +1,10 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-07-01T03:20:46Z",
+  "generated_at": "2026-07-01T04:19:47Z",
   "source": {
     "repo": "github.com/jjfantini/humblSKILLS",
-    "ref": "develop",
-    "sha": "3d0af4b161975be7b41ee8ee9891f125befa67c2"
+    "ref": "cursor/refactor-dedupe-writejson-clamp-edb2",
+    "sha": "ce6102189ad5a2c4745db522259619038ca59cb1"
   },
   "skills": [
     {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Category: internal simplification (no functionality change)

### writeJSON → `internal/jsonutil.WriteFile`
Three private `writeJSON` copies had drifted:
- `eval/harness` — atomic (temp+rename) + `MkdirAll`
- `eval/report` — atomic, no mkdir, plus a Bundle→map projection
- `eval/runner/mock` — **non-atomic** direct write, no mkdir

Consolidated into `internal/jsonutil.WriteFile`, which uses the safest superset: create parent dir, write to temp, rename into place, indented + trailing newline. `report` keeps its Bundle-specific field projection but delegates the actual I/O. Mock now writes atomically (strictly safer; readers never see a half-written `metrics.json`).

### clamp / clampInt
Two byte-identical clamp helpers lived in the same `tui` package (`install_modal.go`, `eval_config_modal.go`). Kept `clamp`, removed `clampInt`, repointed callers.

### Testing
- `make build`, `go -C cli vet ./...`, `go -C cli test -count=1 ./...`
- `make eval-mock` — confirms report/metrics JSON still written end-to-end
- New: `internal/jsonutil/jsonutil_test.go` (dir creation, indentation, round-trip, no stray temp file)

---
*Draft from the backlog. Confirm to keep or scrap.*
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1bb3-3368-7e27-b650-cd1478cbedb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1bb3-3368-7e27-b650-cd1478cbedb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

