### PR TITLE
feat(registry): add a required skill category taxonomy

### DIFF
--- a/cli/cmd/build-registry/main.go
+++ b/cli/cmd/build-registry/main.go
@@ -106,6 +106,7 @@ func run(skillsDir, outFile, repo, ref, sha string, check bool) error {
 			Name:        p.fm.Name,
 			Version:     p.fm.Version(),
 			Description: p.fm.Description,
+			Category:    p.fm.Category(),
 			Tags:        p.fm.Tags(),
 			Platforms:   p.fm.Platforms(),
 			Requires:    p.fm.Requires(),

--- a/cli/cmd/build-registry/main_test.go
+++ b/cli/cmd/build-registry/main_test.go
@@ -16,6 +16,8 @@ func validSkillMD(name, version string) string {
 		"name: " + name + "\n" +
 		"description: " + name + " description line long enough\n" +
 		"version: " + version + "\n" +
+		"metadata:\n" +
+		"  category: development\n" +
 		"---\n\n# " + name + "\n\nBody.\n"
 }
 
@@ -63,6 +65,45 @@ func TestRun_BuildsRegistryForValidSkills(t *testing.T) {
 		if s.DirSHA == "" {
 			t.Errorf("%s: empty DirSHA", s.Name)
 		}
+		if s.Category != "development" {
+			t.Errorf("%s: category = %q, want development", s.Name, s.Category)
+		}
+	}
+}
+
+func TestRun_MissingCategory_Rejected(t *testing.T) {
+	root := t.TempDir()
+	skillsDir := filepath.Join(root, "skills")
+	d := filepath.Join(skillsDir, "nocategory")
+	if err := os.MkdirAll(d, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := "---\nname: nocategory\ndescription: missing category on purpose\nversion: 1.0.0\n---\nBody.\n"
+	if err := os.WriteFile(filepath.Join(d, "SKILL.md"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := run(skillsDir, filepath.Join(root, "registry.json"), "r", "main", "sha", false)
+	if err == nil || !strings.Contains(err.Error(), "category is required") {
+		t.Fatalf("expected missing-category validation error, got %v", err)
+	}
+}
+
+func TestRun_UnknownCategory_Rejected(t *testing.T) {
+	root := t.TempDir()
+	skillsDir := filepath.Join(root, "skills")
+	d := filepath.Join(skillsDir, "badcategory")
+	if err := os.MkdirAll(d, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := "---\nname: badcategory\ndescription: unknown category on purpose\nversion: 1.0.0\nmetadata:\n  category: astrology\n---\nBody.\n"
+	if err := os.WriteFile(filepath.Join(d, "SKILL.md"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := run(skillsDir, filepath.Join(root, "registry.json"), "r", "main", "sha", false)
+	if err == nil || !strings.Contains(err.Error(), `unknown category "astrology"`) {
+		t.Fatalf("expected unknown-category validation error, got %v", err)
 	}
 }
 
@@ -170,6 +211,7 @@ func TestRun_CycleIsRejected(t *testing.T) {
 			"description: cycle test skill body long enough\n" +
 			"version: 1.0.0\n" +
 			"metadata:\n" +
+			"  category: development\n" +
 			"  requires:\n" +
 			"    - " + dep + "@1.0.0\n" +
 			"---\n# " + name + "\nBody.\n"

--- a/cli/cmd/humblskills/browse_skills.go
+++ b/cli/cmd/humblskills/browse_skills.go
@@ -50,7 +50,7 @@ func (s skillItem) primary() *manifest.Installation {
 
 func (s skillItem) Key() string { return s.s.Name }
 func (s skillItem) FilterValue() string {
-	return strings.ToLower(s.s.Name + " " + strings.Join(s.s.Tags, " ") + " " + s.s.Description)
+	return strings.ToLower(s.s.Name + " " + s.s.Category + " " + strings.Join(s.s.Tags, " ") + " " + s.s.Description)
 }
 
 // NaturalWidth reports the row's display width: dot + space + name + 2-gap
@@ -100,6 +100,9 @@ func (s skillItem) Detail(th *ui.Theme, width int) string {
 		sb.WriteString(desc + "\n\n")
 	}
 
+	if s.s.Category != "" {
+		sb.WriteString(kvRow(th, "category", th.Category.Render(s.s.Category)))
+	}
 	if len(s.s.Tags) > 0 {
 		chips := make([]string, 0, len(s.s.Tags))
 		for _, t := range s.s.Tags {

--- a/cli/cmd/humblskills/search.go
+++ b/cli/cmd/humblskills/search.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 
+	"github.com/jjfantini/humblSKILLS/cli/internal/frontmatter"
 	"github.com/jjfantini/humblSKILLS/cli/internal/manifest"
 	"github.com/jjfantini/humblSKILLS/cli/internal/registry"
 	"github.com/jjfantini/humblSKILLS/cli/internal/tui"
@@ -17,11 +18,20 @@ import (
 )
 
 func newSearchCmd(app *App) *cobra.Command {
-	return &cobra.Command{
+	var category string
+	cmd := &cobra.Command{
 		Use:   "search [query]",
 		Short: "Search the registry by name, description, or tag",
-		Args:  cobra.MaximumNArgs(1),
+		Long: "search matches a query against each skill's name, description, and " +
+			"tags. Narrow to one category with --category (see " +
+			"'humblskills search --category=' for the list of valid values).",
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			category = strings.ToLower(strings.TrimSpace(category))
+			if category != "" && !frontmatter.IsKnownCategory(category) {
+				return fmt.Errorf("unknown --category %q (must be one of %s)", category, strings.Join(frontmatter.Categories, ", "))
+			}
+
 			reg, _, err := registry.NewFetcher(app.Config.RegistryURL, app.Config.CacheDir).Load()
 			if err != nil {
 				return err
@@ -33,6 +43,9 @@ func newSearchCmd(app *App) *cobra.Command {
 
 			var hits []registry.Skill
 			for _, s := range reg.Skills {
+				if category != "" && s.Category != category {
+					continue
+				}
 				if query == "" || matches(s, query) {
 					hits = append(hits, s)
 				}
@@ -41,9 +54,10 @@ func newSearchCmd(app *App) *cobra.Command {
 
 			if app.Config.JSON {
 				return app.UI.JSON(struct {
-					Query   string           `json:"query,omitempty"`
-					Results []registry.Skill `json:"results"`
-				}{query, hits})
+					Query    string           `json:"query,omitempty"`
+					Category string           `json:"category,omitempty"`
+					Results  []registry.Skill `json:"results"`
+				}{query, category, hits})
 			}
 			if len(hits) == 0 {
 				app.UI.Warn("no skills matched %q", query)
@@ -61,6 +75,8 @@ func newSearchCmd(app *App) *cobra.Command {
 			return nil
 		},
 	}
+	cmd.Flags().StringVar(&category, "category", "", "restrict results to one category ("+strings.Join(frontmatter.Categories, ", ")+")")
+	return cmd
 }
 
 func matches(s registry.Skill, q string) bool {
@@ -148,6 +164,9 @@ func renderSearchResults(theme *ui.Theme, hits []registry.Skill, query string) s
 			for _, line := range strings.Split(wrapped, "\n") {
 				sb.WriteString("    " + line + "\n")
 			}
+		}
+		if s.Category != "" {
+			sb.WriteString("    " + theme.Label.Render("category ") + theme.Category.Render(s.Category) + "\n")
 		}
 		if len(s.Tags) > 0 {
 			chips := make([]string, 0, len(s.Tags))

--- a/cli/cmd/humblskills/search_test.go
+++ b/cli/cmd/humblskills/search_test.go
@@ -71,6 +71,84 @@ func TestSearch_TagMatch_JSON(t *testing.T) {
 	}
 }
 
+func TestSearch_CategoryFilter_JSON(t *testing.T) {
+	s := testutil.NewSandbox(t)
+
+	regURL := seedTestRegistry(t, s, []testutil.SkillFixture{
+		{Name: "alpha", Version: "1.0.0", Category: "development",
+			Files: testutil.SkillTree{"SKILL.md": sampleSkillMD}},
+		{Name: "beta", Version: "1.0.0", Category: "writing",
+			Files: testutil.SkillTree{"SKILL.md": sampleSkillMD}},
+	})
+	res := runCLIWithStdoutCapture(t,
+		"search",
+		"--category", "development",
+		"--registry", regURL,
+		"--cache-dir", s.CacheDir,
+		"--json",
+	)
+	if res.RunErr != nil {
+		t.Fatalf("run: %v\n%s", res.RunErr, res.Err)
+	}
+	idx := strings.Index(res.Out, "{")
+	var out struct {
+		Results []struct{ Name string } `json:"results"`
+	}
+	if err := json.Unmarshal([]byte(res.Out[idx:]), &out); err != nil {
+		t.Fatalf("parse: %v\n%s", err, res.Out)
+	}
+	if len(out.Results) != 1 || out.Results[0].Name != "alpha" {
+		t.Errorf("results = %+v", out.Results)
+	}
+}
+
+func TestSearch_CategoryFilter_CombinesWithQuery(t *testing.T) {
+	s := testutil.NewSandbox(t)
+
+	regURL := seedTestRegistry(t, s, []testutil.SkillFixture{
+		{Name: "commit-helper", Version: "1.0.0", Category: "development",
+			Files: testutil.SkillTree{"SKILL.md": sampleSkillMD}},
+		{Name: "commit-poems", Version: "1.0.0", Category: "writing",
+			Files: testutil.SkillTree{"SKILL.md": sampleSkillMD}},
+	})
+	res := runCLIWithStdoutCapture(t,
+		"search", "commit",
+		"--category", "writing",
+		"--registry", regURL,
+		"--cache-dir", s.CacheDir,
+		"--json",
+	)
+	if res.RunErr != nil {
+		t.Fatalf("run: %v\n%s", res.RunErr, res.Err)
+	}
+	idx := strings.Index(res.Out, "{")
+	var out struct {
+		Results []struct{ Name string } `json:"results"`
+	}
+	_ = json.Unmarshal([]byte(res.Out[idx:]), &out)
+	if len(out.Results) != 1 || out.Results[0].Name != "commit-poems" {
+		t.Errorf("results = %+v", out.Results)
+	}
+}
+
+func TestSearch_UnknownCategory_Errors(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	regURL := seedTestRegistry(t, s, []testutil.SkillFixture{
+		{Name: "alpha", Version: "1.0.0", Category: "development",
+			Files: testutil.SkillTree{"SKILL.md": sampleSkillMD}},
+	})
+	res := runCLIWithStdoutCapture(t,
+		"search",
+		"--category", "astrology",
+		"--registry", regURL,
+		"--cache-dir", s.CacheDir,
+		"--json",
+	)
+	if res.RunErr == nil {
+		t.Fatal("expected error for unknown --category")
+	}
+}
+
 func TestSearch_NoResults_JSON(t *testing.T) {
 	s := testutil.NewSandbox(t)
 

--- a/cli/internal/frontmatter/frontmatter.go
+++ b/cli/internal/frontmatter/frontmatter.go
@@ -12,6 +12,7 @@
 //	metadata:
 //	  author: jjfantini
 //	  version: 1.0.0                   # humblSKILLS requires this
+//	  category: development            # humblSKILLS requires this, one of a closed set
 //	  tags: [...]
 //	  platforms: [claude-code]
 //	  requires: [...]
@@ -40,6 +41,7 @@ const delimiter = "---"
 type Metadata struct {
 	Author    string   `yaml:"author,omitempty"`
 	Version   string   `yaml:"version,omitempty"`
+	Category  string   `yaml:"category,omitempty"`
 	Requires  []string `yaml:"requires,omitempty"`
 	Platforms []string `yaml:"platforms,omitempty"`
 	Tags      []string `yaml:"tags,omitempty"`
@@ -51,10 +53,10 @@ type Metadata struct {
 // fields it owns.
 //
 // Read humblSKILLS-owned fields through the accessor methods
-// ([Frontmatter.Version], [Frontmatter.Requires], [Frontmatter.Platforms],
-// [Frontmatter.Tags], [Frontmatter.Preserve]) rather than reaching into
-// [Frontmatter.Metadata] directly - the accessors honour the legacy
-// top-level fallback.
+// ([Frontmatter.Version], [Frontmatter.Category], [Frontmatter.Requires],
+// [Frontmatter.Platforms], [Frontmatter.Tags], [Frontmatter.Preserve])
+// rather than reaching into [Frontmatter.Metadata] directly - the accessors
+// honour the legacy top-level fallback (except Category, which has none).
 type Frontmatter struct {
 	Name          string   `yaml:"name"`
 	Description   string   `yaml:"description"`
@@ -80,6 +82,14 @@ func (f Frontmatter) Version() string {
 		return f.Metadata.Version
 	}
 	return f.legacyVersion
+}
+
+// Category returns the skill's single coarse category (e.g. "development",
+// "design"), used for browsing and filtering. Unlike Version/Requires/etc.
+// there is no deprecated top-level fallback - category was introduced after
+// the legacy-field migration window, so metadata is the only source.
+func (f Frontmatter) Category() string {
+	return f.Metadata.Category
 }
 
 // Requires returns the humblSKILLS dep list: metadata.requires first,

--- a/cli/internal/frontmatter/frontmatter_test.go
+++ b/cli/internal/frontmatter/frontmatter_test.go
@@ -13,6 +13,7 @@ license: MIT
 metadata:
   author: jjfantini
   version: 1.2.3
+  category: development
   requires:
     - bar
   platforms: [claude-code]
@@ -35,6 +36,9 @@ Hello.
 	}
 	if fm.Metadata.Author != "jjfantini" {
 		t.Errorf("metadata.author: got %q", fm.Metadata.Author)
+	}
+	if fm.Category() != "development" {
+		t.Errorf("category accessor: got %q", fm.Category())
 	}
 	if fm.Version() != "1.2.3" {
 		t.Errorf("version accessor: got %q", fm.Version())

--- a/cli/internal/frontmatter/validate.go
+++ b/cli/internal/frontmatter/validate.go
@@ -16,6 +16,24 @@ var winDriveRegex = regexp.MustCompile(`^[A-Za-z]:`)
 // NameRegex is the allowed shape for a skill name.
 var NameRegex = regexp.MustCompile(`^[a-z][a-z0-9-]*$`)
 
+// Categories is the closed, stable set of skill categories. It's a single
+// coarse bucket per skill (unlike freeform `tags`), used for browsing and
+// filtering. Keep this list short - adding a category is a taxonomy
+// decision, not a per-skill one.
+var Categories = []string{"development", "design", "writing", "meta"}
+
+// IsKnownCategory reports whether c is one of Categories. Exported so
+// callers outside this package (e.g. the search command's --category flag)
+// can validate against the same closed set used at registry-build time.
+func IsKnownCategory(c string) bool {
+	for _, known := range Categories {
+		if c == known {
+			return true
+		}
+	}
+	return false
+}
+
 // isStrictSemver accepts only MAJOR.MINOR.PATCH, optionally with prerelease
 // or build metadata. Go's x/mod/semver treats "1.2" as valid (v1.2.0); we
 // want to reject shortened forms.
@@ -132,6 +150,13 @@ func (fm Frontmatter) Validate(dirName string, ctx ValidationContext) error {
 		errs = append(errs, "version is required (set `metadata.version`)")
 	case !isStrictSemver(version):
 		errs = append(errs, fmt.Sprintf("version %q is not valid semver (want MAJOR.MINOR.PATCH)", version))
+	}
+
+	switch category := fm.Category(); {
+	case category == "":
+		errs = append(errs, fmt.Sprintf("category is required (set `metadata.category` to one of %s)", strings.Join(Categories, ", ")))
+	case !IsKnownCategory(category):
+		errs = append(errs, fmt.Sprintf("unknown category %q (must be one of %s)", category, strings.Join(Categories, ", ")))
 	}
 
 	for _, plat := range fm.Platforms() {

--- a/cli/internal/frontmatter/validate_test.go
+++ b/cli/internal/frontmatter/validate_test.go
@@ -19,7 +19,7 @@ func mkFM(name, version string, mutate ...func(*Frontmatter)) Frontmatter {
 	fm := Frontmatter{
 		Name:        name,
 		Description: "desc",
-		Metadata:    Metadata{Version: version},
+		Metadata:    Metadata{Version: version, Category: "development"},
 	}
 	for _, m := range mutate {
 		m(&fm)
@@ -75,6 +75,8 @@ func TestValidate_VersionFromLegacyTopLevel(t *testing.T) {
 name: foo
 description: d
 version: 0.2.0
+metadata:
+  category: development
 ---
 body`)
 	fm, _, err := Parse(src)
@@ -113,6 +115,37 @@ func TestValidate_DepVersionSatisfied(t *testing.T) {
 	err := fm.Validate("foo", ctxWith(map[string]string{"bar": "0.3.1"}))
 	if err != nil {
 		t.Fatalf("unexpected: %v", err)
+	}
+}
+
+func TestValidate_CategoryMissing(t *testing.T) {
+	fm := mkFM("foo", "0.1.0", func(f *Frontmatter) {
+		f.Metadata.Category = ""
+	})
+	err := fm.Validate("foo", ctxWith(nil))
+	if err == nil || !strings.Contains(err.Error(), "category is required") {
+		t.Fatalf("expected missing-category error, got %v", err)
+	}
+}
+
+func TestValidate_CategoryUnknown(t *testing.T) {
+	fm := mkFM("foo", "0.1.0", func(f *Frontmatter) {
+		f.Metadata.Category = "astrology"
+	})
+	err := fm.Validate("foo", ctxWith(nil))
+	if err == nil || !strings.Contains(err.Error(), `unknown category "astrology"`) {
+		t.Fatalf("expected unknown-category error, got %v", err)
+	}
+}
+
+func TestValidate_CategoryEveryKnownValueAccepted(t *testing.T) {
+	for _, c := range Categories {
+		fm := mkFM("foo", "0.1.0", func(f *Frontmatter) {
+			f.Metadata.Category = c
+		})
+		if err := fm.Validate("foo", ctxWith(nil)); err != nil {
+			t.Errorf("category %q should validate: %v", c, err)
+		}
 	}
 }
 

--- a/cli/internal/registry/types.go
+++ b/cli/internal/registry/types.go
@@ -25,6 +25,7 @@ type Skill struct {
 	Name        string   `json:"name"`
 	Version     string   `json:"version"`
 	Description string   `json:"description"`
+	Category    string   `json:"category,omitempty"`
 	Tags        []string `json:"tags,omitempty"`
 	Platforms   []string `json:"platforms,omitempty"`
 	Requires    []string `json:"requires,omitempty"`

--- a/cli/internal/testutil/skillfixture.go
+++ b/cli/internal/testutil/skillfixture.go
@@ -14,6 +14,7 @@ type SkillFixture struct {
 	Name        string
 	Version     string
 	Description string
+	Category    string
 	Tags        []string
 	Platforms   []string
 	Requires    []string
@@ -63,6 +64,7 @@ func BuildRegistry(t testing.TB, cacheDir, owner, name, sha string, fixtures []S
 			Name:        f.Name,
 			Version:     f.Version,
 			Description: f.Description,
+			Category:    f.Category,
 			Tags:        f.Tags,
 			Platforms:   f.Platforms,
 			Requires:    f.Requires,

--- a/cli/internal/ui/theme.go
+++ b/cli/internal/ui/theme.go
@@ -27,7 +27,7 @@ type Palette struct {
 	Magenta lipgloss.Color // brand, selected-row accent
 	Red     lipgloss.Color // no dot, missing badge, error
 	Yellow  lipgloss.Color // ro badge, warning
-	Orange  lipgloss.Color // reserved
+	Orange  lipgloss.Color // category badge
 	Teal    lipgloss.Color // reserved
 
 	// --- Semantic aliases (kept so old call sites still compile).
@@ -36,6 +36,7 @@ type Palette struct {
 	Name     lipgloss.Color // names, headings — FG
 	Tag      lipgloss.Color // #tags — Blue
 	Platform lipgloss.Color // platform chips — Cyan
+	Category lipgloss.Color // category badge - Orange
 	Hit      lipgloss.Color // filter match highlight — Yellow
 	Muted    lipgloss.Color // crumbs — Comment
 	Rule     lipgloss.Color // dividers — Border
@@ -71,6 +72,7 @@ func DefaultPalette() Palette {
 	p.Name = p.FG
 	p.Tag = p.Blue
 	p.Platform = p.Cyan
+	p.Category = p.Orange
 	p.Hit = p.Yellow
 	p.Muted = p.Comment
 	p.Rule = p.Border
@@ -137,6 +139,7 @@ type Theme struct {
 	Desc     lipgloss.Style
 	Tag      lipgloss.Style
 	Platform lipgloss.Style
+	Category lipgloss.Style
 	Hit      lipgloss.Style
 	Label    lipgloss.Style
 	Count    lipgloss.Style
@@ -238,6 +241,7 @@ func buildTheme(p Palette, r *lipgloss.Renderer) *Theme {
 	t.Desc = r.NewStyle().Foreground(p.FGDim)
 	t.Tag = r.NewStyle().Foreground(p.Blue)
 	t.Platform = r.NewStyle().Foreground(p.Cyan)
+	t.Category = r.NewStyle().Foreground(p.Orange).Bold(true)
 	t.Hit = r.NewStyle().Foreground(p.Yellow).Bold(true)
 	t.Label = r.NewStyle().Foreground(p.Comment)
 	t.Count = r.NewStyle().Foreground(p.Comment).Italic(true)

--- a/docs/using_humblskills/registry_and_format.md
+++ b/docs/using_humblskills/registry_and_format.md
@@ -10,11 +10,30 @@ humblSKILLS-specific keys live under the optional **`metadata:`** map so the top
 |-------------------------|---------|
 | `requires` | Dependencies or constraints (as defined by the skill) |
 | `platforms` | Which agent platforms the skill targets |
-| `tags` | Discovery / grouping |
+| `category` | One coarse browsing bucket, from a closed set (see below) |
+| `tags` | Freeform keywords for search (many per skill) |
 | `version` | Skill package version (semver) |
 | `preserve` | Paths to keep on `update` when replacing an installed skill (see [Preserving user content](preserving_user_content.md)) |
 
 Other top-level frontmatter follows the normal agentskills.io expectations.
+
+### Categories
+
+`category` is required and validated at registry-build time against a small,
+stable list, unlike `tags`, which is freeform. It exists to give every skill
+exactly one home for browsing and filtering (`humblskills search --category=`),
+rather than relying on inconsistent tag conventions across skill authors.
+
+| Category | Use for |
+|----------|---------|
+| `development` | Git/workflow tooling, integrations, interview/system-design skills |
+| `design` | Frontend, UI/UX, and creative/media generation skills |
+| `writing` | Content and copy editing |
+| `meta` | Skill authoring, project onboarding, and other humblSKILLS-about-humblSKILLS skills |
+
+Adding a new category is a taxonomy decision (edit `frontmatter.Categories` in
+`cli/internal/frontmatter/validate.go`), not something an individual skill
+author should do by picking a new value.
 
 ## Where skills live in the repo
 

--- a/registry.json
+++ b/registry.json
@@ -1,16 +1,17 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-07-01T03:21:02Z",
+  "generated_at": "2026-07-01T03:22:41Z",
   "source": {
     "repo": "github.com/jjfantini/humblSKILLS",
-    "ref": "develop",
-    "sha": "694b22c2ce4ab0f4d3ebb8c9f8c3900ca02ee053"
+    "ref": "cursor/feat-skill-categories-edb2",
+    "sha": "8656ea062ee179ab5bf29aa7b01d1a20dcb3b935"
   },
   "skills": [
     {
       "name": "analyze-ml-system-design",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "description": "Drive an ML system design from an ambiguous prompt to a production-minded solution with a 6-step framework (problem framing, high-level design, data and features, modeling, inference and evaluation, deep dives). Use for an ML system design interview or any \"design X\" ML prompt - recommendation systems, fraud or bot detection, content moderation, ranking, search, personalization - or whenever the core problem is choosing data, features, a model, and an evaluation strategy. For infra or non-ML system design (URL shortener, chat, rate limiter, file sync), use analyze-system-design instead.",
+      "category": "development",
       "tags": [
         "ml-system-design",
         "interviews",
@@ -29,12 +30,13 @@
         "references/patterns.md"
       ],
       "path": "skills/analyze-ml-system-design",
-      "dir_sha": "b672f905bdce5ccd03fdf7c7fcabeafe2ea4f0c3e083fb942af9c334455a9760"
+      "dir_sha": "97b246ae86501e304ed32e21ea32d0c38ea50015f545b35a9619509a3ceaa6b3"
     },
     {
       "name": "analyze-system-design",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "description": "Drive a system design interview from a blank prompt to a simple, complete, defensible design using a 6-step framework (requirements, core entities, API, optional data flow, high-level design, deep dives). Use it for system design interviews, \"design X system\" prompts, high-level design and architecture sketches, deep dives, scaling and data-modeling questions, and choosing technologies (Redis, Kafka, Cassandra, DynamoDB, Postgres). For ML-centric problems (recommendations, fraud or bot detection, ranking, content moderation) use analyze-ml-system-design instead.",
+      "category": "development",
       "tags": [
         "system-design",
         "interviews",
@@ -53,12 +55,13 @@
         "references/patterns.md"
       ],
       "path": "skills/analyze-system-design",
-      "dir_sha": "d0f17c1655b7a1b7946d61f5d4588aee24c3c73b407a78bdd2a9ffb95dba504c"
+      "dir_sha": "083508d595d0e7c728de83c5c4db8a4efa9ba60df7654eaf1231c6075313a47f"
     },
     {
       "name": "create-scroll-animation",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "description": "Generates a production-grade React/Next.js scroll-driven canvas hero from an MP4. Extracts frames via FFmpeg, batch-converts to WebP, emits a single .tsx that scrubs frames against scroll progress using Framer Motion's useScroll + useMotionValueEvent. Mobile-first, LCP target under 1.2s, JS budget under 100KB. Trigger on \"scroll-stop build\", \"scroll animation website\", \"scroll-driven video\", \"Apple-style scroll animation\", \"video on scroll\", or when the user provides an MP4 and asks for a scroll-scrubbed React hero. Do NOT use for HTML-only sites (use scroll-stop-builder), two-frame transitions (use create-video-transition), or non-scroll canvas animations.\n",
+      "category": "design",
       "tags": [
         "scroll",
         "canvas",
@@ -84,12 +87,13 @@
         "references/patterns.md"
       ],
       "path": "skills/create-scroll-animation",
-      "dir_sha": "bee7053d358d3901c6189b4b074a494e77905835815edc52a32eeab92cc0fb30"
+      "dir_sha": "c2e5e970ab28a557c920a105b4414b10a871fd9e7d711e76a58af013a489f665"
     },
     {
       "name": "create-video-transition",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "description": "Generates the prompts needed to produce a video transition between two frames: Prompt A (start image), Prompt B (end image), and Prompt C (video transition, decomposed into exact 2-second blocks). Detects which prompts to produce based on whether the user uploaded a start image, an end image, both, or neither. Prompt C interpolates $VIDEO_LENGTH, $VIDEO_ASPECT_RATIO, $VIDEO_AUDIO, $VIDEO_FPS. Delivers an HTML page with tabbed A/B/C copy buttons and a settings modal for live variable swaps. Trigger when the user says \"video transition prompt\", \"start frame to end frame\", \"animate between these images\", \"transition video from image to image\", or uploads a reference image and asks for a transition. Do NOT use for standalone image prompts (use scroll-stop-prompter) or for writing Runway/Kling UI copy.\n",
+      "category": "design",
       "tags": [
         "video",
         "prompt",
@@ -111,12 +115,13 @@
         "references/patterns.md"
       ],
       "path": "skills/create-video-transition",
-      "dir_sha": "7d773cff062e373fb31ccd558dcb50d1461239cb6a366e3f1ae5568a466231da"
+      "dir_sha": "43be9c82a06e2e6f1c31c7636e12523ca257729cbef821b01146062fb9d733af"
     },
     {
       "name": "smart-claude-init",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "description": "Interview the user relentlessly, one question at a time with a recommended answer for each, to produce a clean iterated CLAUDE.md for a new project. Detects code vs non-code projects and fills a standard 8-section template (project intent, architecture, engineering preferences, code quality, testing, performance, bug protocol, task management and core principles). Use when the user says \"init CLAUDE.md\", \"set up CLAUDE.md\", \"grill me about my project\", \"smart-claude-init\", or wants a guided CLAUDE.md for a new repo. Do NOT use to mechanically document an existing codebase (use the built-in init skill), or to edit an already-good CLAUDE.md.\n",
+      "category": "meta",
       "tags": [
         "claude-md",
         "onboarding",
@@ -137,12 +142,13 @@
         "references/patterns.md"
       ],
       "path": "skills/smart-claude-init",
-      "dir_sha": "cb6a5fa0c3cff0dde4224f5480d7d340f4ede01cfd0380ff1a80bd69523e4199"
+      "dir_sha": "06bac19a4c0b4e0fb7998e3d3ed1ec2c347af54c57ea699d6b114a8e2eaa5149"
     },
     {
       "name": "smart-frontend-design",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "description": "Create distinctive, production-grade frontend interfaces with a synthesized design system and one style-defining intake question. Use when the user asks to build or redesign web components, pages, apps, dashboards, landing pages, UI flows, React/Vue/HTML/CSS interfaces, or \"make this look better\". Avoids generic AI aesthetics by discovering the existing frontend style before coding. Do NOT use for backend-only work, copy-only edits, or pure design critique where no frontend implementation is requested.\n",
+      "category": "design",
       "tags": [
         "frontend",
         "design",
@@ -165,12 +171,13 @@
         "references/patterns.md"
       ],
       "path": "skills/smart-frontend-design",
-      "dir_sha": "e1950fe0bdd73effaef6432673bcbd86965322e88004fecb89a088d0e4164271"
+      "dir_sha": "4ce3280e2df5909cad0dd440040bd1b194aafff4e87bffb47d8a781072d4a002"
     },
     {
       "name": "use-smart-commit",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "description": "Inspect the working tree, group pending changes into atomic related buckets, and author one conventional commit per bucket. Every message covers what changed, why, and the impact (what it resolves or unblocks). Use when the user says \"commit\", \"commit my changes\", \"make a commit\", \"stage and commit\", or after finishing a unit of work and wanting to land it. Do NOT use for squashing existing history, rebasing, force-pushing, or writing PR descriptions.\n",
+      "category": "development",
       "tags": [
         "git",
         "commits",
@@ -191,12 +198,13 @@
         "references/patterns.md"
       ],
       "path": "skills/use-smart-commit",
-      "dir_sha": "e13f043316274e8a440e8cff2bea34cdf669151c19edc45221d8dbb2b9873614"
+      "dir_sha": "0c09d32fa688ff19bbe1e8741c8c3f877b6953dbcdb45c2a3e1796f51784c780"
     },
     {
       "name": "use-smart-humanize-text",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "description": "Strip AI-generated writing patterns from text to make it sound authentically human. Use when writing or editing any content that must not read as AI-generated - outreach, blog posts, applications, social posts, emails, marketing copy. Detects and fixes AI vocabulary, structural tells, soulless tone, filler, hedging, and formatting artifacts. Based on Wikipedia's \"Signs of AI writing\" guide and associated research.\n",
+      "category": "writing",
       "platforms": [
         "claude-code",
         "cursor",
@@ -210,12 +218,13 @@
         "references/patterns.md"
       ],
       "path": "skills/use-smart-humanize-text",
-      "dir_sha": "fe52b548bc7effa69d4075c3e7d66e2a440c1cb499c0b361deebee726c469830"
+      "dir_sha": "b723272cce54353fd0e789fc9abcc1e1659806fb473339ccdfd3fec74273e0ad"
     },
     {
       "name": "use-smart-skill",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "description": "Scaffold production-grade humblSKILLS with progressive disclosure, self-learning memory (patterns/decisions/session log), and lint tooling. Use when creating a new humblSKILL (also known as a smart skill), scaffolding a SKILL.md, migrating a flat skill to a smart skill, refactoring a skill that exceeds ~300 lines, or adding memory/patterns tracking to an existing skill. Do NOT use for editing skill content after scaffold - use the skill directly. Uses CCCCC layering internally (Core/Context/Category/Concept/Command).\n",
+      "category": "meta",
       "tags": [
         "meta",
         "skill-authoring",
@@ -236,12 +245,13 @@
         "references/patterns.md"
       ],
       "path": "skills/use-smart-skill",
-      "dir_sha": "2e03a387029903a75f018970113d516cba566c4d68a5a1c51b03c2dc2a322a5a"
+      "dir_sha": "1708175cdcdc77ef239039701d540b3a6d91de66687ffc34e48b9e9e96868fa5"
     },
     {
       "name": "use-upload-thing",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "description": "Drive the UploadThing REST API end-to-end from the shell: authenticate with an API key, upload files (v7 prepareUpload + ingest PUT), download by key or URL, and list, delete, rename, set ACLs, or read usage. Use when the user wants to upload/download/manage files on UploadThing, mentions UploadThing, ufs.sh, prepareUpload, an sk_live key, or \"put this file on UploadThing\". Also guides first-time API-key setup. Do NOT use for building an app's File Router / React upload components (that is the TS SDK), or for non-UploadThing storage (S3, GCS).\n",
+      "category": "development",
       "tags": [
         "uploadthing",
         "file-upload",
@@ -263,12 +273,13 @@
         "references/patterns.md"
       ],
       "path": "skills/use-upload-thing",
-      "dir_sha": "797402522983d5d2347fd3865af85dbfc45cd2aa05bb75fc8c120eabd8575801"
+      "dir_sha": "ed7031de6c8d28a9dd007b25f2ae45e04ca5f4a7cdaee03ce6a1feac8c40d25f"
     },
     {
       "name": "use-worktree-flow",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "description": "Run a worktree-first development workflow from intent gathering through feature PR, develop merge, main merge, release PR, brew verification, and cleanup. Use when the user says \"worktree flow\", \"start a feature\", \"ship this feature\", \"PR into develop\", \"full dev workflow\", or wants a feature isolated from parallel agents. Do NOT use for atomic commit authoring (use use-smart-commit) or merge-conflict repair.\n",
+      "category": "development",
       "tags": [
         "git",
         "worktree",
@@ -290,7 +301,7 @@
         "references/patterns.md"
       ],
       "path": "skills/use-worktree-flow",
-      "dir_sha": "9e6216a4d41cf260872b9317382c15be095f168075e4ebdf8657674cf252c3a8"
+      "dir_sha": "84263c6f16ebbbedc1c4dcef930728004dfff8afe43297c775ef9e9017f80928"
     }
   ]
 }

--- a/registry.json
+++ b/registry.json
@@ -1,10 +1,10 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-07-01T03:22:41Z",
+  "generated_at": "2026-07-01T13:44:42Z",
   "source": {
     "repo": "github.com/jjfantini/humblSKILLS",
     "ref": "cursor/feat-skill-categories-edb2",
-    "sha": "8656ea062ee179ab5bf29aa7b01d1a20dcb3b935"
+    "sha": "b4f515f2878e0b4d31caa54eaaa23057bf66c268"
   },
   "skills": [
     {

--- a/skills/analyze-ml-system-design/SKILL.md
+++ b/skills/analyze-ml-system-design/SKILL.md
@@ -4,7 +4,8 @@ description: Drive an ML system design from an ambiguous prompt to a production-
 license: MIT
 metadata:
   author: Jennings Fantini
-  version: "2.0.2"
+  version: "2.0.3"
+  category: development
   tags: [ml-system-design, interviews, machine-learning]
   platforms: [claude-code, cursor, codex]
   preserve:

--- a/skills/analyze-system-design/SKILL.md
+++ b/skills/analyze-system-design/SKILL.md
@@ -4,7 +4,8 @@ description: Drive a system design interview from a blank prompt to a simple, co
 license: MIT
 metadata:
   author: Jennings Fantini
-  version: "2.0.2"
+  version: "2.0.3"
+  category: development
   tags: [system-design, interviews, architecture]
   platforms: [claude-code, cursor, codex]
   preserve:

--- a/skills/create-scroll-animation/SKILL.md
+++ b/skills/create-scroll-animation/SKILL.md
@@ -16,7 +16,8 @@ compatibility: Requires ffmpeg and ffprobe on PATH; bash; Node 18+; a React 18+ 
 allowed-tools: "Read Write Edit Glob Grep Bash(ffmpeg:*) Bash(ffprobe:*) Bash(cwebp:*) Bash(bash:*) Bash(mkdir:*) Bash(cp:*) Bash(ls:*)"
 metadata:
   author: jjfantini
-  version: "0.1.2"
+  version: "0.1.3"
+  category: design
   tags: [scroll, canvas, framer-motion, nextjs, react, ffmpeg, webp, apple-style, hero, humblskill]
   platforms: [claude-code, cursor, codex]
   preserve:

--- a/skills/create-video-transition/SKILL.md
+++ b/skills/create-video-transition/SKILL.md
@@ -18,7 +18,8 @@ compatibility: Requires a modern browser to open the HTML deliverable; an AI ima
 allowed-tools: "Read Write Edit Glob Grep Bash(open:*) Bash(xdg-open:*) Bash(bash:*) Bash(mkdir:*) Bash(ls:*)"
 metadata:
   author: jjfantini
-  version: "1.0.2"
+  version: "1.0.3"
+  category: design
   tags: [video, prompt, transition, image-generation, commercial-director, humblskill]
   platforms: [claude-code, cursor, codex]
   preserve:

--- a/skills/smart-claude-init/SKILL.md
+++ b/skills/smart-claude-init/SKILL.md
@@ -15,7 +15,8 @@ compatibility: Requires bash and POSIX utilities (grep, sed) plus python3 for sc
 allowed-tools: "Bash(bash:*) Read Write Edit Glob Grep"
 metadata:
   author: jjfantini
-  version: "0.1.2"
+  version: "0.1.3"
+  category: meta
   tags: [claude-md, onboarding, interview, project-setup, humblskill]
   platforms: [claude-code, cursor, codex]
   preserve:

--- a/skills/smart-frontend-design/SKILL.md
+++ b/skills/smart-frontend-design/SKILL.md
@@ -12,7 +12,8 @@ license: MIT
 compatibility: "Requires python3 only for scripts/lint.sh. Frontend implementation uses whatever stack exists in the target repo."
 metadata:
   author: jjfantini
-  version: "1.0.2"
+  version: "1.0.3"
+  category: design
   tags: [frontend, design, ui, ux, react, css, humblskill]
   platforms: [claude-code, cursor, codex]
   preserve:

--- a/skills/use-smart-commit/SKILL.md
+++ b/skills/use-smart-commit/SKILL.md
@@ -11,7 +11,8 @@ description: >
 license: MIT
 metadata:
   author: jjfantini
-  version: "1.0.2"
+  version: "1.0.3"
+  category: development
   tags: [git, commits, conventional-commits, workflow, humblskill]
   platforms: [claude-code, cursor, codex]
   preserve:

--- a/skills/use-smart-humanize-text/SKILL.md
+++ b/skills/use-smart-humanize-text/SKILL.md
@@ -10,7 +10,8 @@ description: >
 license: MIT
 metadata:
   author: jjfantini
-  version: 2.0.2
+  version: 2.0.3
+  category: writing
   platforms: [claude-code, cursor, codex]
   preserve:
     - references/raw/

--- a/skills/use-smart-skill/SKILL.md
+++ b/skills/use-smart-skill/SKILL.md
@@ -14,7 +14,8 @@ compatibility: Requires bash, POSIX utilities (awk, sed, find, grep), python3, w
 allowed-tools: "Bash(bash:*) Bash(sh:*) Read Write Edit Glob Grep"
 metadata:
   author: jjfantini
-  version: 1.1.2
+  version: 1.1.3
+  category: meta
   tags: [meta, skill-authoring, smart-skill, scaffolding, humblskill]
   platforms: [claude-code, cursor, codex]
   preserve:

--- a/skills/use-smart-skill/scripts/scaffold.sh
+++ b/skills/use-smart-skill/scripts/scaffold.sh
@@ -135,6 +135,7 @@ allowed-tools: "TODO or delete - e.g. Bash(bash:*) Read Write Edit. Restricts wh
 metadata:
   author: TODO
   version: "1.0.0"
+  category: TODO  # required, one of: development, design, writing, meta
   tags: [TODO]
   platforms: [claude-code, cursor]
   preserve:

--- a/skills/use-upload-thing/SKILL.md
+++ b/skills/use-upload-thing/SKILL.md
@@ -12,7 +12,8 @@ license: MIT
 compatibility: "Requires bash, curl, jq, and network access to api.uploadthing.com. Needs an UploadThing API key via UPLOADTHING_API_KEY (or UPLOADTHING_TOKEN), or run scripts/auth.sh --save."
 metadata:
   author: jjfantini
-  version: "1.0.2"
+  version: "1.0.3"
+  category: development
   tags: [uploadthing, file-upload, storage, rest-api, ufs, humblskill]
   platforms: [claude-code, cursor, codex]
   preserve:

--- a/skills/use-worktree-flow/SKILL.md
+++ b/skills/use-worktree-flow/SKILL.md
@@ -11,7 +11,8 @@ license: MIT
 compatibility: "Requires git 2.5+, GitHub CLI (`gh`) for PR/check operations, and network access for remote sync, CI, releases, and Homebrew verification."
 metadata:
   author: jjfantini
-  version: "1.0.2"
+  version: "1.0.3"
+  category: development
   tags: [git, worktree, pull-requests, release, workflow, humblskill]
   platforms: [claude-code, cursor, codex]
   preserve:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Adds a single, required, closed-set `category` field per skill (`development`, `design`, `writing`, `meta`), separate from the existing freeform `tags`. `tags` stays freeform for search keywords; `category` is the one stable bucket a skill lives in for browsing/filtering.

```sh
humblskills search --category development
```

Per discussion: system-design skills (`analyze-system-design`, `analyze-ml-system-design`) go under `development`, not a separate `interviews` bucket - interview prep is one use case among several for those skills, not a distinct skill category. Kept to one flat field rather than a multi-level taxonomy.

## How

- `metadata.category` in `SKILL.md` frontmatter, validated at registry-build time against `frontmatter.Categories` (same pattern as `platforms` validation against known adapters).
- Flows into `registry.json` as `"category"` on every skill entry.
- `humblskills search --category=<name>` filters results (combinable with a text query); text and `--json` output both show it.
- The shared TUI skill browser (used by `search`/`install`/`list`/`uninstall`) shows category in the detail pane and includes it in the `/` filter match.
- Backfilled all 11 existing skills, bumped each skill's patch version (metadata content changed, following the same precedent as the recent `preserve` backfill commit), and regenerated `registry.json`.
- Added `category: TODO` to `use-smart-skill`'s scaffold template so newly authored skills aren't missing it.
- Documented the field and the 4-category taxonomy in `docs/using_humblskills/registry_and_format.md`.

Final mapping:
| Category | Skills |
|---|---|
| `development` | `analyze-system-design`, `analyze-ml-system-design`, `use-smart-commit`, `use-worktree-flow`, `use-upload-thing` |
| `design` | `create-scroll-animation`, `create-video-transition`, `smart-frontend-design` |
| `writing` | `use-smart-humanize-text` |
| `meta` | `smart-claude-init`, `use-smart-skill` |

## Testing

Unit tests cover: category validation (missing/unknown/every-known-value accepted) in `frontmatter`, registry-build enforcement (`TestRun_MissingCategory_Rejected`, `TestRun_UnknownCategory_Rejected`), and `search --category` (filter alone, combined with a query, unknown-category error).

`make registry` / `make registry-check` both pass clean against the real `skills/` tree.

End-to-end against the real regenerated registry (`search --category development/writing`, invalid category error):

[search_category_demo.log](https://cursor.com/artifacts/c/art-a711da02-8bd9-42be-a490-a875e36c1a1c)

Manual TUI walkthrough confirming the category row renders correctly (orange, distinct from tag/platform colors) and updates per-skill, plus the `/` filter matching on category:

![Initial TUI detail pane showing the new category row](https://cursor.com/artifacts/c/art-553a696c-2df5-4058-ab61-3dfeb5bd1b5b)
![Category row showing meta for smart-claude-init](https://cursor.com/artifacts/c/art-2cb5759e-6991-481e-8f5b-f59d67587f72)
![Filtering the TUI list by development](https://cursor.com/artifacts/c/art-70321b74-a647-4de4-a7d4-fce0303f11a4)

- ✅ `go -C cli test -race -count=1 ./...`
- ✅ `go -C cli vet ./...`
- ✅ `make registry` / `make registry-check`
- ✅ manual CLI + TUI testing (above)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1bb3-3368-7e27-b650-cd1478cbedb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1bb3-3368-7e27-b650-cd1478cbedb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

