### PR TITLE
refactor(install): give preserve logic a single home

### DIFF
--- a/cli/internal/install/engine.go
+++ b/cli/internal/install/engine.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/jjfantini/humblSKILLS/cli/internal/adapters"
@@ -588,89 +587,4 @@ func shortSHA(sha string) string {
 		return sha[:12]
 	}
 	return sha
-}
-
-// applyPreserve merges user-owned content from userRoot into stagingRoot
-// according to the preserve list.
-//
-//   - File entry (no trailing "/"): user wins; user's bytes overwrite whatever
-//     staging shipped.
-//   - Directory entry (trailing "/"): deep merge; staging wins on per-file
-//     conflicts. Files only in user land alongside staging's version.
-//
-// Type mismatches (file entry vs user dir, or dir entry vs user file) and
-// symlinks in the user source are rejected rather than silently resolved.
-func applyPreserve(userRoot, stagingRoot string, entries []string) error {
-	for _, raw := range entries {
-		rel := strings.TrimSpace(raw)
-		rel = strings.TrimPrefix(rel, "./")
-		isDir := strings.HasSuffix(rel, "/")
-		relClean := filepath.FromSlash(strings.TrimSuffix(rel, "/"))
-		if relClean == "" || relClean == "." {
-			continue
-		}
-		srcAbs := filepath.Join(userRoot, relClean)
-		dstAbs := filepath.Join(stagingRoot, relClean)
-
-		fi, err := os.Lstat(srcAbs)
-		if err != nil {
-			if os.IsNotExist(err) {
-				continue
-			}
-			return fmt.Errorf("preserve stat %s: %w", srcAbs, err)
-		}
-		if fi.Mode()&os.ModeSymlink != 0 {
-			return fmt.Errorf("preserve: refusing to follow symlink %s", srcAbs)
-		}
-
-		if isDir {
-			if !fi.IsDir() {
-				return fmt.Errorf("preserve: entry %q declares a directory but %s is a file", raw, srcAbs)
-			}
-			if err := preserveMergeDir(srcAbs, dstAbs); err != nil {
-				return err
-			}
-			continue
-		}
-		if fi.IsDir() {
-			return fmt.Errorf("preserve: entry %q declares a file but %s is a directory", raw, srcAbs)
-		}
-		if err := copyFile(srcAbs, dstAbs, fi.Mode()&0o777); err != nil {
-			return fmt.Errorf("preserve copy %s: %w", srcAbs, err)
-		}
-	}
-	return nil
-}
-
-// preserveMergeDir walks userDir and copies every regular file into dstDir
-// only when dstDir does not already have that relative path — staging wins on
-// conflicts. Symlinks anywhere in userDir abort the merge.
-func preserveMergeDir(userDir, dstDir string) error {
-	return filepath.Walk(userDir, func(p string, fi os.FileInfo, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-		rel, err := filepath.Rel(userDir, p)
-		if err != nil {
-			return err
-		}
-		if rel == "." {
-			return os.MkdirAll(dstDir, fi.Mode()&0o777|0o700)
-		}
-		dst := filepath.Join(dstDir, rel)
-		if fi.Mode()&os.ModeSymlink != 0 {
-			return fmt.Errorf("preserve: refusing to follow symlink %s", p)
-		}
-		if fi.IsDir() {
-			if _, err := os.Stat(dst); err == nil {
-				return nil
-			}
-			return os.MkdirAll(dst, fi.Mode()&0o777|0o700)
-		}
-		if _, err := os.Stat(dst); err == nil {
-			// Staging already ships this file; staging wins.
-			return nil
-		}
-		return copyFile(p, dst, fi.Mode()&0o777)
-	})
 }

--- a/cli/internal/install/preserve.go
+++ b/cli/internal/install/preserve.go
@@ -227,3 +227,88 @@ func preserveSeqNode(preserve []string) *yaml.Node {
 	}
 	return seq
 }
+
+// applyPreserve merges user-owned content from userRoot into stagingRoot
+// according to the preserve list.
+//
+//   - File entry (no trailing "/"): user wins; user's bytes overwrite whatever
+//     staging shipped.
+//   - Directory entry (trailing "/"): deep merge; staging wins on per-file
+//     conflicts. Files only in user land alongside staging's version.
+//
+// Type mismatches (file entry vs user dir, or dir entry vs user file) and
+// symlinks in the user source are rejected rather than silently resolved.
+func applyPreserve(userRoot, stagingRoot string, entries []string) error {
+	for _, raw := range entries {
+		rel := strings.TrimSpace(raw)
+		rel = strings.TrimPrefix(rel, "./")
+		isDir := strings.HasSuffix(rel, "/")
+		relClean := filepath.FromSlash(strings.TrimSuffix(rel, "/"))
+		if relClean == "" || relClean == "." {
+			continue
+		}
+		srcAbs := filepath.Join(userRoot, relClean)
+		dstAbs := filepath.Join(stagingRoot, relClean)
+
+		fi, err := os.Lstat(srcAbs)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return fmt.Errorf("preserve stat %s: %w", srcAbs, err)
+		}
+		if fi.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("preserve: refusing to follow symlink %s", srcAbs)
+		}
+
+		if isDir {
+			if !fi.IsDir() {
+				return fmt.Errorf("preserve: entry %q declares a directory but %s is a file", raw, srcAbs)
+			}
+			if err := preserveMergeDir(srcAbs, dstAbs); err != nil {
+				return err
+			}
+			continue
+		}
+		if fi.IsDir() {
+			return fmt.Errorf("preserve: entry %q declares a file but %s is a directory", raw, srcAbs)
+		}
+		if err := copyFile(srcAbs, dstAbs, fi.Mode()&0o777); err != nil {
+			return fmt.Errorf("preserve copy %s: %w", srcAbs, err)
+		}
+	}
+	return nil
+}
+
+// preserveMergeDir walks userDir and copies every regular file into dstDir
+// only when dstDir does not already have that relative path — staging wins on
+// conflicts. Symlinks anywhere in userDir abort the merge.
+func preserveMergeDir(userDir, dstDir string) error {
+	return filepath.Walk(userDir, func(p string, fi os.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		rel, err := filepath.Rel(userDir, p)
+		if err != nil {
+			return err
+		}
+		if rel == "." {
+			return os.MkdirAll(dstDir, fi.Mode()&0o777|0o700)
+		}
+		dst := filepath.Join(dstDir, rel)
+		if fi.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("preserve: refusing to follow symlink %s", p)
+		}
+		if fi.IsDir() {
+			if _, err := os.Stat(dst); err == nil {
+				return nil
+			}
+			return os.MkdirAll(dst, fi.Mode()&0o777|0o700)
+		}
+		if _, err := os.Stat(dst); err == nil {
+			// Staging already ships this file; staging wins.
+			return nil
+		}
+		return copyFile(p, dst, fi.Mode()&0o777)
+	})
+}

--- a/registry.json
+++ b/registry.json
@@ -1,10 +1,10 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-07-01T03:20:46Z",
+  "generated_at": "2026-07-01T04:21:39Z",
   "source": {
     "repo": "github.com/jjfantini/humblSKILLS",
-    "ref": "develop",
-    "sha": "3d0af4b161975be7b41ee8ee9891f125befa67c2"
+    "ref": "cursor/refactor-preserve-onehome-edb2",
+    "sha": "14b06f83720c887b2d17db15b33e846b45589c41"
   },
   "skills": [
     {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Category: internal simplification (no functionality change)

`preserve.go` already owned the SKILL.md frontmatter side of preserve (`loadLocalPreserve`, `mergePreserveIntoSkillMD`, `frontmatterBounds`, `setPreserveKey`, `preserveSeqNode`), but the file-merge half (`applyPreserve`, `preserveMergeDir`) sat at the tail of `engine.go`, far from its siblings.

This moves those two functions into `preserve.go` so the entire preserve story reads in one place. Pure relocation within `package install` — no behavior change. `copyFile` stays in `engine.go` (still shared with `copyTree`); the now-unused `strings` import is dropped from `engine.go`.

### Testing
- `make build`, `go -C cli vet ./internal/install/`, `go -C cli test -count=1 ./internal/install/` (all pass; existing `engine_test.go` / `preserve_test.go` cover this logic)

---
*Draft from the backlog. Confirm to keep or scrap.*
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1bb3-3368-7e27-b650-cd1478cbedb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1bb3-3368-7e27-b650-cd1478cbedb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

