### PR TITLE
feat(registry): persist registry URL in profile, store token in OS keychain

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,18 +93,34 @@ humblskills sync                      # install everything in humblskills.json
 
 ### Private registries
 
-Point the CLI at any registry with `--registry` (or `HUMBLSKILLS_REGISTRY`). When
-that registry is backed by a **private** GitHub repo, pass a token so both the
-`registry.json` fetch and each skill download are authenticated — supply it with
-`--token` or the `HUMBLSKILLS_TOKEN` env var (a GitHub PAT or token with read
-access to the repo). The token is sent as a `Bearer` Authorization header on
-those requests; it's ignored for `file://` registries and the public default.
+Point the CLI at any registry, and — when it's backed by a **private** GitHub repo —
+give it a token (a GitHub PAT with read access). The token authenticates both the
+`registry.json` fetch and each skill download, sent as a `Bearer` header; it's ignored
+for `file://` registries and the public default.
+
+**Durable, no env vars (recommended).** Persist the registry URL in your profile and
+store the token in your OS keychain once — then plain `humblskills` commands just work:
+
+```sh
+humblskills profile set registry https://raw.githubusercontent.com/<owner>/<repo>/main/registry.json
+humblskills registry login          # prompts for the token (masked); stored in the OS keychain
+humblskills search                  # uses the saved registry + token automatically
+humblskills install <skill>
+humblskills registry logout         # remove the stored token
+```
+
+`registry login` also accepts the token via `--token <t>` or piped stdin
+(`echo "$TOK" | humblskills registry login`), and falls back to a `0600` file if no
+keychain is available.
+
+**Or ad-hoc / CI**, via flags or env vars (highest precedence, in this order:
+`--token` → `HUMBLSKILLS_TOKEN` → keychain → file; and `--registry` → `HUMBLSKILLS_REGISTRY`
+→ profile → hosted default):
 
 ```sh
 export HUMBLSKILLS_REGISTRY=https://raw.githubusercontent.com/<owner>/<repo>/main/registry.json
 export HUMBLSKILLS_TOKEN=<github token with read access>
 humblskills search
-humblskills install <skill>
 ```
 
 ### Sharing skill sets across a team

--- a/cli/cmd/humblskills/profile.go
+++ b/cli/cmd/humblskills/profile.go
@@ -47,7 +47,7 @@ func newProfileSetCmd(app *App) *cobra.Command {
 	return &cobra.Command{
 		Use: "set <key> <value>",
 		Short: "Set a profile value. Keys: platforms (csv), scope (global|user|project|adapter-default), " +
-			"status_auto_return_seconds (seconds, or default|off).",
+			"registry (URL/file:// path, or \"\" to clear), status_auto_return_seconds (seconds, or default|off).",
 		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runProfileSet(app, args[0], args[1])
@@ -142,6 +142,8 @@ func runProfileShow(app *App) error {
 		th.KVValue.Render(formatPlatforms(p.DefaultPlatforms)))
 	fmt.Fprintln(app.UI.Out(), "  "+th.KVKey.Render("scope")+"        "+
 		th.KVValue.Render(formatScope(p.DefaultScope)))
+	fmt.Fprintln(app.UI.Out(), "  "+th.KVKey.Render("registry")+"     "+
+		th.KVValue.Render(formatRegistry(p.Registry)))
 	fmt.Fprintln(app.UI.Out(), "  "+th.KVKey.Render("auto-return")+"  "+
 		th.KVValue.Render(formatAutoReturn(p.StatusAutoReturnSeconds)))
 	fmt.Fprintln(app.UI.Out(), "  "+th.KVKey.Render("path")+"         "+
@@ -178,6 +180,12 @@ func runProfileSet(app *App, key, value string) error {
 			return fmt.Errorf("invalid scope %q — valid: global, user, project, adapter-default, \"\"", value)
 		}
 		p.DefaultScope = value
+	case "registry":
+		reg := strings.TrimSpace(value)
+		if reg != "" && !isPlausibleRegistry(reg) {
+			return fmt.Errorf("invalid registry %q — expected an http(s):// URL, a file:// URL, or a filesystem path", value)
+		}
+		p.Registry = reg
 	case "status_auto_return_seconds":
 		seconds, err := parseStatusAutoReturnSeconds(value)
 		if err != nil {
@@ -185,7 +193,7 @@ func runProfileSet(app *App, key, value string) error {
 		}
 		p.StatusAutoReturnSeconds = seconds
 	default:
-		return fmt.Errorf("unknown key %q — valid keys: platforms, scope, status_auto_return_seconds", key)
+		return fmt.Errorf("unknown key %q — valid keys: platforms, scope, registry, status_auto_return_seconds", key)
 	}
 
 	if err := profile.Save(app.Config.ProfilePath, p); err != nil {
@@ -283,6 +291,25 @@ func formatAutoReturn(seconds *int) string {
 	default:
 		return fmt.Sprintf("%ds", *seconds)
 	}
+}
+
+// formatRegistry renders Profile.Registry for `profile show`.
+func formatRegistry(s string) string {
+	if strings.TrimSpace(s) == "" {
+		return "(hosted default)"
+	}
+	return s
+}
+
+// isPlausibleRegistry does a light sanity check on a registry value: an
+// http(s):// or file:// URL, or something path-like. It intentionally stays
+// lenient — the fetcher does the real interpretation.
+func isPlausibleRegistry(s string) bool {
+	return strings.HasPrefix(s, "http://") ||
+		strings.HasPrefix(s, "https://") ||
+		strings.HasPrefix(s, "file://") ||
+		strings.Contains(s, "/") ||
+		strings.HasSuffix(s, ".json")
 }
 
 func formatScope(s string) string {

--- a/cli/cmd/humblskills/registry.go
+++ b/cli/cmd/humblskills/registry.go
@@ -2,11 +2,16 @@ package main
 
 import (
 	"fmt"
+	"io"
+	"os"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 
 	"github.com/jjfantini/humblSKILLS/cli/internal/profile"
+	"github.com/jjfantini/humblSKILLS/cli/internal/secrets"
 	"github.com/jjfantini/humblSKILLS/cli/internal/textutil"
 	"github.com/jjfantini/humblSKILLS/cli/internal/tui"
 )
@@ -24,8 +29,79 @@ func newRegistryCmd(app *App) *cobra.Command {
 		Use:   "registry",
 		Short: "Inspect and refresh the skill registry cache",
 	}
-	cmd.AddCommand(newRegistryRefreshCmd(app))
+	cmd.AddCommand(
+		newRegistryRefreshCmd(app),
+		newRegistryLoginCmd(app),
+		newRegistryLogoutCmd(app),
+	)
 	return cmd
+}
+
+func newRegistryLoginCmd(app *App) *cobra.Command {
+	return &cobra.Command{
+		Use:   "login",
+		Short: "Store a registry auth token (for a private registry) in the OS keychain",
+		Long: "login saves the GitHub token used to read a private registry and download its skills. " +
+			"The token is stored in the OS keychain (falling back to a 0600 file if the keychain is " +
+			"unavailable) and used automatically on registry + skill fetches — no env var needed. " +
+			"Provide it with the global --token flag, by piping it on stdin, or via the masked prompt.",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runRegistryLogin(app)
+		},
+	}
+}
+
+func newRegistryLogoutCmd(app *App) *cobra.Command {
+	return &cobra.Command{
+		Use:   "logout",
+		Short: "Remove the stored registry auth token from the keychain / secrets file",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := secrets.DeleteRegistryToken(); err != nil {
+				return err
+			}
+			if app.Config.JSON {
+				return app.UI.JSON(map[string]string{"status": "removed"})
+			}
+			app.UI.Success("removed stored registry token")
+			return nil
+		},
+	}
+}
+
+func runRegistryLogin(app *App) error {
+	// Priority: global --token flag > piped stdin > interactive masked prompt.
+	token := strings.TrimSpace(app.Config.RegistryToken)
+	if token == "" {
+		if term.IsTerminal(int(os.Stdin.Fd())) {
+			v, err := app.Prompt.Secret("Registry auth token (input hidden)")
+			if err != nil {
+				return err
+			}
+			token = strings.TrimSpace(v)
+		} else {
+			b, err := io.ReadAll(os.Stdin)
+			if err != nil {
+				return fmt.Errorf("read token from stdin: %w", err)
+			}
+			token = strings.TrimSpace(string(b))
+		}
+	}
+	if token == "" {
+		return fmt.Errorf("no token provided (use --token, pipe it on stdin, or enter it at the prompt)")
+	}
+
+	src, err := secrets.SetRegistryToken(token)
+	if err != nil {
+		return err
+	}
+	if app.Config.JSON {
+		return app.UI.JSON(map[string]string{"stored": string(src)})
+	}
+	app.UI.Success("stored registry token in %s", src)
+	if src == secrets.SourceFile {
+		app.UI.Detail("OS keychain unavailable — stored in a 0600 secrets file instead")
+	}
+	return nil
 }
 
 func newRegistryRefreshCmd(app *App) *cobra.Command {

--- a/cli/cmd/humblskills/root.go
+++ b/cli/cmd/humblskills/root.go
@@ -14,6 +14,7 @@ import (
 	"github.com/jjfantini/humblSKILLS/cli/internal/manifest"
 	"github.com/jjfantini/humblSKILLS/cli/internal/profile"
 	"github.com/jjfantini/humblSKILLS/cli/internal/registry"
+	"github.com/jjfantini/humblSKILLS/cli/internal/secrets"
 	"github.com/jjfantini/humblSKILLS/cli/internal/textutil"
 	"github.com/jjfantini/humblSKILLS/cli/internal/tui"
 	"github.com/jjfantini/humblSKILLS/cli/internal/ui"
@@ -42,9 +43,10 @@ type NavContext struct {
 // Config captures every flag/env-resolved setting used by subcommands.
 type Config struct {
 	RegistryURL string
-	// RegistryToken, when set, is sent as a Bearer token on registry.json and
-	// skill-tarball fetches so a private registry (e.g. a private GitHub repo)
-	// can be read. Empty means unauthenticated (the public default).
+	// RegistryToken holds ONLY the --token flag value. The effective token is
+	// resolved lazily by (*App).registryToken(): flag > HUMBLSKILLS_TOKEN env >
+	// OS keyring > secrets file. Resolving lazily keeps commands that never
+	// fetch (list, profile, doctor) from touching the keychain.
 	RegistryToken string
 	CacheDir      string
 	ManifestPath  string
@@ -159,9 +161,24 @@ func configureApp(_ *cobra.Command, app *App, g globalFlags) error {
 			len(res.Loaded), res.Path, len(res.Kept))
 	}
 
+	profilePath, err := resolveProfilePath(textutil.FirstNonEmpty(g.profile, os.Getenv("HUMBLSKILLS_PROFILE")))
+	if err != nil {
+		return err
+	}
+
+	// Load the profile up front (best-effort) so a persisted registry URL can
+	// act as a fallback below. A missing profile yields an empty one, so a read
+	// error here is non-fatal — commands that need the profile load it and
+	// surface real errors themselves.
+	var profileRegistry string
+	if p, perr := profile.Load(profilePath); perr == nil && p != nil {
+		profileRegistry = p.Registry
+	}
+
 	cfg := Config{
-		RegistryURL:   textutil.FirstNonEmpty(g.registry, os.Getenv("HUMBLSKILLS_REGISTRY"), registry.DefaultURL),
-		RegistryToken: textutil.FirstNonEmpty(g.token, os.Getenv("HUMBLSKILLS_TOKEN")),
+		RegistryURL:   textutil.FirstNonEmpty(g.registry, os.Getenv("HUMBLSKILLS_REGISTRY"), profileRegistry, registry.DefaultURL),
+		RegistryToken: g.token, // flag only; env/keyring/file resolved in registryToken()
+		ProfilePath:   profilePath,
 		JSON:          g.json,
 		NoColor:       g.noColor,
 		Verbose:       g.verbose,
@@ -182,16 +199,22 @@ func configureApp(_ *cobra.Command, app *App, g globalFlags) error {
 	}
 	cfg.ManifestPath = manifestPath
 
-	profilePath, err := resolveProfilePath(textutil.FirstNonEmpty(g.profile, os.Getenv("HUMBLSKILLS_PROFILE")))
-	if err != nil {
-		return err
-	}
-	cfg.ProfilePath = profilePath
-
 	app.Config = cfg
 	app.Adapters = adapters.Load
 
 	return nil
+}
+
+// registryToken resolves the effective registry auth token, in precedence
+// order: the --token flag > HUMBLSKILLS_TOKEN env > OS keyring > secrets file.
+// It is called only when a fetcher/engine is actually built, so commands that
+// never fetch don't touch the keychain.
+func (a *App) registryToken() string {
+	if a.Config.RegistryToken != "" {
+		return a.Config.RegistryToken
+	}
+	tok, _ := secrets.GetRegistryToken()
+	return tok
 }
 
 // registryFetcher builds a registry Fetcher using the resolved registry URL,
@@ -199,7 +222,7 @@ func configureApp(_ *cobra.Command, app *App, g globalFlags) error {
 // token wired into every command that reads the registry.
 func (a *App) registryFetcher() *registry.Fetcher {
 	f := registry.NewFetcher(a.Config.RegistryURL, a.Config.CacheDir)
-	f.Token = a.Config.RegistryToken
+	f.Token = a.registryToken()
 	return f
 }
 
@@ -208,7 +231,7 @@ func (a *App) registryFetcher() *registry.Fetcher {
 // registry's backing repo.
 func (a *App) installEngine() *install.Engine {
 	e := install.NewEngine(a.Config.CacheDir, a.Config.ManifestPath)
-	e.Fetcher.Token = a.Config.RegistryToken
+	e.Fetcher.Token = a.registryToken()
 	return e
 }
 

--- a/cli/internal/profile/profile.go
+++ b/cli/internal/profile/profile.go
@@ -38,10 +38,14 @@ const DefaultStatusAutoReturnSeconds = 5
 
 // Profile is the full on-disk document.
 type Profile struct {
-	SchemaVersion    int          `json:"schema_version"`
-	DefaultPlatforms []string     `json:"default_platforms,omitempty"`
-	DefaultScope     string       `json:"default_scope,omitempty"`
-	Eval             *EvalProfile `json:"eval,omitempty"`
+	SchemaVersion    int      `json:"schema_version"`
+	DefaultPlatforms []string `json:"default_platforms,omitempty"`
+	DefaultScope     string   `json:"default_scope,omitempty"`
+	// Registry, when set, is the default registry URL (or file:// path) used
+	// when neither --registry nor HUMBLSKILLS_REGISTRY is provided. Empty means
+	// the built-in hosted default.
+	Registry string       `json:"registry,omitempty"`
+	Eval     *EvalProfile `json:"eval,omitempty"`
 
 	// StatusAutoReturnSeconds controls how long a completed status screen
 	// (registry refresh, install, update) waits before automatically

--- a/cli/internal/secrets/registry_token_test.go
+++ b/cli/internal/secrets/registry_token_test.go
@@ -1,0 +1,61 @@
+package secrets
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// keyring is mocked in-process by init() in secrets_test.go, so Set/Get/Delete
+// operate on an in-memory store and never touch the real OS keychain.
+
+func TestRegistryToken_EnvWins(t *testing.T) {
+	t.Setenv(RegistryTokenEnvVar, "env-token")
+	// Even with a keyring value present, env takes precedence.
+	if _, err := setRegistryToken(filepath.Join(t.TempDir(), "secrets.json"), "keyring-token"); err != nil {
+		t.Fatal(err)
+	}
+	v, src := getRegistryToken("")
+	if v != "env-token" || src != SourceEnv {
+		t.Fatalf("got (%q,%s), want (env-token,env)", v, src)
+	}
+	_ = deleteRegistryToken(filepath.Join(t.TempDir(), "secrets.json"))
+}
+
+func TestRegistryToken_KeyringRoundTrip(t *testing.T) {
+	t.Setenv(RegistryTokenEnvVar, "") // ensure env doesn't shadow
+	path := filepath.Join(t.TempDir(), "secrets.json")
+
+	src, err := setRegistryToken(path, "  ghp_secret  ") // also checks trimming
+	if err != nil {
+		t.Fatal(err)
+	}
+	if src != SourceKeyring {
+		t.Fatalf("Set source = %s, want keyring (mock)", src)
+	}
+
+	v, gsrc := getRegistryToken(path)
+	if v != "ghp_secret" || gsrc != SourceKeyring {
+		t.Fatalf("Get = (%q,%s), want (ghp_secret,keyring)", v, gsrc)
+	}
+
+	if err := deleteRegistryToken(path); err != nil {
+		t.Fatal(err)
+	}
+	if v, src := getRegistryToken(path); v != "" || src != SourceAbsent {
+		t.Fatalf("after delete Get = (%q,%s), want (\"\",absent)", v, src)
+	}
+}
+
+func TestRegistryToken_RejectsEmpty(t *testing.T) {
+	if _, err := setRegistryToken(filepath.Join(t.TempDir(), "secrets.json"), "   "); err == nil {
+		t.Fatal("expected error storing empty token")
+	}
+}
+
+func TestRegistryToken_KeyringAccountIsolated(t *testing.T) {
+	// The registry token must not collide with an LLM provider's "-api-key"
+	// keyring account.
+	if got := registryTokenKey; got == keyringAccount("anthropic") || got == keyringAccount("openai") {
+		t.Fatalf("registry token key %q collides with a provider api-key account", got)
+	}
+}

--- a/cli/internal/secrets/secrets.go
+++ b/cli/internal/secrets/secrets.go
@@ -222,6 +222,84 @@ func writeFileSecret(path, provider, value string) error {
 
 func keyringAccount(provider string) string { return provider + "-api-key" }
 
+// --- registry auth token ----------------------------------------------------
+//
+// The registry token authenticates fetches from a private skill registry. It is
+// deliberately NOT an LLM Provider (so it stays out of Providers(), doctor's
+// provider list, and the eval key prompts) but reuses the same
+// env > keyring > file resolution and the same on-disk secrets file.
+
+// RegistryTokenEnvVar is the environment variable checked first when resolving
+// the registry auth token.
+const RegistryTokenEnvVar = "HUMBLSKILLS_TOKEN"
+
+// registryTokenKey is the keyring account and secrets-file key for the token.
+const registryTokenKey = "registry-token"
+
+// GetRegistryToken resolves the registry auth token, preferring the
+// environment, then the OS keyring, then the 0600 secrets file. Returns
+// ("", SourceAbsent) when unset.
+func GetRegistryToken() (string, Source) {
+	path, _ := defaultFilePath()
+	return getRegistryToken(path)
+}
+
+func getRegistryToken(filePath string) (string, Source) {
+	if v := strings.TrimSpace(os.Getenv(RegistryTokenEnvVar)); v != "" {
+		return v, SourceEnv
+	}
+	if v, err := keyring.Get(Service, registryTokenKey); err == nil && v != "" {
+		return v, SourceKeyring
+	}
+	if filePath != "" {
+		if v, ok := readFile(filePath, registryTokenKey); ok {
+			return v, SourceFile
+		}
+	}
+	return "", SourceAbsent
+}
+
+// SetRegistryToken stores the registry token, preferring the OS keyring and
+// falling back to the 0600 secrets file when the keyring is unavailable.
+func SetRegistryToken(value string) (Source, error) {
+	path, err := defaultFilePath()
+	if err != nil {
+		return SourceAbsent, err
+	}
+	return setRegistryToken(path, value)
+}
+
+func setRegistryToken(filePath, value string) (Source, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return SourceAbsent, errors.New("refusing to store empty token")
+	}
+	if err := keyring.Set(Service, registryTokenKey, value); err == nil {
+		// Drop any stale file copy so file/keyring precedence can't disagree.
+		_ = writeFileSecret(filePath, registryTokenKey, "")
+		return SourceKeyring, nil
+	}
+	if err := writeFileSecret(filePath, registryTokenKey, value); err != nil {
+		return SourceAbsent, fmt.Errorf("keyring unavailable and file fallback failed: %w", err)
+	}
+	return SourceFile, nil
+}
+
+// DeleteRegistryToken removes the stored registry token from both the keyring
+// and the secrets file.
+func DeleteRegistryToken() error {
+	path, err := defaultFilePath()
+	if err != nil {
+		return err
+	}
+	return deleteRegistryToken(path)
+}
+
+func deleteRegistryToken(filePath string) error {
+	_ = keyring.Delete(Service, registryTokenKey)
+	return writeFileSecret(filePath, registryTokenKey, "")
+}
+
 // KeyringAvailable reports whether the OS keyring appears reachable. Used by
 // doctor to surface a helpful hint when secrets will land in the file.
 func KeyringAvailable() bool {

--- a/registry.json
+++ b/registry.json
@@ -1,10 +1,10 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-07-21T19:30:19Z",
+  "generated_at": "2026-07-21T21:19:51Z",
   "source": {
     "repo": "github.com/jjfantini/humblSKILLS",
-    "ref": "main",
-    "sha": "2dc83638361800712411623efc9724af63208b9a"
+    "ref": "feat/registry-config-and-keychain-token",
+    "sha": "02e6b31a685956d81be867060708e2b5e6502992"
   },
   "skills": [
     {


### PR DESCRIPTION
## What

Removes the need for env vars to use a private registry — the two things asked for: set the registry **in the CLI** (persisted config) and keep the token in the **OS keychain**.

- **`humblskills profile set registry <url>`** — persists a default registry URL. Resolution: `--registry` → `HUMBLSKILLS_REGISTRY` → **profile** → hosted default. Shown in `profile show`.
- **`humblskills registry login` / `logout`** — stores/removes the auth token in the **OS keychain** (via the existing `secrets` store, under a dedicated `registry-token` account so it stays out of the LLM-provider list), falling back to a `0600` file. `login` takes the token from `--token`, piped stdin, or a masked prompt.
- Token resolution: `--token` → `HUMBLSKILLS_TOKEN` → **keychain** → file — resolved **lazily** (only when a fetcher/engine is built) so `list`/`profile`/`doctor` never touch the keychain.

## Testing

- Full `go test -race ./...` (38 pkgs) + `go vet` green.
- New unit tests: registry-token env precedence, keychain round-trip (mock), empty rejection, provider-account isolation.
- **End-to-end verified**: with `HUMBLSKILLS_REGISTRY` and `HUMBLSKILLS_TOKEN` unset, `search` + `install` from the private registry succeed using only the persisted profile URL + keychain token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)