### PR TITLE
Promote develop to main: TUI status screens, scrollable done-screens

### DIFF
--- a/cli/cmd/humblskills/start.go
+++ b/cli/cmd/humblskills/start.go
@@ -3,12 +3,14 @@ package main
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 
 	"github.com/jjfantini/humblSKILLS/cli/internal/adapters"
 	"github.com/jjfantini/humblSKILLS/cli/internal/install"
 	"github.com/jjfantini/humblSKILLS/cli/internal/manifest"
+	"github.com/jjfantini/humblSKILLS/cli/internal/profile"
 	"github.com/jjfantini/humblSKILLS/cli/internal/registry"
 	"github.com/jjfantini/humblSKILLS/cli/internal/skillset"
 	"github.com/jjfantini/humblSKILLS/cli/internal/tui"
@@ -75,12 +77,65 @@ func runStart(app *App) error {
 			Crumb:  "Dashboard > " + crumbLabel(res.Command),
 			Status: status,
 		}
-		if err := dispatchDashboardCommand(app, res.Command); err != nil {
-			// Surface the error, then loop back so the user can keep working.
-			app.UI.Error("%s: %v", res.Command, err)
+		if err := runDashboardCommand(app, res.Command); err != nil {
+			return err
 		}
 		app.Nav = NavContext{}
 	}
+}
+
+// runDashboardCommand dispatches cmd and makes sure nothing it would have
+// printed gets lost. Every dashboard sub-command re-enters this loop's
+// alt-screen the instant it returns, which used to silently overwrite any
+// plain app.UI.Info/Warn/Error/Success line printed in the gap — e.g. sync's
+// "no such file" error, or update's "all skills are up-to-date" - before
+// anyone could read it (standalone `humblskills <cmd>` never had this
+// problem, since nothing redraws over the terminal after it exits).
+//
+// It captures everything the sub-command writes via app.UI while it runs;
+// if that capture is non-empty, or the sub-command returned an error, it
+// shows exactly that (the same text the standalone CLI would have printed)
+// on a blocking status screen instead of letting it flash by. A command
+// that already used its own blocking screen for feedback (install/update
+// progress, registry refresh) and printed nothing extra gets no additional
+// screen, so there's no double-dialog.
+//
+// The returned error is only ever a genuine bubbletea/status-screen
+// plumbing failure (e.g. Run() itself couldn't launch) - dispatch errors
+// from cmd itself are always shown via the status screen and swallowed
+// here so the dashboard loop keeps going, matching today's "surface then
+// keep working" behavior.
+func runDashboardCommand(app *App, cmd string) error {
+	restore := app.UI.CaptureWriters()
+	cmdErr := dispatchDashboardCommand(app, cmd)
+	captured := restore()
+
+	if strings.TrimSpace(captured) == "" && cmdErr == nil {
+		return nil
+	}
+
+	autoReturn := profile.DefaultStatusAutoReturnSeconds * time.Second
+	if p, err := profile.Load(app.Config.ProfilePath); err == nil {
+		autoReturn = p.StatusAutoReturnDuration()
+	}
+
+	// ExecuteWithStatus's second return value is exactly whatever our
+	// closure returned as its error, i.e. cmdErr reflected straight back
+	// once the screen has already been shown and dismissed. Propagating
+	// that as this function's own error would make the caller treat a
+	// perfectly normal (and already-displayed) sub-command failure as a
+	// fatal problem and tear down the whole dashboard - which is the exact
+	// "flash back to a bare shell" bug this function exists to prevent.
+	// Only a genuinely different error - Run() failing to even launch the
+	// status screen - is worth propagating further.
+	_, statusErr := tui.ExecuteWithStatus(app.UI.Theme(), app.Nav.Crumb, "…", autoReturn,
+		func() (tui.StatusResult, error) {
+			return tui.StatusResult{Raw: captured}, cmdErr
+		})
+	if statusErr != nil && statusErr != cmdErr {
+		return statusErr
+	}
+	return nil
 }
 
 // crumbLabel maps a dashboard command back to its display label for the

--- a/cli/internal/tui/progress.go
+++ b/cli/internal/tui/progress.go
@@ -44,9 +44,10 @@ func Subscribe(ch <-chan install.Event, doneErr <-chan error) tea.Cmd {
 	}
 }
 
-// ProgressModel renders a framed progress bar + per-target status list driven
-// by install engine events. Use alongside a goroutine that wraps
-// engine.Execute and forwards events onto a channel.
+// ProgressModel renders a framed progress bar + a scrollable per-target
+// status list (or, once finished, the grouped summary) driven by install
+// engine events. Use alongside a goroutine that wraps engine.Execute and
+// forwards events onto a channel.
 type ProgressModel struct {
 	theme   *ui.Theme
 	command string // breadcrumb detail, e.g. "install" or "update"
@@ -57,13 +58,16 @@ type ProgressModel struct {
 	total   int
 	done    int
 	width   int
+	height  int
 	current *progressEntry
 	err     error
 	running bool
 	events  <-chan install.Event
 	doneErr <-chan error
 
-	autoReturn autoReturnTimer
+	// resultView owns the scrollable body (live target list, or the done
+	// summary) plus the shared auto-return countdown — see scrollstatus.go.
+	resultView scrollableDone
 }
 
 type progressEntry struct {
@@ -90,7 +94,9 @@ func (p *progressEntry) key() string {
 // the header breadcrumb ("install" or "update"). autoReturn is how long the
 // done screen waits before auto-returning to the dashboard on success (0
 // disables it - see profile.Profile.StatusAutoReturnDuration); a failed run
-// always waits for the user regardless of this value.
+// always waits for the user regardless of this value, and even a successful
+// run waits for the user to scroll to the bottom first if the summary
+// doesn't already fit on screen — see scrollableDone.ArmIfReady.
 func NewProgressModel(theme *ui.Theme, command string, events <-chan install.Event, doneErr <-chan error, autoReturn time.Duration) ProgressModel {
 	p := progress.New(
 		progress.WithGradient(string(theme.Palette.Brand), string(theme.Palette.Accent)),
@@ -111,7 +117,7 @@ func NewProgressModel(theme *ui.Theme, command string, events <-chan install.Eve
 		events:     events,
 		doneErr:    doneErr,
 		running:    true,
-		autoReturn: autoReturnTimer{duration: autoReturn},
+		resultView: newScrollableDone(autoReturn),
 	}
 }
 
@@ -127,6 +133,7 @@ func (m ProgressModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
+		m.height = msg.Height
 		barW := m.width - 12
 		if barW < 20 {
 			barW = 20
@@ -135,6 +142,7 @@ func (m ProgressModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			barW = 60
 		}
 		m.bar.Width = barW
+		m.refreshResultContent(false)
 		return m, nil
 
 	case ProgressEventMsg:
@@ -143,6 +151,7 @@ func (m ProgressModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.total > 0 {
 			cmds = append(cmds, m.bar.SetPercent(float64(m.done)/float64(m.total)))
 		}
+		m.refreshResultContent(false)
 		return m, tea.Batch(cmds...)
 
 	case ProgressDoneMsg:
@@ -153,17 +162,16 @@ func (m ProgressModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// state (running=false) and stays on screen; the tea.KeyMsg case
 		// below is what actually dismisses it, matching the "enter/q to
 		// close" footer hint that was previously dead code. On success only,
-		// autoReturn additionally arms a countdown that dismisses the screen
-		// on its own — a failure always waits for the user to read it.
+		// ArmIfReady additionally arms a countdown that dismisses the screen
+		// on its own once the summary has been fully seen — a failure
+		// always waits for the user to read it.
 		m.err = msg.Err
 		m.running = false
-		if m.err == nil {
-			return m, m.autoReturn.Start()
-		}
-		return m, nil
+		m.refreshResultContent(true)
+		return m, m.resultView.ArmIfReady(m.err == nil)
 
 	case autoReturnTickMsg:
-		quit, cmd := m.autoReturn.Tick()
+		quit, cmd := m.resultView.Tick()
 		if quit {
 			return m, tea.Quit
 		}
@@ -181,9 +189,16 @@ func (m ProgressModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, cmd
 
+	case tea.MouseMsg:
+		cmd := m.resultView.HandleMouse(msg)
+		return m, tea.Batch(cmd, m.resultView.ArmIfReady(!m.running && m.err == nil))
+
 	case tea.KeyMsg:
 		if !m.running && (msg.String() == "q" || msg.String() == "enter" || msg.String() == "esc") {
 			return m, tea.Quit
+		}
+		if m.resultView.HandleKey(msg.String()) {
+			return m, m.resultView.ArmIfReady(!m.running && m.err == nil)
 		}
 	}
 	return m, nil
@@ -191,50 +206,120 @@ func (m ProgressModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 func (m ProgressModel) View() string {
 	th := m.theme
-	header := Header(th, HeaderSpec{Section: m.command}, m.width)
+	header := Header(th, HeaderSpec{
+		Section: m.command,
+		Meta:    m.resultView.ScrollIndicator(th),
+	}, m.width)
 
-	var sb strings.Builder
-	if m.running {
-		sb.WriteString("  " + m.spin.View() + " " +
-			th.Name.Render(fmt.Sprintf("%d / %d", m.done, m.total)) + "\n")
-	} else if m.err != nil {
-		sb.WriteString("  " + th.Error.Render("✗ ") +
-			th.Name.Render(fmt.Sprintf("%d / %d", m.done, m.total)) + "\n")
-	} else {
-		sb.WriteString("  " + th.Success.Render("✓ ") +
-			th.Name.Render(fmt.Sprintf("%d / %d complete", m.done, m.total)) + "\n")
-	}
-	sb.WriteString("  " + m.bar.View() + "\n\n")
-
-	if !m.running && m.err == nil {
-		sb.WriteString(m.renderSummary())
-	} else {
-		for _, it := range m.items {
-			active := m.running && m.current == it && !it.done && !it.errored
-			line := m.renderEntry(it, active)
-			prefix := "  "
-			if active {
-				prefix = th.Bullet.Render("▌") + " "
-			}
-			sb.WriteString(prefix + line + "\n")
-		}
-	}
-
-	if m.err != nil {
-		sb.WriteString("\n  " + th.Error.Render("error: ") + th.Detail.Render(m.err.Error()) + "\n")
-	}
-
-	var footer string
+	var top strings.Builder
 	switch {
 	case m.running:
-		footer = Footer(th, []KeyHint{{Keys: "ctrl+c", Label: "abort"}}, "", m.width)
-	case m.autoReturn.Active():
-		footer = Footer(th, []KeyHint{{Keys: "enter/q", Label: "close now"}},
-			th.Detail.Render(fmt.Sprintf("closing in %ds", m.autoReturn.RemainingSeconds())), m.width)
+		top.WriteString("  " + m.spin.View() + " " + th.Name.Render(fmt.Sprintf("%d / %d", m.done, m.total)) + "\n")
+	case m.err != nil:
+		top.WriteString("  " + th.Error.Render("✗ ") + th.Name.Render(fmt.Sprintf("%d / %d", m.done, m.total)) + "\n")
 	default:
-		footer = Footer(th, []KeyHint{{Keys: "enter/q", Label: "close"}}, "", m.width)
+		top.WriteString("  " + th.Success.Render("✓ ") + th.Name.Render(fmt.Sprintf("%d / %d complete", m.done, m.total)) + "\n")
 	}
-	return header + "\n\n" + sb.String() + "\n" + footer
+	top.WriteString("  " + m.bar.View())
+
+	var tail string
+	if m.err != nil {
+		tail = "\n  " + th.Error.Render("error: ") + th.Detail.Render(m.err.Error())
+	}
+
+	footer := m.renderFooter(th)
+
+	return header + "\n\n" + top.String() + "\n\n" + m.resultView.View() + "\n" + tail + "\n" + footer
+}
+
+// renderFooter picks the key hints + right-anchored context for the current
+// state: running (abort + scroll if the live list overflows), done with an
+// error (close + scroll if there's more than the error line to read), or
+// done successfully (close, plus whichever auto-return affordance applies).
+func (m ProgressModel) renderFooter(th *ui.Theme) string {
+	switch {
+	case m.running:
+		hints := []KeyHint{{Keys: "ctrl+c", Label: "abort"}}
+		if m.resultView.Overflows() {
+			hints = append(hints, KeyHint{Keys: "↑↓/pgup/pgdn", Label: "scroll"})
+		}
+		return Footer(th, hints, "", m.width)
+	case m.err != nil:
+		hints := []KeyHint{{Keys: "enter/q", Label: "close"}}
+		if m.resultView.Overflows() {
+			hints = append(hints, KeyHint{Keys: "↑↓", Label: "scroll"})
+		}
+		return Footer(th, hints, "", m.width)
+	case m.resultView.Active():
+		return Footer(th, []KeyHint{{Keys: "enter/q", Label: "close now"}},
+			th.Detail.Render(fmt.Sprintf("closing in %ds", m.resultView.RemainingSeconds())), m.width)
+	case m.resultView.Enabled():
+		return Footer(th, []KeyHint{{Keys: "enter/q", Label: "close"}, {Keys: "↓/end", Label: "scroll to bottom"}},
+			th.Detail.Render("scroll to bottom to auto-close"), m.width)
+	default:
+		return Footer(th, []KeyHint{{Keys: "enter/q", Label: "close"}}, "", m.width)
+	}
+}
+
+// resizeResultView computes the scrollable body's height budget: total
+// height minus the header, the fixed status+bar block above the body, the
+// blank separator rows, the footer, and (when present) the error line below
+// the body. Mirrors listdetail.go's bodyH computation.
+func (m *ProgressModel) resizeResultView() {
+	if m.width == 0 || m.height == 0 {
+		return
+	}
+	const (
+		headerH   = 2
+		topH      = 2 // status line + bar
+		footerH   = 2
+		blankRows = 3 // header/top, top/body, body/footer separators
+	)
+	fixed := headerH + topH + footerH + blankRows
+	if m.err != nil {
+		fixed += 2 // blank + error line
+	}
+	bodyH := m.height - fixed
+	if bodyH < 3 {
+		bodyH = 3
+	}
+	m.resultView.Resize(m.width, bodyH)
+}
+
+// refreshResultContent recomputes the scrollable body's dimensions and
+// content. resetToTop should be true exactly once — when the run reaches
+// its terminal state — so the user reads the summary from the start; while
+// running, the live list instead tails the bottom like a log.
+func (m *ProgressModel) refreshResultContent(resetToTop bool) {
+	m.resizeResultView()
+	var body string
+	if !m.running && m.err == nil {
+		body = m.renderSummary()
+	} else {
+		body = m.renderItemsList()
+	}
+	m.resultView.SetContent(body, resetToTop)
+	if m.running {
+		m.resultView.FollowBottom()
+	}
+}
+
+// renderItemsList renders one line per tracked target — used both while
+// running (with the active entry highlighted) and, if the run ends in
+// error, as the frozen final state of that same list.
+func (m ProgressModel) renderItemsList() string {
+	th := m.theme
+	var sb strings.Builder
+	for _, it := range m.items {
+		active := m.running && m.current == it && !it.done && !it.errored
+		line := m.renderEntry(it, active)
+		prefix := "  "
+		if active {
+			prefix = th.Bullet.Render("▌") + " "
+		}
+		sb.WriteString(prefix + line + "\n")
+	}
+	return sb.String()
 }
 
 func (m *ProgressModel) applyEvent(ev install.Event) {

--- a/cli/internal/tui/progress_test.go
+++ b/cli/internal/tui/progress_test.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -63,7 +64,7 @@ func TestProgressModel_ApplyEventLifecycle(t *testing.T) {
 
 func TestProgressModel_RenderSummary_GroupsBySkillAndShowsStorePath(t *testing.T) {
 	m := newTestProgress(t)
-	m.width = 100
+	m.width, m.height = 100, 40
 	m.running = false
 	m.err = nil
 	m.applyEvent(install.Event{Phase: install.PhaseRunStart, Total: 3})
@@ -97,6 +98,10 @@ func TestProgressModel_RenderSummary_GroupsBySkillAndShowsStorePath(t *testing.T
 		t.Errorf("bar group malformed: %+v", groups[1])
 	}
 
+	// The done summary lives in the scrollable resultView body, which is
+	// only populated on Update (WindowSizeMsg/ProgressDoneMsg) in real use —
+	// simulate that here since the test drives applyEvent directly.
+	m.refreshResultContent(true)
 	view := m.View()
 	for _, want := range []string{
 		"foo", "v1.0.0", "/home/u/.humblskills/skills/foo",
@@ -112,9 +117,10 @@ func TestProgressModel_RenderSummary_GroupsBySkillAndShowsStorePath(t *testing.T
 
 func TestProgressModel_RenderSummary_EmptyWhenNothingInstalled(t *testing.T) {
 	m := newTestProgress(t)
-	m.width = 80
+	m.width, m.height = 80, 40
 	m.running = false
 	m.err = nil
+	m.refreshResultContent(true)
 	view := m.View()
 	if !strings.Contains(view, "nothing to do") {
 		t.Errorf("expected empty-summary message, got:\n%s", view)
@@ -162,12 +168,13 @@ func TestProgressModel_UpsertReturnsExisting(t *testing.T) {
 
 func TestProgressModel_ViewMentionsCommandAndCounts(t *testing.T) {
 	m := newTestProgress(t)
-	m.width = 80
+	m.width, m.height = 80, 40
 	m.applyEvent(install.Event{Phase: install.PhaseRunStart, Total: 2})
 	m.applyEvent(install.Event{
 		Phase: install.PhaseTargetStart,
 		Skill: "foo", Platform: "x", Scope: "user",
 	})
+	m.refreshResultContent(false)
 	v := m.View()
 	if !strings.Contains(v, "install") {
 		t.Errorf("view missing command header:\n%s", v)
@@ -261,10 +268,13 @@ func TestProgressModel_DoneMsg_Success_WithAutoReturn_StartsCountdown(t *testing
 	doneErr := make(chan error, 1)
 	m := NewProgressModel(ui.DefaultTheme(), "install", events, doneErr, 5*time.Second)
 	m.running = true
+	// A short, empty summary fits without scrolling, so — like today, before
+	// this screen could ever overflow — the countdown arms immediately.
+	m.width, m.height = 80, 40
 	out, cmd := m.Update(ProgressDoneMsg{Err: nil})
 	updated := out.(ProgressModel)
-	if !updated.autoReturn.Active() {
-		t.Error("expected the autoReturn timer to be armed on a successful done state")
+	if !updated.resultView.Active() {
+		t.Error("expected the auto-return timer to be armed on a successful done state that already fits on screen")
 	}
 	if cmd == nil {
 		t.Error("expected a tea.Cmd to schedule the first countdown tick")
@@ -276,9 +286,10 @@ func TestProgressModel_DoneMsg_Error_WithAutoReturn_NeverStartsCountdown(t *test
 	doneErr := make(chan error, 1)
 	m := NewProgressModel(ui.DefaultTheme(), "install", events, doneErr, 5*time.Second)
 	m.running = true
+	m.width, m.height = 80, 40
 	out, cmd := m.Update(ProgressDoneMsg{Err: errors.New("boom")})
 	updated := out.(ProgressModel)
-	if updated.autoReturn.Active() {
+	if updated.resultView.Active() {
 		t.Error("a failed run must never auto-return, regardless of the configured duration")
 	}
 	if cmd != nil {
@@ -286,10 +297,52 @@ func TestProgressModel_DoneMsg_Error_WithAutoReturn_NeverStartsCountdown(t *test
 	}
 }
 
+// TestProgressModel_ArmIfReady_WaitsForScrollWhenContentOverflows is the
+// core of the "auto-return should only trigger once the user has scrolled
+// down to see all the content" behavior: when the done summary is taller
+// than the viewport, the countdown must not arm until the user actually
+// scrolls to the bottom.
+func TestProgressModel_ArmIfReady_WaitsForScrollWhenContentOverflows(t *testing.T) {
+	events := make(chan install.Event, 32)
+	doneErr := make(chan error, 1)
+	m := NewProgressModel(ui.DefaultTheme(), "update", events, doneErr, 5*time.Second)
+	m.running = true
+	// A tall terminal budget-wise but small enough that ten skills' worth of
+	// summary blocks won't fit — see resizeResultView's bodyH computation.
+	m.width, m.height = 80, 12
+
+	for i := 0; i < 10; i++ {
+		skill := fmt.Sprintf("skill-%d", i)
+		m.applyEvent(install.Event{
+			Phase: install.PhaseTargetDone, Skill: skill, Platform: "claude-code", Scope: "user",
+			Outcome: install.OutcomeInstalled, Path: "/x/" + skill, Version: "1.0.0", StorePath: "/store/" + skill,
+		})
+	}
+
+	out, cmd := m.Update(ProgressDoneMsg{Err: nil})
+	updated := out.(ProgressModel)
+	if !updated.resultView.Overflows() {
+		t.Fatalf("expected the 10-skill summary to overflow a %d-row viewport", updated.resultView.content.Height)
+	}
+	if updated.resultView.Active() || cmd != nil {
+		t.Fatal("auto-return must not arm before the user has scrolled to see the whole summary")
+	}
+
+	// Scroll all the way down.
+	out, cmd = updated.Update(tea.KeyMsg{Type: tea.KeyEnd})
+	updated = out.(ProgressModel)
+	if !updated.resultView.Active() {
+		t.Error("expected auto-return to arm once the user scrolled to the bottom")
+	}
+	if cmd == nil {
+		t.Error("expected a tea.Cmd to schedule the first countdown tick after reaching the bottom")
+	}
+}
+
 func TestProgressModel_AutoReturnTick_QuitsAfterDeadline(t *testing.T) {
 	m := newTestProgress(t)
 	m.running = false
-	m.autoReturn = autoReturnTimer{duration: time.Millisecond, deadline: time.Now().Add(-time.Second)}
+	m.resultView.auto = autoReturnTimer{duration: time.Millisecond, deadline: time.Now().Add(-time.Second)}
 	_, cmd := m.Update(autoReturnTickMsg{})
 	if cmd == nil {
 		t.Fatal("expected a tea.Quit cmd once the deadline has passed")
@@ -302,8 +355,8 @@ func TestProgressModel_AutoReturnTick_QuitsAfterDeadline(t *testing.T) {
 func TestProgressModel_View_ShowsCountdownWhenAutoReturnActive(t *testing.T) {
 	m := newTestProgress(t)
 	m.running = false
-	m.width = 80
-	m.autoReturn = autoReturnTimer{duration: 5 * time.Second, deadline: time.Now().Add(5 * time.Second)}
+	m.width, m.height = 80, 40
+	m.resultView.auto = autoReturnTimer{duration: 5 * time.Second, deadline: time.Now().Add(5 * time.Second)}
 	v := m.View()
 	if !strings.Contains(v, "closing in") {
 		t.Errorf("view should show the countdown when auto-return is active:\n%s", v)

--- a/cli/internal/tui/scrollstatus.go
+++ b/cli/internal/tui/scrollstatus.go
@@ -1,0 +1,163 @@
+package tui
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/charmbracelet/bubbles/viewport"
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/jjfantini/humblSKILLS/cli/internal/ui"
+)
+
+// scrollableDone renders a "what just happened" body of arbitrary length
+// inside a viewport sized to whatever vertical space remains once the
+// caller's fixed chrome (header, footer, any fixed lines above/below the
+// body) is subtracted, and gates a shared autoReturnTimer so a completed
+// screen never auto-dismisses before the user has actually seen everything:
+// the countdown only arms once the body already fits on screen, or the user
+// has scrolled all the way to the bottom. Embedded by value in ProgressModel
+// and StatusModel so both share one implementation of "scroll to read it
+// all, then auto-close (or don't, if you scrolled to read it)".
+type scrollableDone struct {
+	content viewport.Model
+	auto    autoReturnTimer
+	armed   bool
+}
+
+// newScrollableDone builds a zero-sized viewport (sized on the first
+// Resize) paired with a countdown of the given duration (0 disables it,
+// matching autoReturnTimer's own semantics).
+func newScrollableDone(autoReturn time.Duration) scrollableDone {
+	return scrollableDone{
+		content: viewport.New(0, 0),
+		auto:    autoReturnTimer{duration: autoReturn},
+	}
+}
+
+// Resize updates the viewport dimensions. Call on tea.WindowSizeMsg and
+// whenever the fixed chrome around the scroll region changes size (e.g. an
+// error line appearing shrinks the body budget by one row).
+func (s *scrollableDone) Resize(width, height int) {
+	if width < 1 {
+		width = 1
+	}
+	if height < 1 {
+		height = 1
+	}
+	s.content.Width = width
+	s.content.Height = height
+}
+
+// SetContent replaces the body text. resetToTop should be true the moment a
+// run transitions into its terminal state, so the user reads the summary
+// from the beginning instead of wherever a live-updating list happened to
+// leave the scroll position.
+func (s *scrollableDone) SetContent(body string, resetToTop bool) {
+	s.content.SetContent(body)
+	if resetToTop {
+		s.content.GotoTop()
+	}
+}
+
+// FollowBottom keeps the viewport pinned to the newest content — used while
+// a run is still in progress so the live per-target list behaves like a
+// tailed log instead of freezing at whatever the scroll offset was when the
+// list was shorter.
+func (s *scrollableDone) FollowBottom() {
+	s.content.GotoBottom()
+}
+
+// Overflows reports whether the body is taller than the viewport, i.e.
+// whether there's anything to scroll at all.
+func (s scrollableDone) Overflows() bool {
+	return s.content.TotalLineCount() > s.content.Height
+}
+
+// ArmIfReady starts the countdown the first time the user has seen the
+// entire body: either because it already fits without scrolling (AtBottom
+// is trivially true the instant there's nothing to scroll), or because
+// they've scrolled all the way down. ready gates this to the run's terminal
+// success state — callers should pass false while running or on error, since
+// a failed run must never auto-return. Once armed, it stays armed: scrolling
+// back up afterward does not cancel the countdown, and repeated calls (e.g.
+// holding a scroll key at the bottom) never re-extend the deadline.
+func (s *scrollableDone) ArmIfReady(ready bool) tea.Cmd {
+	if s.armed || !ready || !s.content.AtBottom() {
+		return nil
+	}
+	s.armed = true
+	return s.auto.Start()
+}
+
+// Tick advances the countdown; quit reports the screen should close now.
+func (s *scrollableDone) Tick() (quit bool, cmd tea.Cmd) {
+	return s.auto.Tick()
+}
+
+// Active reports whether the countdown is currently running (armed and not
+// yet expired).
+func (s scrollableDone) Active() bool { return s.auto.Active() }
+
+// Enabled reports whether auto-return is configured at all (duration > 0),
+// independent of whether it has armed yet — used to decide whether to show
+// a "scroll to bottom to auto-close" hint versus no countdown affordance.
+func (s scrollableDone) Enabled() bool { return s.auto.duration > 0 }
+
+// RemainingSeconds is the whole seconds left before auto-quit.
+func (s scrollableDone) RemainingSeconds() int { return s.auto.RemainingSeconds() }
+
+// HandleKey applies a known scroll key to the viewport. ok reports whether
+// key was a scroll key, so the caller can distinguish "consumed as a scroll"
+// from "not a scroll key, handle it another way".
+func (s *scrollableDone) HandleKey(key string) (ok bool) {
+	switch key {
+	case "up":
+		s.content.LineUp(1)
+	case "down":
+		s.content.LineDown(1)
+	case "pgup":
+		s.content.ViewUp()
+	case "pgdown":
+		s.content.ViewDown()
+	case "ctrl+u":
+		s.content.HalfViewUp()
+	case "ctrl+d":
+		s.content.HalfViewDown()
+	case "home":
+		s.content.GotoTop()
+	case "end":
+		s.content.GotoBottom()
+	default:
+		return false
+	}
+	return true
+}
+
+// HandleMouse forwards a mouse event (wheel scroll) to the viewport.
+func (s *scrollableDone) HandleMouse(msg tea.MouseMsg) tea.Cmd {
+	var cmd tea.Cmd
+	s.content, cmd = s.content.Update(msg)
+	return cmd
+}
+
+// View renders the current viewport window.
+func (s scrollableDone) View() string { return s.content.View() }
+
+// ScrollIndicator returns a compact "▲▼ NN%" widget when the body overflows
+// the viewport, or "" when everything is already visible — mirrors
+// listdetail.go's scrollIndicator so both screens share the same affordance.
+func (s scrollableDone) ScrollIndicator(th *ui.Theme) string {
+	if !s.Overflows() {
+		return ""
+	}
+	up, down := "△", "▽"
+	if !s.content.AtTop() {
+		up = "▲"
+	}
+	if !s.content.AtBottom() {
+		down = "▼"
+	}
+	pct := int(s.content.ScrollPercent()*100 + 0.5)
+	return th.Meta.Render(fmt.Sprintf("%s%s %d%%", up, down, pct))
+}

--- a/cli/internal/tui/status.go
+++ b/cli/internal/tui/status.go
@@ -12,10 +12,15 @@ import (
 )
 
 // StatusResult is the summary a StatusModel renders once fn completes
-// successfully: one headline plus optional key/value detail lines.
+// successfully: one headline plus optional detail content. Exactly one of
+// Raw or Lines is normally set: Raw is pre-rendered/already-styled text
+// (e.g. text captured verbatim from app.UI calls) that's shown as-is; Lines
+// is a list of plain strings the model styles itself with the muted detail
+// color. Raw takes precedence when both are set.
 type StatusResult struct {
 	Headline string
 	Lines    []string
+	Raw      string
 }
 
 // statusDoneMsg carries fn's result back into the bubbletea event loop.
@@ -27,9 +32,10 @@ type statusDoneMsg struct {
 // StatusModel renders a single blocking operation (e.g. "refresh the
 // registry") as a spinner while it runs, then a persistent success/error
 // screen that stays up until the user dismisses it or - on success only -
-// an optional auto-return timer fires. This mirrors ProgressModel's
-// done-screen behavior for operations that don't have granular per-target
-// progress to report, just one result at the end (registry refresh today).
+// an optional auto-return timer fires once they've seen the whole result.
+// This mirrors ProgressModel's done-screen behavior for operations that
+// don't have granular per-target progress to report, just one result (or,
+// via StatusResult.Raw, arbitrary captured output) at the end.
 type StatusModel struct {
 	theme   *ui.Theme
 	command string // header breadcrumb, e.g. "registry"
@@ -40,14 +46,19 @@ type StatusModel struct {
 	running bool
 	result  StatusResult
 	err     error
+	width   int
+	height  int
 
-	autoReturn autoReturnTimer
-	width      int
+	// resultView owns the scrollable result body plus the shared
+	// auto-return countdown — see scrollstatus.go.
+	resultView scrollableDone
 }
 
 // NewStatusModel builds a model that runs fn once fn is kicked off by Init.
 // autoReturn is the countdown duration for the success screen (0 disables
-// it, matching Profile.StatusAutoReturnDuration's semantics).
+// it, matching Profile.StatusAutoReturnDuration's semantics); even when
+// enabled, the countdown waits for the user to scroll to the bottom if the
+// result doesn't already fit on screen — see scrollableDone.ArmIfReady.
 func NewStatusModel(theme *ui.Theme, command, label string, autoReturn time.Duration, fn func() (StatusResult, error)) StatusModel {
 	sp := spinner.New()
 	sp.Spinner = spinner.Dot
@@ -60,7 +71,7 @@ func NewStatusModel(theme *ui.Theme, command, label string, autoReturn time.Dura
 		spin:       sp,
 		fn:         fn,
 		running:    true,
-		autoReturn: autoReturnTimer{duration: autoReturn},
+		resultView: newScrollableDone(autoReturn),
 	}
 }
 
@@ -86,20 +97,19 @@ func runStatusFn(fn func() (StatusResult, error)) tea.Cmd {
 func (m StatusModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
-		m.width = msg.Width
+		m.width, m.height = msg.Width, msg.Height
+		m.refreshResultContent(false)
 		return m, nil
 
 	case statusDoneMsg:
 		m.running = false
 		m.result = msg.result
 		m.err = msg.err
-		if m.err == nil {
-			return m, m.autoReturn.Start()
-		}
-		return m, nil
+		m.refreshResultContent(true)
+		return m, m.resultView.ArmIfReady(m.err == nil)
 
 	case autoReturnTickMsg:
-		quit, cmd := m.autoReturn.Tick()
+		quit, cmd := m.resultView.Tick()
 		if quit {
 			return m, tea.Quit
 		}
@@ -110,9 +120,16 @@ func (m StatusModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.spin, cmd = m.spin.Update(msg)
 		return m, cmd
 
+	case tea.MouseMsg:
+		cmd := m.resultView.HandleMouse(msg)
+		return m, tea.Batch(cmd, m.resultView.ArmIfReady(!m.running && m.err == nil))
+
 	case tea.KeyMsg:
 		if !m.running && (msg.String() == "q" || msg.String() == "enter" || msg.String() == "esc") {
 			return m, tea.Quit
+		}
+		if m.resultView.HandleKey(msg.String()) {
+			return m, m.resultView.ArmIfReady(!m.running && m.err == nil)
 		}
 	}
 	return m, nil
@@ -120,42 +137,121 @@ func (m StatusModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 func (m StatusModel) View() string {
 	th := m.theme
-	header := Header(th, HeaderSpec{Section: m.command}, m.width)
+	header := Header(th, HeaderSpec{
+		Section: m.command,
+		Meta:    m.resultView.ScrollIndicator(th),
+	}, m.width)
 
-	var sb strings.Builder
+	top := m.renderTop(th)
+	footer := m.renderFooter(th)
+
+	if m.running {
+		return header + "\n\n" + top + "\n\n" + footer
+	}
+	return header + "\n\n" + top + "\n\n" + m.resultView.View() + "\n" + footer
+}
+
+// renderTop is the fixed, always-visible state line above the scrollable
+// body: the spinner while running, or a compact ✓/✗ + short label once done
+// (the substantive detail lives in the scrollable body below it).
+func (m StatusModel) renderTop(th *ui.Theme) string {
 	switch {
 	case m.running:
-		sb.WriteString("  " + m.spin.View() + " " + th.Crumb.Render(m.label) + "\n")
+		return "  " + m.spin.View() + " " + th.Crumb.Render(m.label)
 	case m.err != nil:
-		sb.WriteString("  " + th.Error.Render("✗ ") + th.Name.Render("failed") + "\n\n")
-		sb.WriteString("  " + th.Error.Render("error: ") + th.Detail.Render(m.err.Error()) + "\n")
+		return "  " + th.Error.Render("✗ ") + th.Name.Render("failed")
 	default:
 		headline := m.result.Headline
 		if headline == "" {
 			headline = "done"
 		}
-		sb.WriteString("  " + th.Success.Render("✓ ") + th.Name.Render(headline) + "\n")
-		for _, line := range m.result.Lines {
-			sb.WriteString("  " + th.Detail.Render(line) + "\n")
-		}
+		return "  " + th.Success.Render("✓ ") + th.Name.Render(headline)
 	}
+}
 
-	var footer string
+// renderFooter picks the key hints + right-anchored context for the current
+// state, matching ProgressModel.renderFooter's pattern.
+func (m StatusModel) renderFooter(th *ui.Theme) string {
 	switch {
 	case m.running:
-		footer = Footer(th, []KeyHint{{Keys: "ctrl+c", Label: "abort"}}, "", m.width)
-	case m.autoReturn.Active():
-		footer = Footer(th, []KeyHint{{Keys: "enter/q", Label: "close now"}},
-			th.Detail.Render(fmt.Sprintf("closing in %ds", m.autoReturn.RemainingSeconds())), m.width)
+		return Footer(th, []KeyHint{{Keys: "ctrl+c", Label: "abort"}}, "", m.width)
+	case m.err != nil:
+		hints := []KeyHint{{Keys: "enter/q", Label: "close"}}
+		if m.resultView.Overflows() {
+			hints = append(hints, KeyHint{Keys: "↑↓", Label: "scroll"})
+		}
+		return Footer(th, hints, "", m.width)
+	case m.resultView.Active():
+		return Footer(th, []KeyHint{{Keys: "enter/q", Label: "close now"}},
+			th.Detail.Render(fmt.Sprintf("closing in %ds", m.resultView.RemainingSeconds())), m.width)
+	case m.resultView.Enabled():
+		return Footer(th, []KeyHint{{Keys: "enter/q", Label: "close"}, {Keys: "↓/end", Label: "scroll to bottom"}},
+			th.Detail.Render("scroll to bottom to auto-close"), m.width)
 	default:
-		footer = Footer(th, []KeyHint{{Keys: "enter/q", Label: "close"}}, "", m.width)
+		return Footer(th, []KeyHint{{Keys: "enter/q", Label: "close"}}, "", m.width)
 	}
-	return header + "\n\n" + sb.String() + "\n" + footer
+}
+
+// resizeResultView computes the scrollable body's height budget: total
+// height minus the header, the fixed top status line, the blank separator
+// rows, and the footer. Mirrors ProgressModel.resizeResultView.
+func (m *StatusModel) resizeResultView() {
+	if m.width == 0 || m.height == 0 {
+		return
+	}
+	const (
+		headerH   = 2
+		topH      = 1
+		footerH   = 2
+		blankRows = 3 // header/top, top/body, body/footer separators
+	)
+	bodyH := m.height - (headerH + topH + footerH + blankRows)
+	if bodyH < 3 {
+		bodyH = 3
+	}
+	m.resultView.Resize(m.width, bodyH)
+}
+
+// refreshResultContent recomputes the scrollable body's dimensions and
+// content. resetToTop should be true exactly once — when fn finishes — so
+// the user reads the result from the start.
+func (m *StatusModel) refreshResultContent(resetToTop bool) {
+	m.resizeResultView()
+	m.resultView.SetContent(m.resultBody(), resetToTop)
+}
+
+// resultBody composes the scrollable body: the pre-rendered Raw text if
+// set, otherwise Lines styled with the muted detail color, followed by the
+// error line (if any) so a failure still shows whatever context was
+// captured before it — e.g. sync's "skipping unknown skill" warnings ahead
+// of a later hard failure.
+func (m StatusModel) resultBody() string {
+	th := m.theme
+	var sb strings.Builder
+	switch {
+	case m.result.Raw != "":
+		sb.WriteString(strings.TrimRight(m.result.Raw, "\n"))
+	case len(m.result.Lines) > 0:
+		for i, line := range m.result.Lines {
+			if i > 0 {
+				sb.WriteString("\n")
+			}
+			sb.WriteString("  " + th.Detail.Render(line))
+		}
+	}
+	if m.err != nil {
+		if sb.Len() > 0 {
+			sb.WriteString("\n\n")
+		}
+		sb.WriteString("  " + th.Error.Render("error: ") + th.Detail.Render(m.err.Error()))
+	}
+	return sb.String()
 }
 
 // ExecuteWithStatus runs fn in the background while a StatusModel shows a
 // spinner, then its success/error result, staying on screen until the user
-// dismisses it or (success only) autoReturn elapses.
+// dismisses it or (success only, once they've seen the whole result)
+// autoReturn elapses.
 func ExecuteWithStatus(theme *ui.Theme, command, label string, autoReturn time.Duration, fn func() (StatusResult, error)) (StatusResult, error) {
 	m, err := Run(NewStatusModel(theme, command, label, autoReturn, fn))
 	if err != nil {

--- a/cli/internal/tui/status_test.go
+++ b/cli/internal/tui/status_test.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -36,13 +37,48 @@ func TestStatusModel_DoneMsg_Success_NoAutoReturn_DoesNotAutoQuit(t *testing.T) 
 func TestStatusModel_DoneMsg_Success_WithAutoReturn_StartsCountdown(t *testing.T) {
 	m := newTestStatus(5 * time.Second)
 	m.running = true
+	// An empty result fits without scrolling, so the countdown arms
+	// immediately — matching today's behavior for short results.
+	m.width, m.height = 80, 40
 	out, cmd := m.Update(statusDoneMsg{result: StatusResult{Headline: "ok"}})
 	updated := out.(StatusModel)
-	if !updated.autoReturn.Active() {
-		t.Error("expected autoReturn timer to be armed on success")
+	if !updated.resultView.Active() {
+		t.Error("expected the auto-return timer to be armed on a successful result that already fits on screen")
 	}
 	if cmd == nil {
 		t.Error("expected a tea.Cmd to schedule the first tick")
+	}
+}
+
+// TestStatusModel_ArmIfReady_WaitsForScrollWhenContentOverflows mirrors the
+// equivalent ProgressModel test: a result taller than the viewport must not
+// auto-return until the user has scrolled all the way down to see it.
+func TestStatusModel_ArmIfReady_WaitsForScrollWhenContentOverflows(t *testing.T) {
+	m := newTestStatus(5 * time.Second)
+	m.running = true
+	m.width, m.height = 80, 12
+
+	lines := make([]string, 30)
+	for i := range lines {
+		lines[i] = fmt.Sprintf("detail line %d", i)
+	}
+
+	out, cmd := m.Update(statusDoneMsg{result: StatusResult{Headline: "ok", Lines: lines}})
+	updated := out.(StatusModel)
+	if !updated.resultView.Overflows() {
+		t.Fatalf("expected 30 detail lines to overflow a %d-row viewport", updated.resultView.content.Height)
+	}
+	if updated.resultView.Active() || cmd != nil {
+		t.Fatal("auto-return must not arm before the user has scrolled to see the whole result")
+	}
+
+	out, cmd = updated.Update(tea.KeyMsg{Type: tea.KeyEnd})
+	updated = out.(StatusModel)
+	if !updated.resultView.Active() {
+		t.Error("expected auto-return to arm once the user scrolled to the bottom")
+	}
+	if cmd == nil {
+		t.Error("expected a tea.Cmd to schedule the first countdown tick after reaching the bottom")
 	}
 }
 
@@ -52,7 +88,7 @@ func TestStatusModel_DoneMsg_Error_NeverAutoReturns(t *testing.T) {
 	boom := errors.New("boom")
 	out, cmd := m.Update(statusDoneMsg{err: boom})
 	updated := out.(StatusModel)
-	if updated.autoReturn.Active() {
+	if updated.resultView.Active() {
 		t.Error("a failed run must never auto-return — the user needs to read the error")
 	}
 	if cmd != nil {
@@ -66,7 +102,7 @@ func TestStatusModel_DoneMsg_Error_NeverAutoReturns(t *testing.T) {
 func TestStatusModel_AutoReturnTick_QuitsAfterDeadline(t *testing.T) {
 	m := newTestStatus(1 * time.Millisecond)
 	m.running = false
-	m.autoReturn.deadline = time.Now().Add(-time.Second) // already elapsed
+	m.resultView.auto.deadline = time.Now().Add(-time.Second) // already elapsed
 	_, cmd := m.Update(autoReturnTickMsg{})
 	if cmd == nil {
 		t.Fatal("expected tea.Quit cmd once the deadline has passed")
@@ -89,7 +125,8 @@ func TestStatusModel_View_ShowsHeadlineAndDetailLines(t *testing.T) {
 	m := newTestStatus(0)
 	m.running = false
 	m.result = StatusResult{Headline: "registry refreshed: 11 skills", Lines: []string{"cache: /tmp/registry.json"}}
-	m.width = 80
+	m.width, m.height = 80, 40
+	m.refreshResultContent(true)
 	v := m.View()
 	if !strings.Contains(v, "registry refreshed: 11 skills") {
 		t.Errorf("view missing headline:\n%s", v)
@@ -105,8 +142,8 @@ func TestStatusModel_View_ShowsHeadlineAndDetailLines(t *testing.T) {
 func TestStatusModel_View_ShowsCountdownWhenAutoReturnActive(t *testing.T) {
 	m := newTestStatus(5 * time.Second)
 	m.running = false
-	m.autoReturn.deadline = time.Now().Add(5 * time.Second)
-	m.width = 80
+	m.resultView.auto.deadline = time.Now().Add(5 * time.Second)
+	m.width, m.height = 80, 40
 	v := m.View()
 	if !strings.Contains(v, "closing in") {
 		t.Errorf("view should show the countdown when auto-return is active:\n%s", v)
@@ -117,7 +154,8 @@ func TestStatusModel_View_ShowsError(t *testing.T) {
 	m := newTestStatus(0)
 	m.running = false
 	m.err = errors.New("registry unreachable")
-	m.width = 80
+	m.width, m.height = 80, 40
+	m.refreshResultContent(true)
 	v := m.View()
 	if !strings.Contains(v, "registry unreachable") {
 		t.Errorf("view missing error:\n%s", v)

--- a/cli/internal/ui/ui.go
+++ b/cli/internal/ui/ui.go
@@ -4,6 +4,7 @@
 package ui
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -135,6 +136,33 @@ func (p *Printer) IsJSON() bool { return p.jsonMode }
 // level semantics.
 func (p *Printer) Out() io.Writer { return p.out }
 func (p *Printer) Err() io.Writer { return p.err }
+
+// CaptureWriters temporarily redirects both Out and Err to an in-memory
+// buffer and returns a restore function that puts the original writers back
+// and returns everything written while captured.
+//
+// This exists for callers like the dashboard loop that re-enter an
+// alt-screen bubbletea program immediately after running a sub-command: any
+// plain Info/Success/Warn/Error line that sub-command prints in the gap
+// between screens would otherwise be silently overwritten before anyone
+// could read it. Capturing it here lets the caller show it as a proper
+// blocking status screen instead — the dashboard ends up displaying exactly
+// what the standalone CLI would have printed.
+//
+// Safe with respect to colour: the Theme's renderer already picked its
+// colour profile from the real Out at Printer construction time (see
+// NewTheme in theme.go), so redirecting p.out/p.err afterward doesn't
+// change how styles are rendered — it only changes where the resulting
+// bytes are written.
+func (p *Printer) CaptureWriters() (restore func() string) {
+	var buf bytes.Buffer
+	prevOut, prevErr := p.out, p.err
+	p.out, p.err = &buf, &buf
+	return func() string {
+		p.out, p.err = prevOut, prevErr
+		return buf.String()
+	}
+}
 
 // Header prints the shared breadcrumb used above command output:
 //

--- a/cli/internal/ui/ui_test.go
+++ b/cli/internal/ui/ui_test.go
@@ -88,6 +88,31 @@ func TestJSONEncodesDocument(t *testing.T) {
 	}
 }
 
+func TestCaptureWriters_CollectsOutAndErrThenRestores(t *testing.T) {
+	p, out, errW := newTestPrinter(Options{Level: LevelNormal})
+
+	restore := p.CaptureWriters()
+	p.Info("captured info")
+	p.Warn("captured warn")
+	p.Error("captured error")
+	if out.Len() != 0 || errW.Len() != 0 {
+		t.Fatalf("expected nothing written to the original writers while captured, got out=%q err=%q", out.String(), errW.String())
+	}
+
+	captured := restore()
+	for _, want := range []string{"captured info", "captured warn", "captured error"} {
+		if !strings.Contains(captured, want) {
+			t.Errorf("captured output missing %q:\n%s", want, captured)
+		}
+	}
+
+	// Restored writers should receive output normally again.
+	p.Info("after restore")
+	if !strings.Contains(out.String(), "after restore") {
+		t.Errorf("expected writes after restore to reach the original writer, got %q", out.String())
+	}
+}
+
 func TestNoColorStripsANSI(t *testing.T) {
 	// No-color printer produces plain text.
 	p, out, _ := newTestPrinter(Options{Level: LevelNormal})

--- a/registry.json
+++ b/registry.json
@@ -1,10 +1,10 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-07-01T19:06:48Z",
+  "generated_at": "2026-07-01T21:00:36Z",
   "source": {
     "repo": "github.com/jjfantini/humblSKILLS",
-    "ref": "cursor/tui-status-screens-ffa3",
-    "sha": "bce60c39891ab7dd11dbd74d41f9a496d635e534"
+    "ref": "develop",
+    "sha": "68e4d856b2971e766cc3ae3e39383e9a1d4d6fc5"
   },
   "skills": [
     {

--- a/registry.json
+++ b/registry.json
@@ -1,10 +1,10 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-07-01T15:50:02Z",
+  "generated_at": "2026-07-01T19:06:48Z",
   "source": {
     "repo": "github.com/jjfantini/humblSKILLS",
-    "ref": "develop",
-    "sha": "d17cfa1668042ed9eb39deb40bc5f29cd66dd957"
+    "ref": "cursor/tui-status-screens-ffa3",
+    "sha": "bce60c39891ab7dd11dbd74d41f9a496d635e534"
   },
   "skills": [
     {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Promotes `develop` to `main` following the standard release flow.

Includes PR #169: dashboard sub-commands no longer swallow status/error messages (fixes the `sync`-with-no-manifest and `update`-all-up-to-date "flash back to home" bugs), and `ProgressModel`/`StatusModel` done-screens are now scrollable with an auto-return countdown that waits until the user has scrolled to see everything.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d5e4aa27-945a-4f10-ab1c-216f09aeffa3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d5e4aa27-945a-4f10-ab1c-216f09aeffa3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

