### PR TITLE
feat(registry): support auth token for private registries

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,22 @@ humblskills export                    # snapshot installed skills to humblskills
 humblskills sync                      # install everything in humblskills.json
 ```
 
+### Private registries
+
+Point the CLI at any registry with `--registry` (or `HUMBLSKILLS_REGISTRY`). When
+that registry is backed by a **private** GitHub repo, pass a token so both the
+`registry.json` fetch and each skill download are authenticated — supply it with
+`--token` or the `HUMBLSKILLS_TOKEN` env var (a GitHub PAT or token with read
+access to the repo). The token is sent as a `Bearer` Authorization header on
+those requests; it's ignored for `file://` registries and the public default.
+
+```sh
+export HUMBLSKILLS_REGISTRY=https://raw.githubusercontent.com/<owner>/<repo>/main/registry.json
+export HUMBLSKILLS_TOKEN=<github token with read access>
+humblskills search
+humblskills install <skill>
+```
+
 ### Sharing skill sets across a team
 
 `humblskills export` snapshots the skills you have installed into a

--- a/cli/cmd/humblskills/doctor_report.go
+++ b/cli/cmd/humblskills/doctor_report.go
@@ -133,7 +133,7 @@ func buildDoctorReport(app *App) (doctorReport, error) {
 		}
 	}
 
-	f := registry.NewFetcher(app.Config.RegistryURL, app.Config.CacheDir)
+	f := app.registryFetcher()
 	// No spinner here - the caller (runDoctor) already wraps this whole
 	// function in one loading/spinner screen, so a second nested spinner
 	// would just fight it for the terminal.

--- a/cli/cmd/humblskills/install.go
+++ b/cli/cmd/humblskills/install.go
@@ -61,7 +61,7 @@ func runInstall(app *App, skill string, f installFlags, fromDashboard bool) erro
 		if err != nil {
 			return preload{}, fmt.Errorf("load adapters: %w", err)
 		}
-		reg, _, err := registry.NewFetcher(app.Config.RegistryURL, app.Config.CacheDir).Load()
+		reg, _, err := app.registryFetcher().Load()
 		if err != nil {
 			return preload{}, fmt.Errorf("load registry: %w", err)
 		}
@@ -129,7 +129,7 @@ func runInstall(app *App, skill string, f installFlags, fromDashboard bool) erro
 		return err
 	}
 
-	engine := install.NewEngine(app.Config.CacheDir, app.Config.ManifestPath)
+	engine := app.installEngine()
 
 	if !useTUI {
 		app.UI.Detail("plan:")

--- a/cli/cmd/humblskills/list.go
+++ b/cli/cmd/humblskills/list.go
@@ -68,7 +68,7 @@ func runList(app *App, fromDashboard bool) error {
 // registry is read from the local cache only (never fetched); if no cached
 // registry is available the map is nil and callers show no drift.
 func availableUpdates(app *App, m *manifest.Manifest) map[string]string {
-	reg, ok := registry.NewFetcher(app.Config.RegistryURL, app.Config.CacheDir).LoadCached()
+	reg, ok := app.registryFetcher().LoadCached()
 	if !ok || reg == nil {
 		return nil
 	}
@@ -185,7 +185,7 @@ func renderListTable(app *App, installs []manifest.Installation, avail map[strin
 func runListTUI(app *App, m *manifest.Manifest, fromDashboard bool) error {
 	// Pull the registry to know whether each installed skill has drifted. If
 	// the registry is unreachable, fall back to the manifest versions.
-	reg, _, _ := registry.NewFetcher(app.Config.RegistryURL, app.Config.CacheDir).Load()
+	reg, _, _ := app.registryFetcher().Load()
 
 	// Build a "virtual" registry view of only the skills we have installed,
 	// preferring the registry version when available so `outdated` can render.

--- a/cli/cmd/humblskills/migrate.go
+++ b/cli/cmd/humblskills/migrate.go
@@ -12,7 +12,6 @@ import (
 	"github.com/jjfantini/humblSKILLS/cli/internal/frontmatter"
 	"github.com/jjfantini/humblSKILLS/cli/internal/install"
 	"github.com/jjfantini/humblSKILLS/cli/internal/profile"
-	"github.com/jjfantini/humblSKILLS/cli/internal/registry"
 	"github.com/jjfantini/humblSKILLS/cli/internal/tui"
 )
 
@@ -72,7 +71,7 @@ func runMigrate(app *App, sourcePlatform string, f migrateFlags) error {
 		return err
 	}
 
-	reg, _, err := registry.NewFetcher(app.Config.RegistryURL, app.Config.CacheDir).Load()
+	reg, _, err := app.registryFetcher().Load()
 	if err != nil {
 		return fmt.Errorf("load registry: %w", err)
 	}
@@ -96,7 +95,7 @@ func runMigrate(app *App, sourcePlatform string, f migrateFlags) error {
 		return fmt.Errorf("no platforms selected - run 'humblskills doctor' to see what's detected")
 	}
 
-	engine := install.NewEngine(app.Config.CacheDir, app.Config.ManifestPath)
+	engine := app.installEngine()
 	useTUI := tui.ShouldUseTUI(app.Config.JSON, app.Config.Quiet, app.Config.Yes)
 	result := migrateResult{Skipped: skipped}
 	var aggregate install.Result

--- a/cli/cmd/humblskills/registry.go
+++ b/cli/cmd/humblskills/registry.go
@@ -7,7 +7,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/jjfantini/humblSKILLS/cli/internal/profile"
-	"github.com/jjfantini/humblSKILLS/cli/internal/registry"
 	"github.com/jjfantini/humblSKILLS/cli/internal/textutil"
 	"github.com/jjfantini/humblSKILLS/cli/internal/tui"
 )
@@ -40,7 +39,7 @@ func newRegistryRefreshCmd(app *App) *cobra.Command {
 }
 
 func runRegistryRefresh(app *App) error {
-	f := registry.NewFetcher(app.Config.RegistryURL, app.Config.CacheDir)
+	f := app.registryFetcher()
 
 	refresh := func() (refreshResult, error) {
 		r, o, err := f.Refresh()

--- a/cli/cmd/humblskills/root.go
+++ b/cli/cmd/humblskills/root.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/jjfantini/humblSKILLS/cli/internal/adapters"
 	"github.com/jjfantini/humblSKILLS/cli/internal/env"
+	"github.com/jjfantini/humblSKILLS/cli/internal/install"
 	"github.com/jjfantini/humblSKILLS/cli/internal/manifest"
 	"github.com/jjfantini/humblSKILLS/cli/internal/profile"
 	"github.com/jjfantini/humblSKILLS/cli/internal/registry"
@@ -40,20 +41,25 @@ type NavContext struct {
 
 // Config captures every flag/env-resolved setting used by subcommands.
 type Config struct {
-	RegistryURL  string
-	CacheDir     string
-	ManifestPath string
-	ProfilePath  string
-	JSON         bool
-	NoColor      bool
-	Verbose      bool
-	Quiet        bool
-	Yes          bool
-	Fullscreen   bool
+	RegistryURL string
+	// RegistryToken, when set, is sent as a Bearer token on registry.json and
+	// skill-tarball fetches so a private registry (e.g. a private GitHub repo)
+	// can be read. Empty means unauthenticated (the public default).
+	RegistryToken string
+	CacheDir      string
+	ManifestPath  string
+	ProfilePath   string
+	JSON          bool
+	NoColor       bool
+	Verbose       bool
+	Quiet         bool
+	Yes           bool
+	Fullscreen    bool
 }
 
 type globalFlags struct {
 	registry   string
+	token      string
 	cacheDir   string
 	manifest   string
 	profile    string
@@ -89,6 +95,7 @@ func newRootCmd() *cobra.Command {
 
 	f := cmd.PersistentFlags()
 	f.StringVar(&g.registry, "registry", "", "registry URL (or file:// path). Defaults to the hosted registry; env: HUMBLSKILLS_REGISTRY")
+	f.StringVar(&g.token, "token", "", "auth token for a private registry, sent as a Bearer token on registry + skill fetches (env: HUMBLSKILLS_TOKEN)")
 	f.StringVar(&g.cacheDir, "cache-dir", "", "cache directory (env: HUMBLSKILLS_CACHE_DIR; default: XDG_CACHE_HOME/humblskills)")
 	f.StringVar(&g.manifest, "manifest", "", "install manifest path (env: HUMBLSKILLS_MANIFEST; default: XDG_STATE_HOME/humblskills/manifest.json)")
 	f.StringVar(&g.profile, "profile", "", "profile config path (env: HUMBLSKILLS_PROFILE; default: ~/.humblskills/profile.json)")
@@ -153,13 +160,14 @@ func configureApp(_ *cobra.Command, app *App, g globalFlags) error {
 	}
 
 	cfg := Config{
-		RegistryURL: textutil.FirstNonEmpty(g.registry, os.Getenv("HUMBLSKILLS_REGISTRY"), registry.DefaultURL),
-		JSON:        g.json,
-		NoColor:     g.noColor,
-		Verbose:     g.verbose,
-		Quiet:       g.quiet,
-		Yes:         g.yes,
-		Fullscreen:  g.fullscreen,
+		RegistryURL:   textutil.FirstNonEmpty(g.registry, os.Getenv("HUMBLSKILLS_REGISTRY"), registry.DefaultURL),
+		RegistryToken: textutil.FirstNonEmpty(g.token, os.Getenv("HUMBLSKILLS_TOKEN")),
+		JSON:          g.json,
+		NoColor:       g.noColor,
+		Verbose:       g.verbose,
+		Quiet:         g.quiet,
+		Yes:           g.yes,
+		Fullscreen:    g.fullscreen,
 	}
 
 	cacheDir, err := resolveCacheDir(textutil.FirstNonEmpty(g.cacheDir, os.Getenv("HUMBLSKILLS_CACHE_DIR")))
@@ -184,6 +192,24 @@ func configureApp(_ *cobra.Command, app *App, g globalFlags) error {
 	app.Adapters = adapters.Load
 
 	return nil
+}
+
+// registryFetcher builds a registry Fetcher using the resolved registry URL,
+// cache dir, and (optional) auth token. Centralising construction here keeps the
+// token wired into every command that reads the registry.
+func (a *App) registryFetcher() *registry.Fetcher {
+	f := registry.NewFetcher(a.Config.RegistryURL, a.Config.CacheDir)
+	f.Token = a.Config.RegistryToken
+	return f
+}
+
+// installEngine builds an install Engine with the (optional) auth token wired
+// into its tarball fetcher, so skill content can be pulled from a private
+// registry's backing repo.
+func (a *App) installEngine() *install.Engine {
+	e := install.NewEngine(a.Config.CacheDir, a.Config.ManifestPath)
+	e.Fetcher.Token = a.Config.RegistryToken
+	return e
 }
 
 func resolveCacheDir(override string) (string, error) {

--- a/cli/cmd/humblskills/search.go
+++ b/cli/cmd/humblskills/search.go
@@ -32,7 +32,7 @@ func newSearchCmd(app *App) *cobra.Command {
 				return fmt.Errorf("unknown --category %q (must be one of %s)", category, strings.Join(frontmatter.Categories, ", "))
 			}
 
-			reg, _, err := registry.NewFetcher(app.Config.RegistryURL, app.Config.CacheDir).Load()
+			reg, _, err := app.registryFetcher().Load()
 			if err != nil {
 				return err
 			}

--- a/cli/cmd/humblskills/skillset.go
+++ b/cli/cmd/humblskills/skillset.go
@@ -11,7 +11,6 @@ import (
 	"github.com/jjfantini/humblSKILLS/cli/internal/install"
 	"github.com/jjfantini/humblSKILLS/cli/internal/manifest"
 	"github.com/jjfantini/humblSKILLS/cli/internal/profile"
-	"github.com/jjfantini/humblSKILLS/cli/internal/registry"
 	"github.com/jjfantini/humblSKILLS/cli/internal/skillset"
 	"github.com/jjfantini/humblSKILLS/cli/internal/textutil"
 	"github.com/jjfantini/humblSKILLS/cli/internal/tui"
@@ -185,7 +184,7 @@ func runSync(app *App, path string, f installFlags, prune bool) error {
 	if err != nil {
 		return fmt.Errorf("load adapters: %w", err)
 	}
-	reg, _, err := registry.NewFetcher(app.Config.RegistryURL, app.Config.CacheDir).Load()
+	reg, _, err := app.registryFetcher().Load()
 	if err != nil {
 		return fmt.Errorf("load registry: %w", err)
 	}
@@ -206,7 +205,7 @@ func runSync(app *App, path string, f installFlags, prune bool) error {
 		return fmt.Errorf("no platforms selected — run 'humblskills doctor' to see what's detected")
 	}
 
-	engine := install.NewEngine(app.Config.CacheDir, app.Config.ManifestPath)
+	engine := app.installEngine()
 	var aggregate install.Result
 	var missing []string
 
@@ -307,7 +306,7 @@ func pruneToSkillset(app *App, set *skillset.Set) ([]install.TargetResult, error
 		}
 	}
 
-	engine := install.NewEngine(app.Config.CacheDir, app.Config.ManifestPath)
+	engine := app.installEngine()
 	var pruned []install.TargetResult
 	for _, name := range extra {
 		res, err := engine.Uninstall(name)

--- a/cli/cmd/humblskills/start.go
+++ b/cli/cmd/humblskills/start.go
@@ -160,7 +160,7 @@ func dispatchDashboardCommand(app *App, cmd string) error {
 		return runUpgrade(app, upgradeFlags{})
 	case "search":
 		hits, err := tui.RunWithLoading(app.UI.Theme(), "loading registry…", func() ([]registry.Skill, error) {
-			reg, _, err := registry.NewFetcher(app.Config.RegistryURL, app.Config.CacheDir).Load()
+			reg, _, err := app.registryFetcher().Load()
 			if err != nil {
 				return nil, err
 			}
@@ -219,7 +219,7 @@ func buildDashboardSummary(app *App) dashboardSummary {
 		}
 	}
 
-	reg, _, err := registry.NewFetcher(app.Config.RegistryURL, app.Config.CacheDir).Load()
+	reg, _, err := app.registryFetcher().Load()
 	if err == nil && reg != nil {
 		s.drifted = len(install.PlanUpdates(reg, m, nil))
 	}

--- a/cli/cmd/humblskills/uninstall.go
+++ b/cli/cmd/humblskills/uninstall.go
@@ -44,7 +44,7 @@ func runUninstallPicker(app *App, fromDashboard bool) error {
 		return nil
 	}
 
-	reg, _, _ := registry.NewFetcher(app.Config.RegistryURL, app.Config.CacheDir).Load()
+	reg, _, _ := app.registryFetcher().Load()
 
 	installedNames := uniqueSkillsFromManifest(m)
 	skills := make([]registry.Skill, 0, len(installedNames))
@@ -114,7 +114,7 @@ func runUninstall(app *App, skill string) error {
 		return nil
 	}
 
-	engine := install.NewEngine(app.Config.CacheDir, app.Config.ManifestPath)
+	engine := app.installEngine()
 	res, err := engine.Uninstall(skill)
 	if err != nil {
 		return err

--- a/cli/cmd/humblskills/update.go
+++ b/cli/cmd/humblskills/update.go
@@ -64,7 +64,7 @@ func runUpdate(app *App, only []string, f updateFlags) error {
 	}
 
 	reg, err := tui.RunWithLoadingIf(useTUI, app.UI.Theme(), "loading registry…", func() (*registry.Registry, error) {
-		reg, _, err := registry.NewFetcher(app.Config.RegistryURL, app.Config.CacheDir).Load()
+		reg, _, err := app.registryFetcher().Load()
 		if err != nil {
 			return nil, fmt.Errorf("load registry: %w", err)
 		}
@@ -108,7 +108,7 @@ func runUpdate(app *App, only []string, f updateFlags) error {
 		adapterKnown[a.Name] = struct{}{}
 	}
 
-	engine := install.NewEngine(app.Config.CacheDir, app.Config.ManifestPath)
+	engine := app.installEngine()
 	var aggregate install.Result
 
 	run := func(sink install.EventSink) error {

--- a/cli/internal/fetch/auth_test.go
+++ b/cli/internal/fetch/auth_test.go
@@ -1,0 +1,51 @@
+package fetch_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestFetch_SendsBearerToken verifies that a configured Token is sent as a
+// Bearer Authorization header on the codeload tarball fetch, so skill content
+// can be pulled from a private repo.
+func TestFetch_SendsBearerToken(t *testing.T) {
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/gzip")
+		_, _ = w.Write([]byte("tarball-bytes"))
+	}))
+	defer srv.Close()
+
+	f := fetcherWithMockHTTP(t.TempDir(), srv)
+	f.Token = "s3cret"
+
+	if _, err := f.Fetch("owner/repo", "deadbeef0000"); err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if want := "Bearer s3cret"; gotAuth != want {
+		t.Errorf("Authorization header: got %q, want %q", gotAuth, want)
+	}
+}
+
+// TestFetch_NoAuthHeaderWithoutToken verifies no Authorization header is sent
+// when Token is empty.
+func TestFetch_NoAuthHeaderWithoutToken(t *testing.T) {
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/gzip")
+		_, _ = w.Write([]byte("tarball-bytes"))
+	}))
+	defer srv.Close()
+
+	f := fetcherWithMockHTTP(t.TempDir(), srv)
+
+	if _, err := f.Fetch("owner/repo", "deadbeef0000"); err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if gotAuth != "" {
+		t.Errorf("expected no Authorization header, got %q", gotAuth)
+	}
+}

--- a/cli/internal/fetch/tarball.go
+++ b/cli/internal/fetch/tarball.go
@@ -24,6 +24,9 @@ const DefaultHTTPTimeout = 60 * time.Second
 type Fetcher struct {
 	CacheDir string
 	HTTP     *http.Client
+	// Token, when non-empty, is sent as a Bearer Authorization header so skill
+	// content can be pulled from a private repo's codeload endpoint.
+	Token string
 }
 
 // NewFetcher returns a Fetcher with sensible defaults. cacheDir should be the
@@ -62,6 +65,9 @@ func (f *Fetcher) Fetch(repo, sha string) (string, error) {
 		return "", fmt.Errorf("build request: %w", err)
 	}
 	req.Header.Set("User-Agent", "humblskills-cli")
+	if f.Token != "" {
+		req.Header.Set("Authorization", "Bearer "+f.Token)
+	}
 
 	resp, err := f.HTTP.Do(req)
 	if err != nil {

--- a/cli/internal/registry/auth_test.go
+++ b/cli/internal/registry/auth_test.go
@@ -1,0 +1,53 @@
+package registry
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestFetch_SendsBearerToken verifies that a configured Token is sent as a
+// Bearer Authorization header on the registry HTTP fetch, so a private registry
+// can be read.
+func TestFetch_SendsBearerToken(t *testing.T) {
+	body := testRegistryBody(t)
+
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.Write(body)
+	}))
+	defer srv.Close()
+
+	f := NewFetcher(srv.URL, t.TempDir())
+	f.Token = "s3cret"
+
+	if _, _, err := f.Load(); err != nil {
+		t.Fatal(err)
+	}
+	if want := "Bearer s3cret"; gotAuth != want {
+		t.Errorf("Authorization header: got %q, want %q", gotAuth, want)
+	}
+}
+
+// TestFetch_NoAuthHeaderWithoutToken verifies that no Authorization header is
+// sent when Token is empty (the public default).
+func TestFetch_NoAuthHeaderWithoutToken(t *testing.T) {
+	body := testRegistryBody(t)
+
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.Write(body)
+	}))
+	defer srv.Close()
+
+	f := NewFetcher(srv.URL, t.TempDir())
+
+	if _, _, err := f.Load(); err != nil {
+		t.Fatal(err)
+	}
+	if gotAuth != "" {
+		t.Errorf("expected no Authorization header, got %q", gotAuth)
+	}
+}

--- a/cli/internal/registry/fetcher.go
+++ b/cli/internal/registry/fetcher.go
@@ -34,6 +34,10 @@ type Fetcher struct {
 	TTL      time.Duration
 	HTTP     *http.Client
 	Now      func() time.Time
+	// Token, when non-empty, is sent as a Bearer Authorization header on the
+	// HTTP registry fetch so a private registry can be read. Ignored for
+	// file:// URLs and bare paths.
+	Token string
 }
 
 // NewFetcher returns a Fetcher with sensible defaults. cacheDir should be the
@@ -172,6 +176,9 @@ func (f *Fetcher) fetchAndCache() (*Registry, error) {
 		return nil, fmt.Errorf("build request: %w", err)
 	}
 	req.Header.Set("User-Agent", "humblskills-cli")
+	if f.Token != "" {
+		req.Header.Set("Authorization", "Bearer "+f.Token)
+	}
 
 	resp, err := f.HTTP.Do(req)
 	if err != nil {
@@ -207,8 +214,8 @@ func (f *Fetcher) loadLocal() (*Registry, error) {
 	return parseRegistry(data)
 }
 
-func (f *Fetcher) bodyPath() string  { return filepath.Join(f.CacheDir, "registry.json") }
-func (f *Fetcher) metaPath() string  { return filepath.Join(f.CacheDir, "registry.meta.json") }
+func (f *Fetcher) bodyPath() string { return filepath.Join(f.CacheDir, "registry.json") }
+func (f *Fetcher) metaPath() string { return filepath.Join(f.CacheDir, "registry.meta.json") }
 func (f *Fetcher) writeCache(body []byte) error {
 	if err := os.MkdirAll(f.CacheDir, 0o755); err != nil {
 		return err

--- a/registry.json
+++ b/registry.json
@@ -1,10 +1,10 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-07-01T21:03:29Z",
+  "generated_at": "2026-07-21T16:14:12Z",
   "source": {
     "repo": "github.com/jjfantini/humblSKILLS",
-    "ref": "main",
-    "sha": "84126b8f19927acce029dd88790581d130e0cc5b"
+    "ref": "feat/registry-token-auth",
+    "sha": "d360aa239e35b6c1e0c486ced40fc239b9ab2508"
   },
   "skills": [
     {


### PR DESCRIPTION
## What

Adds an optional auth token so `humblskills` can read and install from a **private** GitHub-backed registry.

- New `--token` flag / `HUMBLSKILLS_TOKEN` env var, resolved in `configureApp`.
- `registry.Fetcher` and `fetch.Fetcher` gain a `Token` field; when set it is sent as `Authorization: Bearer <token>` on the `registry.json` fetch and the codeload skill-tarball fetch. Ignored for `file://` URLs / the public default.
- `App.registryFetcher()` / `App.installEngine()` centralise construction so the token reaches all 12 registry-read sites and all engine sites. `NewFetcher`/`NewEngine` signatures unchanged (keeps the ~24 test call sites intact).
- README: new "Private registries" section.

## Testing

- `go test -race ./...` green; `go vet ./...` clean.
- New unit tests assert the `Bearer` header is present when a token is set and absent otherwise, for both fetchers.
- **End-to-end verified** against a real private repo: `humblskills search` + `humblskills install` succeed with `HUMBLSKILLS_TOKEN` set, 404 without. `Bearer` accepted by both `raw.githubusercontent.com` and `codeload.github.com`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)