### PR TITLE
fix(tui): footer overflow, filter-mode hints, and detail scroll indicator

### DIFF
--- a/cli/go.mod
+++ b/cli/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.4
 	github.com/charmbracelet/huh v0.6.0
 	github.com/charmbracelet/lipgloss v1.1.0
+	github.com/charmbracelet/x/ansi v0.9.3
 	github.com/maaslalani/confetty v0.0.0-20221105190856-6c6f1b5b605f
 	github.com/muesli/termenv v0.16.0
 	github.com/openai/openai-go v1.12.0
@@ -26,7 +27,6 @@ require (
 	github.com/catppuccin/go v0.3.0 // indirect
 	github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc // indirect
 	github.com/charmbracelet/harmonica v0.2.0 // indirect
-	github.com/charmbracelet/x/ansi v0.9.3 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.13 // indirect
 	github.com/charmbracelet/x/exp/strings v0.0.0-20240722160745-212f7b056ed0 // indirect
 	github.com/charmbracelet/x/term v0.2.1 // indirect

--- a/cli/internal/tui/chrome.go
+++ b/cli/internal/tui/chrome.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
 
 	"github.com/jjfantini/humblSKILLS/cli/internal/ui"
 )
@@ -66,9 +67,29 @@ func Footer(theme *ui.Theme, hints []KeyHint, right string, width int) string {
 	left := strings.Join(parts, "  ")
 	// `right` is passed through unchanged so callers can compose mixed
 	// styles (e.g. muted label + magenta value for `focused: <name>`).
-	line := padBetween(left, right, width-2)
+	line := composeFooterLine(left, right, width-2)
 	rule := DashedRule(theme, width-2)
 	return "  " + rule + "\n  " + line
+}
+
+// composeFooterLine fits the hint block (left) and context (right) into avail
+// display columns without overflowing — an overflowing footer wraps in the
+// alt-screen and shoves the whole layout up a row. Priority: keep the
+// keybindings. If left+right won't fit, drop the (secondary) right context;
+// if the hints alone still overflow, truncate them with an ellipsis.
+func composeFooterLine(left, right string, avail int) string {
+	if avail < 1 {
+		avail = 1
+	}
+	lw := lipgloss.Width(left)
+	rw := lipgloss.Width(right)
+	if rw > 0 && lw+1+rw <= avail {
+		return padBetween(left, right, avail)
+	}
+	if lw <= avail {
+		return left
+	}
+	return ansi.Truncate(left, avail, "…")
 }
 
 // DashedRule returns a dashed horizontal line (╌) coloured with the border

--- a/cli/internal/tui/chrome_test.go
+++ b/cli/internal/tui/chrome_test.go
@@ -1,0 +1,68 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/jjfantini/humblSKILLS/cli/internal/ui"
+)
+
+func asciiTheme() *ui.Theme {
+	return ui.NewTheme(ui.DefaultPalette(), nil, true)
+}
+
+// A footer that overflows the terminal width wraps in the alt-screen and shoves
+// the layout up a row, so no rendered line may exceed the requested width.
+func TestFooter_DoesNotOverflowWidth(t *testing.T) {
+	th := asciiTheme()
+	hints := []KeyHint{
+		{Keys: "↑↓", Label: "select"},
+		{Keys: "/", Label: "filter"},
+		{Keys: "⇞⇟", Label: "scroll"},
+		{Keys: "i/enter", Label: "install"},
+		{Keys: "u", Label: "update"},
+		{Keys: "x", Label: "uninstall"},
+		{Keys: "q", Label: "quit"},
+	}
+	for _, w := range []int{40, 55, 80, 120} {
+		f := Footer(th, hints, "focused: some-really-long-skill-name", w)
+		for _, ln := range strings.Split(f, "\n") {
+			if got := lipgloss.Width(ln); got > w {
+				t.Errorf("width=%d: footer line %q width=%d exceeds %d", w, ln, got, w)
+			}
+		}
+	}
+}
+
+func TestComposeFooterLine_TruncatesLongHints(t *testing.T) {
+	left := strings.Repeat("x", 100)
+	got := composeFooterLine(left, "", 20)
+	if w := lipgloss.Width(got); w > 20 {
+		t.Errorf("width=%d exceeds 20: %q", w, got)
+	}
+	if !strings.HasSuffix(got, "…") {
+		t.Errorf("expected ellipsis suffix, got %q", got)
+	}
+}
+
+func TestComposeFooterLine_DropsRightWhenTight(t *testing.T) {
+	left := strings.Repeat("x", 18)
+	right := "yyyy"
+	// 18 + 1 + 4 = 23 > 20, so the right context must be dropped entirely.
+	got := composeFooterLine(left, right, 20)
+	if strings.Contains(got, "y") {
+		t.Errorf("right context should be dropped when it doesn't fit: %q", got)
+	}
+	if w := lipgloss.Width(got); w > 20 {
+		t.Errorf("width=%d exceeds 20: %q", w, got)
+	}
+}
+
+func TestComposeFooterLine_KeepsRightWhenItFits(t *testing.T) {
+	got := composeFooterLine("abc", "xyz", 40)
+	if !strings.Contains(got, "abc") || !strings.Contains(got, "xyz") {
+		t.Errorf("expected both left and right to fit: %q", got)
+	}
+}

--- a/cli/internal/tui/listdetail.go
+++ b/cli/internal/tui/listdetail.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/charmbracelet/bubbles/key"
@@ -413,15 +414,23 @@ func (m Model) View() string {
 
 	body := m.renderBody(leftW, rightW)
 
-	focused := ""
-	if m.cfg.FocusedLabel != nil {
-		focused = m.cfg.FocusedLabel(m.items, m.cursor)
-	} else if len(m.items) > 0 {
-		// "focused:" stays muted; the value (item key) renders in the
-		// magenta brand colour to match the design.
-		focused = th.Meta.Render("focused: ") + th.Brand.Render(m.items[m.cursor].Key())
+	var footer string
+	if m.filtOn {
+		// While typing a filter the nav/action keys are inert, so surface the
+		// two keys that actually do something (esc clears, enter applies) plus
+		// a live match count instead of the stale nav hints.
+		footer = Footer(th, m.filterHints(), m.filterContext(), m.width)
+	} else {
+		focused := ""
+		if m.cfg.FocusedLabel != nil {
+			focused = m.cfg.FocusedLabel(m.items, m.cursor)
+		} else if len(m.items) > 0 {
+			// "focused:" stays muted; the value (item key) renders in the
+			// magenta brand colour to match the design.
+			focused = th.Meta.Render("focused: ") + th.Brand.Render(m.items[m.cursor].Key())
+		}
+		footer = Footer(th, m.hints(), focused, m.width)
 	}
-	footer := Footer(th, m.hints(), focused, m.width)
 
 	bodyH := m.height - lipgloss.Height(header) - lipgloss.Height(footer) - 1
 	if bodyH < 5 {
@@ -510,6 +519,13 @@ func (m Model) renderRight(width int) string {
 		return title
 	}
 
+	// When the detail body overflows the viewport, right-anchor a compact
+	// scroll indicator on the title row (▲/▽ arrows + percent) so users know
+	// there's more to see and which way to scroll.
+	if ind := m.scrollIndicator(th); ind != "" {
+		title = padBetween(title, ind, width)
+	}
+
 	preview := m.preview.View()
 	lines := strings.Split(preview, "\n")
 	out := make([]string, 0, len(lines)+2)
@@ -520,8 +536,47 @@ func (m Model) renderRight(width int) string {
 	for _, ln := range lines {
 		out = append(out, bar+" "+ln)
 	}
-	_ = width
 	return strings.Join(out, "\n")
+}
+
+// scrollIndicator returns a compact "▲▼ NN%" widget when the detail viewport
+// has more content than fits, or "" when everything is visible. A filled arrow
+// means there's content in that direction; a hollow one means you're at that
+// edge.
+func (m Model) scrollIndicator(th *ui.Theme) string {
+	if m.preview.TotalLineCount() <= m.preview.Height {
+		return ""
+	}
+	up, down := "△", "▽"
+	if !m.preview.AtTop() {
+		up = "▲"
+	}
+	if !m.preview.AtBottom() {
+		down = "▼"
+	}
+	pct := int(m.preview.ScrollPercent()*100 + 0.5)
+	return th.Meta.Render(fmt.Sprintf("%s%s %d%%", up, down, pct))
+}
+
+// filterHints are the footer hints shown while the filter input is focused.
+// Only esc/enter do anything in this mode, so advertise exactly those.
+func (m Model) filterHints() []KeyHint {
+	return []KeyHint{
+		{Keys: "esc", Label: "clear filter"},
+		{Keys: "enter", Label: "apply"},
+	}
+}
+
+// filterContext is the right-anchored footer text during filtering: a live
+// count of how many items currently match.
+func (m Model) filterContext() string {
+	th := m.cfg.Theme
+	n := len(m.items)
+	noun := "matches"
+	if n == 1 {
+		noun = "match"
+	}
+	return th.Meta.Render(fmt.Sprintf("%d %s", n, noun))
 }
 
 func (m Model) hints() []KeyHint {

--- a/cli/internal/tui/listdetail_test.go
+++ b/cli/internal/tui/listdetail_test.go
@@ -178,6 +178,57 @@ func TestModel_ViewMentionsTitles(t *testing.T) {
 	}
 }
 
+func TestModel_FilterFooterShowsEscHintAndCount(t *testing.T) {
+	m := newTestListDetail([]Item{
+		testItem{name: "alpha", filter: "alpha"},
+		testItem{name: "beta", filter: "beta"},
+	}, nil)
+	m.width, m.height = 80, 24
+	m.resize()
+
+	// Open the filter; footer should switch to filter-mode hints + a count.
+	out, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("/")})
+	mm := out.(Model)
+	v := mm.View()
+	for _, want := range []string{"clear filter", "apply", "2 matches"} {
+		if !strings.Contains(v, want) {
+			t.Errorf("filter footer missing %q:\n%s", want, v)
+		}
+	}
+
+	// Narrow it to a single match -> singular noun.
+	for _, r := range "alph" {
+		out, _ = mm.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+		mm = out.(Model)
+	}
+	if v := mm.View(); !strings.Contains(v, "1 match") {
+		t.Errorf("expected singular '1 match':\n%s", v)
+	}
+}
+
+func TestModel_ScrollIndicator(t *testing.T) {
+	m := newTestListDetail([]Item{testItem{name: "a", filter: "a"}}, nil)
+	m.width, m.height = 80, 12
+	m.resize()
+
+	// Short content: nothing overflows, so no indicator.
+	if ind := m.scrollIndicator(m.cfg.Theme); ind != "" {
+		t.Errorf("expected no indicator for short content, got %q", ind)
+	}
+
+	// Tall content: indicator appears with a percent and a down arrow (we're
+	// at the top, so more content lies below).
+	m.preview.SetContent(strings.Repeat("line\n", 100))
+	m.preview.GotoTop()
+	ind := m.scrollIndicator(m.cfg.Theme)
+	if ind == "" {
+		t.Fatal("expected scroll indicator for overflowing content")
+	}
+	if !strings.Contains(ind, "%") || !strings.Contains(ind, "▼") {
+		t.Errorf("indicator should show percent and a down arrow: %q", ind)
+	}
+}
+
 func TestModel_EmptyItemsShowsEmptyMsg(t *testing.T) {
 	m := newTestListDetail(nil, nil)
 	m.width, m.height = 80, 24

--- a/registry.json
+++ b/registry.json
@@ -1,10 +1,10 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-07-01T03:20:46Z",
+  "generated_at": "2026-07-01T04:51:01Z",
   "source": {
     "repo": "github.com/jjfantini/humblSKILLS",
-    "ref": "develop",
-    "sha": "3d0af4b161975be7b41ee8ee9891f125befa67c2"
+    "ref": "cursor/fix-footer-filter-scroll-hints-edb2",
+    "sha": "3abf578f1b9e03e7cc085afcc8a69d6da36e4c27"
   },
   "skills": [
     {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Three small, focused UX fixes to the shared `listdetail` two-pane TUI:

1. **Footer no longer overflows.** `Footer` composed `left + right` and, when the combined hint block was wider than the terminal, let it overflow — which wraps in the alt-screen and shoves the whole layout up a row. New `composeFooterLine` fits the line into the available width: keep the keybindings, drop the secondary right context if it doesn't fit, and ANSI-truncate the hints with `…` as a last resort (uses `charmbracelet/x/ansi`).
2. **Filter mode gets its own footer.** While the `/` filter input is focused, nav/action keys are inert, yet the footer kept showing them. It now shows exactly the keys that work (`esc clear filter`, `enter apply`) plus a live match count (`7 matches` / `1 match`).
3. **Detail pane scroll indicator.** When the right-pane detail overflows the viewport, a compact `▲▼ NN%` widget is right-anchored on the DETAIL title row (hollow triangle = at that edge, filled = more content that way), so users know it's scrollable and where they are.

## Why

The footer overflow visibly broke the layout on narrow terminals; the filter footer advertised dead keys; and long detail bodies gave no hint they were scrollable.

## Testing

- `go -C cli test -race -count=1 ./internal/tui/...` - new `chrome_test.go` (footer width never exceeds requested width; truncation/drop-right behavior) and `listdetail_test.go` cases for filter footer hints/count and the scroll indicator.
- `make vet`, `make build`, `go mod tidy` (promotes `x/ansi` to a direct dep).
- Manual GUI test via `./bin/humblskills doctor`:

<a href="https://cursor.com/agents/bc-019f1bb3-3368-7e27-b650-cd1478cbedb2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftui_footer_filter_scroll_demo.mp4"><img src="https://cursor.com/artifacts/c/art-54f2c1c0-5414-4e72-9e2b-e53bd4411d79" alt="tui_footer_filter_scroll_demo.mp4" /></a>

Filter-mode footer with live match count:
![Filter footer hints](https://cursor.com/artifacts/c/art-88d76c92-a090-4427-a53f-6cb4c35a2ee5)

Detail scroll indicator (▲▼ 57%) in a narrow terminal, footer staying on one line:
![Scroll indicator](https://cursor.com/artifacts/c/art-e0ab4b11-6470-4d5c-9c8b-0a80c5d15ab5)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1bb3-3368-7e27-b650-cd1478cbedb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1bb3-3368-7e27-b650-cd1478cbedb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

