### PR TITLE
feat(tui): add ? help overlay to the two-pane list model

### DIFF
--- a/cli/internal/tui/listdetail.go
+++ b/cli/internal/tui/listdetail.go
@@ -97,6 +97,7 @@ type Model struct {
 	preview  viewport.Model
 	filter   textinput.Model
 	filtOn   bool
+	helpOn   bool // ? overlay: full-body keybinding cheatsheet
 	result   Result
 	keys     Keys
 	actions  map[string]ActionSpec // keyed by ActionSpec.Key
@@ -165,11 +166,27 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, cmd
 
 	case tea.KeyMsg:
+		if m.helpOn {
+			return m.updateHelp(msg)
+		}
 		if m.filtOn {
 			return m.updateFilter(msg)
 		}
 		return m.updateNav(msg)
 	}
+	return m, nil
+}
+
+// updateHelp handles keys while the ? overlay is open. ctrl+c still quits the
+// program; every other key just dismisses the overlay so it never traps the
+// user.
+func (m Model) updateHelp(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if msg.String() == "ctrl+c" {
+		m.result = Result{Quit: true}
+		m.done = true
+		return m, tea.Quit
+	}
+	m.helpOn = false
 	return m, nil
 }
 
@@ -217,6 +234,9 @@ func (m Model) updateNav(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.filtOn = true
 			m.filter.Focus()
 		}
+		return m, nil
+	case key.Matches(msg, m.keys.Help):
+		m.helpOn = true
 		return m, nil
 	}
 
@@ -411,17 +431,23 @@ func (m Model) View() string {
 		Meta:    metaRight,
 	}, m.width)
 
-	body := m.renderBody(leftW, rightW)
-
-	focused := ""
-	if m.cfg.FocusedLabel != nil {
-		focused = m.cfg.FocusedLabel(m.items, m.cursor)
-	} else if len(m.items) > 0 {
-		// "focused:" stays muted; the value (item key) renders in the
-		// magenta brand colour to match the design.
-		focused = th.Meta.Render("focused: ") + th.Brand.Render(m.items[m.cursor].Key())
+	var body string
+	var footer string
+	if m.helpOn {
+		body = m.renderHelp()
+		footer = Footer(th, []KeyHint{{Keys: "any key", Label: "close help"}}, "", m.width)
+	} else {
+		body = m.renderBody(leftW, rightW)
+		focused := ""
+		if m.cfg.FocusedLabel != nil {
+			focused = m.cfg.FocusedLabel(m.items, m.cursor)
+		} else if len(m.items) > 0 {
+			// "focused:" stays muted; the value (item key) renders in the
+			// magenta brand colour to match the design.
+			focused = th.Meta.Render("focused: ") + th.Brand.Render(m.items[m.cursor].Key())
+		}
+		footer = Footer(th, m.hints(), focused, m.width)
 	}
-	footer := Footer(th, m.hints(), focused, m.width)
 
 	bodyH := m.height - lipgloss.Height(header) - lipgloss.Height(footer) - 1
 	if bodyH < 5 {
@@ -553,8 +579,83 @@ func (m Model) hints() []KeyHint {
 	if backLabel == "" {
 		backLabel = "quit"
 	}
+	hints = append(hints, KeyHint{Keys: "?", Label: "help"})
 	hints = append(hints, KeyHint{Keys: backKey, Label: backLabel})
 	return hints
+}
+
+// renderHelp draws the ? overlay body: a keybinding cheatsheet grouped by
+// concern. It reflects the model's actual configuration (filter only when the
+// list is filterable, the caller's Actions, the caller's back key/label) so the
+// sheet never advertises a key that does nothing.
+func (m Model) renderHelp() string {
+	th := m.cfg.Theme
+
+	type helpRow struct{ keys, label string }
+	type helpGroup struct {
+		title string
+		rows  []helpRow
+	}
+
+	nav := helpGroup{title: "NAVIGATE", rows: []helpRow{
+		{"↑ / k", "move up"},
+		{"↓ / j", "move down"},
+	}}
+	if m.cfg.Items != nil {
+		nav.rows = append(nav.rows, helpRow{"/", "filter list"})
+	}
+
+	scroll := helpGroup{title: "SCROLL DETAIL", rows: []helpRow{
+		{"⇞ / ⇟", "page up / down"},
+		{"ctrl+u / ctrl+d", "half page up / down"},
+		{"shift+↑ / shift+↓", "line up / down"},
+		{"home / end", "jump to top / bottom"},
+	}}
+
+	groups := []helpGroup{nav, scroll}
+
+	if len(m.cfg.Actions) > 0 {
+		rows := make([]helpRow, 0, len(m.cfg.Actions))
+		for i, a := range m.cfg.Actions {
+			keys := a.Key
+			if i == 0 {
+				// The first action is also bound to enter (see updateNav).
+				keys = a.Key + " / enter"
+			}
+			rows = append(rows, helpRow{keys, a.Label})
+		}
+		groups = append(groups, helpGroup{title: "ACTIONS", rows: rows})
+	}
+
+	backKey := firstNonEmpty(m.cfg.BackKey, "q")
+	backLabel := firstNonEmpty(m.cfg.BackLabel, "quit")
+	groups = append(groups, helpGroup{title: "GENERAL", rows: []helpRow{
+		{"?", "toggle this help"},
+		{backKey + " / esc", backLabel},
+		{"ctrl+c", "quit"},
+	}})
+
+	// Align the key column to the widest key across every group so the labels
+	// form a clean second column.
+	keyW := 0
+	for _, g := range groups {
+		for _, r := range g.rows {
+			if w := lipgloss.Width(r.keys); w > keyW {
+				keyW = w
+			}
+		}
+	}
+
+	var sb strings.Builder
+	sb.WriteString("  " + th.SectionTitle.Render(spacedUpper("Keybindings")) + "\n")
+	for _, g := range groups {
+		sb.WriteString("\n  " + th.Meta.Render(g.title) + "\n")
+		for _, r := range g.rows {
+			keyCol := r.keys + strings.Repeat(" ", keyW-lipgloss.Width(r.keys))
+			sb.WriteString("    " + th.Brand.Render(keyCol) + "  " + th.Detail.Render(r.label) + "\n")
+		}
+	}
+	return strings.TrimRight(sb.String(), "\n")
 }
 
 // RunListDetail runs the model on an alt-screen and returns the user's choice.

--- a/cli/internal/tui/listdetail_test.go
+++ b/cli/internal/tui/listdetail_test.go
@@ -178,6 +178,65 @@ func TestModel_ViewMentionsTitles(t *testing.T) {
 	}
 }
 
+func TestModel_HelpOverlayTogglesAndDismisses(t *testing.T) {
+	m := newTestListDetail(
+		[]Item{testItem{name: "a", filter: "a"}},
+		[]ActionSpec{{Key: "i", Label: "install", Action: "install"}},
+	)
+	m.width, m.height = 80, 24
+	m.resize()
+
+	// ? opens the overlay.
+	out, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("?")})
+	mm := out.(Model)
+	if !mm.helpOn {
+		t.Fatal("expected help overlay on after ?")
+	}
+
+	// The overlay body lists the caller's action and the general keys.
+	v := mm.View()
+	for _, want := range []string{"KEYBINDINGS", "NAVIGATE", "install", "toggle this help", "close help"} {
+		if !strings.Contains(v, want) {
+			t.Errorf("help view missing %q:\n%s", want, v)
+		}
+	}
+
+	// Any key (here: a bare rune) dismisses the overlay without firing actions.
+	out, _ = mm.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("x")})
+	mm = out.(Model)
+	if mm.helpOn {
+		t.Error("expected help overlay dismissed after key press")
+	}
+	if mm.result.Action != "" || mm.result.Quit {
+		t.Errorf("dismiss key should not trigger action/quit: %+v", mm.result)
+	}
+}
+
+func TestModel_HelpOverlayCtrlCQuits(t *testing.T) {
+	m := newTestListDetail([]Item{testItem{name: "a", filter: "a"}}, nil)
+	m.width, m.height = 80, 24
+	out, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("?")})
+	mm := out.(Model)
+	out, cmd := mm.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
+	mm = out.(Model)
+	if !mm.result.Quit {
+		t.Error("ctrl+c from help should quit")
+	}
+	if cmd == nil {
+		t.Error("expected Quit cmd from ctrl+c")
+	}
+}
+
+func TestModel_FooterShowsHelpHint(t *testing.T) {
+	m := newTestListDetail([]Item{testItem{name: "a", filter: "a"}}, nil)
+	m.width, m.height = 80, 24
+	m.resize()
+	v := m.View()
+	if !strings.Contains(v, "help") {
+		t.Errorf("footer should advertise the ? help hint:\n%s", v)
+	}
+}
+
 func TestModel_EmptyItemsShowsEmptyMsg(t *testing.T) {
 	m := newTestListDetail(nil, nil)
 	m.width, m.height = 80, 24

--- a/registry.json
+++ b/registry.json
@@ -1,10 +1,10 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-07-01T03:20:46Z",
+  "generated_at": "2026-07-01T04:43:17Z",
   "source": {
     "repo": "github.com/jjfantini/humblSKILLS",
-    "ref": "develop",
-    "sha": "3d0af4b161975be7b41ee8ee9891f125befa67c2"
+    "ref": "cursor/feat-tui-help-overlay-edb2",
+    "sha": "81c474ebbecb2bce3c336108e6e1648f74ac506b"
   },
   "skills": [
     {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Adds a discoverable `?` keybinding cheatsheet overlay to the shared `listdetail` two-pane TUI model (used by `doctor`, `update`, and skill browsing). The `Help` binding (`?`) already existed in `DefaultKeys()` but was never wired to anything.

Pressing `?` swaps the two-pane body for a grouped keybinding sheet:

- **NAVIGATE** - up/down, and filter (only shown when the list is filterable)
- **SCROLL DETAIL** - page/half-page/line scroll + home/end
- **ACTIONS** - the caller's configured `ActionSpec`s (first also bound to enter)
- **GENERAL** - `?` toggle, the caller's back key/label, `ctrl+c`

The sheet reflects the model's actual config, so it never advertises a key that does nothing. Any key dismisses the overlay (`ctrl+c` still quits). The footer gains a `? help` hint for discoverability, and switches to `any key  close help` while the overlay is open.

## Why

The keymap advertised a help key but had no help screen. New users had no in-app way to learn scroll/action bindings beyond the terse footer.

## Testing

- `go -C cli test -race -count=1 ./internal/tui/...` - added `TestModel_HelpOverlayTogglesAndDismisses`, `TestModel_HelpOverlayCtrlCQuits`, `TestModel_FooterShowsHelpHint`.
- `make vet`, `make build`.
- Manual GUI test via `./bin/humblskills doctor`:

<a href="https://cursor.com/agents/bc-019f1bb3-3368-7e27-b650-cd1478cbedb2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftui_help_overlay_demo.mp4"><img src="https://cursor.com/artifacts/c/art-76010600-0533-4abd-9fd8-d6a2e8bcd741" alt="tui_help_overlay_demo.mp4" /></a>

![Help overlay](https://cursor.com/artifacts/c/art-cb0acced-23cf-4121-a8f9-fa8493254cfe)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1bb3-3368-7e27-b650-cd1478cbedb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1bb3-3368-7e27-b650-cd1478cbedb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

