### PR TITLE
refactor(eval): drop non-functional grade stub subcommand

### DIFF
--- a/cli/cmd/humblskills/eval.go
+++ b/cli/cmd/humblskills/eval.go
@@ -47,7 +47,6 @@ func newEvalCmd(app *App) *cobra.Command {
 	cmd.AddCommand(
 		newEvalRunCmd(app),
 		newEvalInitCmd(app),
-		newEvalGradeCmd(app),
 		newEvalAggregateCmd(app),
 		newEvalReportCmd(app),
 		newEvalCompareCmd(app),
@@ -265,16 +264,7 @@ func runEvalInit(app *App, skill string) error {
 	return scaffoldEvalsDir(filepath.Join(skillDir, "evals"), skillBasename(skillDir))
 }
 
-// --- eval grade / aggregate / report ---------------------------------------
-
-func newEvalGradeCmd(app *App) *cobra.Command {
-	return &cobra.Command{
-		Use:   "grade <iteration-dir>",
-		Short: "Re-grade every session in an existing iteration directory",
-		Args:  cobra.ExactArgs(1),
-		RunE:  func(cmd *cobra.Command, args []string) error { return fmt.Errorf("grade: not implemented in v1 — re-run `eval run` to regrade") },
-	}
-}
+// --- eval aggregate / report ------------------------------------------------
 
 func newEvalAggregateCmd(app *App) *cobra.Command {
 	return &cobra.Command{


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Category: cleanup without regression

`eval grade <iteration-dir>` was a v1 placeholder whose `RunE` always returned `"grade: not implemented in v1 — re-run eval run to regrade"`. It advertised a capability that doesn't exist, is undocumented, and isn't referenced by any test.

### Decision: drop (not implement)
A correct standalone re-grade would need to reconstruct a full `grader.Request` per session from disk (eval prompt, assertions remapped from `scenarios.json`, persisted transcript, tool-call counts) and re-instantiate the LLM judge. That's a real feature with correctness risk, out of scope for a cleanup. The existing `eval aggregate` already rebuilds `trajectory.json`/`benchmark.json` from on-disk `grading.json` files, covering the "recompute without re-running the agent" need. Implementing true re-grade is left for a dedicated PR.

### Testing
- `make build`, `go -C cli vet ./cmd/humblskills/`, `go -C cli test -count=1 ./cmd/humblskills/`
- `eval --help` no longer lists `grade`; `aggregate` still present

---
*Draft from the backlog. Confirm to keep or scrap — if you'd prefer a real re-grade implementation instead, say so and I'll spec it out.*
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1bb3-3368-7e27-b650-cd1478cbedb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1bb3-3368-7e27-b650-cd1478cbedb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

