### PR TITLE
feat(doctor): humanize adapter match reasons and explain rw/ro badges

### DIFF
--- a/cli/cmd/humblskills/doctor.go
+++ b/cli/cmd/humblskills/doctor.go
@@ -433,12 +433,12 @@ func (a adapterItem) Detail(th *ui.Theme, width int) string {
 		th.Success.Render("detected"),
 		th.Error.Render("missing"))))
 	if a.a.Reason != "" {
-		sb.WriteString(kvRow(th, "matched on", th.KVValue.Render(a.a.Reason)))
+		sb.WriteString(kvRow(th, "reason", th.KVValue.Render(a.a.Reason)))
 	}
 
 	if len(a.a.Targets) > 0 {
 		sb.WriteString("\n")
-		sb.WriteString(th.SectionTitle.Render("PATHS"))
+		sb.WriteString(th.SectionTitle.Render("PATHS") + "  " + th.Detail.Render(rwLegend))
 		sb.WriteString("\n")
 		for i, t := range a.a.Targets {
 			if i > 0 {
@@ -701,6 +701,10 @@ func kvRow(th *ui.Theme, key, value string) string {
 	return "  " + label + strings.Repeat(" ", pad) + value + "\n"
 }
 
+// rwLegend explains the pills rendered by pathRow so users don't have to guess
+// what rw/ro mean.
+const rwLegend = "rw = writable · ro = read-only"
+
 // pathRow formats one target as `scope  [rw]  path`, matching the PATHS stack
 // in the design's detail pane.
 func pathRow(th *ui.Theme, t targetReport) string {
@@ -739,6 +743,7 @@ func printDoctorStatic(app *App, r doctorReport) {
 
 	app.UI.Section("Adapters")
 	anyDetected := false
+	legendShown := false
 	for _, a := range r.Adapters {
 		if a.Detected {
 			anyDetected = true
@@ -751,7 +756,12 @@ func printDoctorStatic(app *App, r doctorReport) {
 		}
 		fmt.Fprintf(app.UI.Out(), "  %s %s  %s\n", dot, th.DetailTitle.Render(a.Name), badge)
 		if a.Reason != "" {
-			fmt.Fprintf(app.UI.Out(), "    %s %s\n", th.KVKey.Render("matched on"), th.KVValue.Render(a.Reason))
+			fmt.Fprintf(app.UI.Out(), "    %s %s\n", th.KVKey.Render("reason"), th.KVValue.Render(a.Reason))
+		}
+		if len(a.Targets) > 0 && !legendShown {
+			// Explain the rw/ro pills once, the first time paths appear.
+			fmt.Fprintf(app.UI.Out(), "    %s\n", th.Detail.Render(rwLegend))
+			legendShown = true
 		}
 		for _, t := range a.Targets {
 			fmt.Fprintln(app.UI.Out(), "    "+pathRow(th, t))

--- a/cli/cmd/humblskills/doctor_test.go
+++ b/cli/cmd/humblskills/doctor_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/jjfantini/humblSKILLS/cli/internal/testutil"
+	"github.com/jjfantini/humblSKILLS/cli/internal/ui"
 )
 
 // Doctor tests exercise the JSON output path (deterministic) rather
@@ -61,6 +62,28 @@ func TestDoctor_ReportsAdapters(t *testing.T) {
 	}
 	if got.Registry.Skills != 1 {
 		t.Errorf("registry.skills = %d, want 1", got.Registry.Skills)
+	}
+}
+
+func TestAdapterItem_DetailHumanizesReasonAndExplainsBadges(t *testing.T) {
+	th := ui.NewTheme(ui.DefaultPalette(), nil, true)
+	it := adapterItem{a: adapterReport{
+		Name:     "cursor",
+		Detected: true,
+		Reason:   "found ~/.cursor",
+		Targets: []targetReport{
+			{Scope: "user", Path: "/home/x/.cursor/skills", Writable: true},
+			{Scope: "project", Path: "/ro/.cursor/skills", Writable: false},
+		},
+	}}
+	d := it.Detail(th, 60)
+	for _, want := range []string{"reason", "found ~/.cursor", "rw = writable", "read-only"} {
+		if !strings.Contains(d, want) {
+			t.Errorf("adapter detail missing %q:\n%s", want, d)
+		}
+	}
+	if strings.Contains(d, "matched on") {
+		t.Errorf("stale 'matched on' label still present:\n%s", d)
 	}
 }
 

--- a/cli/internal/adapters/adapters_coverage_test.go
+++ b/cli/internal/adapters/adapters_coverage_test.go
@@ -75,7 +75,7 @@ func TestDetect_AllOfFailsEarly(t *testing.T) {
 	if got[0].Detected {
 		t.Error("expected Detected=false")
 	}
-	if !strings.Contains(got[0].Reason, "all_of failed") {
+	if !strings.Contains(got[0].Reason, "not found") {
 		t.Errorf("reason = %q", got[0].Reason)
 	}
 }
@@ -97,7 +97,7 @@ func TestDetect_AnyOfMatchesFirst(t *testing.T) {
 	if !got[0].Detected {
 		t.Errorf("expected match: %+v", got[0])
 	}
-	if !strings.Contains(got[0].Reason, "matched") {
+	if !strings.Contains(got[0].Reason, "is set") {
 		t.Errorf("reason = %q", got[0].Reason)
 	}
 }

--- a/cli/internal/adapters/detect.go
+++ b/cli/internal/adapters/detect.go
@@ -31,19 +31,19 @@ func evalRules(d DetectRules) (bool, string) {
 	case len(d.AllOf) > 0:
 		for _, r := range d.AllOf {
 			if !evalRule(r) {
-				return false, "all_of failed at: " + describeRule(r)
+				return false, describeMiss(r)
 			}
 		}
-		return true, "all_of rules matched"
+		return true, "all checks passed"
 	case len(d.AnyOf) > 0:
 		for _, r := range d.AnyOf {
 			if evalRule(r) {
-				return true, "matched: " + describeRule(r)
+				return true, describeMatch(r)
 			}
 		}
-		return false, "no any_of rule matched"
+		return false, "no matching paths or env vars found"
 	default:
-		return false, "no detect rules declared"
+		return false, "no detection rules configured"
 	}
 }
 
@@ -62,16 +62,33 @@ func evalRule(r DetectRule) bool {
 	return false
 }
 
-func describeRule(r DetectRule) string {
+// describeMatch phrases why a rule matched, in plain language suitable for the
+// doctor "reason" row (e.g. "found ~/.claude", "$CURSOR_TRACE_ID is set").
+func describeMatch(r DetectRule) string {
 	switch {
 	case r.PathExists != "" && r.Env != "":
-		return fmt.Sprintf("path_exists=%s env=%s", r.PathExists, r.Env)
+		return fmt.Sprintf("found %s or $%s set", r.PathExists, r.Env)
 	case r.PathExists != "":
-		return "path_exists=" + r.PathExists
+		return "found " + r.PathExists
 	case r.Env != "":
-		return "env=" + r.Env
+		return "$" + r.Env + " is set"
 	default:
-		return "<empty rule>"
+		return "matched an empty rule"
+	}
+}
+
+// describeMiss phrases why a rule did not match, mirroring describeMatch (e.g.
+// "~/.cursor not found", "$CURSOR_TRACE_ID not set").
+func describeMiss(r DetectRule) string {
+	switch {
+	case r.PathExists != "" && r.Env != "":
+		return fmt.Sprintf("%s not found and $%s not set", r.PathExists, r.Env)
+	case r.PathExists != "":
+		return r.PathExists + " not found"
+	case r.Env != "":
+		return "$" + r.Env + " not set"
+	default:
+		return "empty detection rule"
 	}
 }
 

--- a/registry.json
+++ b/registry.json
@@ -1,10 +1,10 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-07-01T03:20:46Z",
+  "generated_at": "2026-07-01T05:00:03Z",
   "source": {
     "repo": "github.com/jjfantini/humblSKILLS",
-    "ref": "develop",
-    "sha": "3d0af4b161975be7b41ee8ee9891f125befa67c2"
+    "ref": "cursor/feat-doctor-humanize-reasons-edb2",
+    "sha": "d8986a0c259dbcede49a1fc512a0754c04498fcc"
   },
   "skills": [
     {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Two small doctor readability improvements:

1. **Plain-English detection reasons.** Adapter detection previously surfaced its internal rule syntax as the "matched on" value - e.g. `matched: path_exists=~/.cursor`, `all_of failed at: path_exists=~/.claude`, `no any_of rule matched`. These now read as sentences:
   - `found ~/.cursor`
   - `$CURSOR_TRACE_ID is set`
   - `~/.claude not found`
   - `no matching paths or env vars found`
   - `all checks passed` / `no detection rules configured`

   Humanized at the source in `adapters/detect.go` (single source of truth: JSON `reason`, TUI, and static output all stay consistent). The doctor detail label changed from `matched on` to `reason` so it reads well for both detected and missing adapters.

2. **rw/ro legend.** The PATHS stack renders `rw`/`ro` pills with no explanation. Added a one-line legend `rw = writable · ro = read-only` under the PATHS heading (TUI) and once before the first path (static/non-TTY).

## Why

The old reasons leaked the detect-rule DSL at users; the rw/ro pills were unexplained. Both are quick wins for a command whose whole job is being understandable.

## Testing

- `go -C cli test -race -count=1 ./internal/adapters/... ./cmd/humblskills/...` - updated adapter reason assertions to the new phrasing; added `TestAdapterItem_DetailHumanizesReasonAndExplainsBadges`.
- `make vet`, `make build`, plus `./bin/humblskills doctor` static output confirming reasons + legend.
- Manual GUI test:

<a href="https://cursor.com/agents/bc-019f1bb3-3368-7e27-b650-cd1478cbedb2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdoctor_humanized_reasons_demo.mp4"><img src="https://cursor.com/artifacts/c/art-136e5411-b148-46d6-b221-9b235a4c9cd6" alt="doctor_humanized_reasons_demo.mp4" /></a>

![Doctor detail with plain-English reason and rw/ro legend](https://cursor.com/artifacts/c/art-acdf4c80-9f56-49a7-9f5e-957395add2d4)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1bb3-3368-7e27-b650-cd1478cbedb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1bb3-3368-7e27-b650-cd1478cbedb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

