### PR TITLE
feat(registry): multi-registry support with grouped-by-registry views

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,24 @@ export HUMBLSKILLS_TOKEN=<github token with read access>
 humblskills search
 ```
 
+### Multiple registries at once
+
+Register several registries and `search`/`browse` show them **together, grouped by
+registry** (each skill tagged with its source). Each registry keeps its own token.
+
+```sh
+humblskills registry add public https://raw.githubusercontent.com/jjfantini/humblSKILLS/main/registry.json
+humblskills registry add work   https://raw.githubusercontent.com/<org>/<private-repo>/main/registry.json
+humblskills registry login --name work    # token for the private one (keychain)
+humblskills registry list                  # show configured registries + token state
+humblskills search                         # grouped: "── public ──" then "── work ──"
+humblskills install <skill>                # resolves to whichever registry has it
+humblskills registry remove work           # drop it (and its stored token)
+```
+
+When no named registries are configured, everything falls back to the single registry
+above (`--registry`/`HUMBLSKILLS_REGISTRY`/`profile set registry`/hosted default).
+
 ### Sharing skill sets across a team
 
 `humblskills export` snapshots the skills you have installed into a

--- a/cli/cmd/humblskills/browse_skills.go
+++ b/cli/cmd/humblskills/browse_skills.go
@@ -101,6 +101,9 @@ func (s skillItem) Detail(th *ui.Theme, width int) string {
 		sb.WriteString(desc + "\n\n")
 	}
 
+	if s.s.Registry != "" {
+		sb.WriteString(kvRow(th, "registry", th.KVValue.Render(s.s.Registry)))
+	}
 	if s.s.Category != "" {
 		sb.WriteString(kvRow(th, "category", th.Category.Render(s.s.Category)))
 	}
@@ -201,9 +204,78 @@ func buildSkillItems(skills []registry.Skill, m *manifest.Manifest) []skillItem 
 		items = append(items, it)
 	}
 	sort.SliceStable(items, func(i, j int) bool {
+		// Group by source registry (empty registry — single-registry views —
+		// all collapse into one group), then by skill name within a group.
+		if items[i].s.Registry != items[j].s.Registry {
+			return items[i].s.Registry < items[j].s.Registry
+		}
 		return items[i].s.Name < items[j].s.Name
 	})
 	return items
+}
+
+// registryHeaderItem is a non-selectable section-header row rendered above each
+// registry's skills when more than one registry is shown.
+type registryHeaderItem struct{ name string }
+
+func (h registryHeaderItem) IsHeader() bool      { return true }
+func (h registryHeaderItem) Key() string         { return "__header__:" + h.name }
+func (h registryHeaderItem) FilterValue() string { return "" }
+func (h registryHeaderItem) NaturalWidth(th *ui.Theme) int {
+	return lipgloss.Width(h.render(th))
+}
+func (h registryHeaderItem) render(th *ui.Theme) string {
+	return th.SectionTitle.Render("── " + h.name + " ──")
+}
+func (h registryHeaderItem) Row(th *ui.Theme, width int, _ bool) string {
+	return h.render(th)
+}
+func (h registryHeaderItem) Detail(th *ui.Theme, width int) string { return "" }
+
+// interleaveRegistryHeaders turns a (registry, name)-sorted item list into a
+// tui.Item slice with a "── <registry> ──" header before each registry's
+// block. When only one registry is present, no headers are added.
+func interleaveRegistryHeaders(skills []skillItem, grouped bool) []tui.Item {
+	items := make([]tui.Item, 0, len(skills)+4)
+	last := ""
+	first := true
+	for _, s := range skills {
+		if grouped && (first || s.s.Registry != last) {
+			items = append(items, registryHeaderItem{name: registryDisplayName(s.s.Registry)})
+			last = s.s.Registry
+			first = false
+		}
+		items = append(items, s)
+	}
+	return items
+}
+
+func registryDisplayName(name string) string {
+	if name == "" {
+		return "default"
+	}
+	return name
+}
+
+// countSkills counts the non-header items (real skills) in a tui.Item list.
+func countSkills(items []tui.Item) int {
+	n := 0
+	for _, it := range items {
+		if h, ok := it.(tui.HeaderItem); ok && h.IsHeader() {
+			continue
+		}
+		n++
+	}
+	return n
+}
+
+// distinctRegistries counts the distinct source-registry names across skills.
+func distinctRegistries(skills []skillItem) int {
+	seen := map[string]struct{}{}
+	for _, s := range skills {
+		seen[s.s.Registry] = struct{}{}
+	}
+	return len(seen)
 }
 
 // runSkillBrowser opens the shared two-pane picker over skills and routes the
@@ -217,10 +289,7 @@ func runSkillBrowser(app *App, section string, skills []skillItem, mode skillsBr
 		app.UI.Info(emptyMsg)
 		return "", "", nil
 	}
-	items := make([]tui.Item, 0, len(skills))
-	for _, s := range skills {
-		items = append(items, s)
-	}
+	items := interleaveRegistryHeaders(skills, distinctRegistries(skills) > 1)
 
 	var actions []tui.ActionSpec
 	switch mode {
@@ -247,7 +316,8 @@ func runSkillBrowser(app *App, section string, skills []skillItem, mode skillsBr
 		}
 	}
 	localMeta := func(items []tui.Item, _ int) string {
-		parts := []string{fmt.Sprintf("%d skill%s", len(items), textutil.Plural(len(items)))}
+		n := countSkills(items)
+		parts := []string{fmt.Sprintf("%d skill%s", n, textutil.Plural(n))}
 		if installedCount > 0 {
 			parts = append(parts, fmt.Sprintf("%d installed", installedCount))
 		}

--- a/cli/cmd/humblskills/install.go
+++ b/cli/cmd/humblskills/install.go
@@ -54,23 +54,29 @@ func runInstall(app *App, skill string, f installFlags, fromDashboard bool) erro
 
 	type preload struct {
 		adapters []adapters.Adapter
-		reg      *registry.Registry
+		loaded   []registrySkills
+		merged   *registry.Registry
 	}
 	pre, err := tui.RunWithLoadingIf(useTUI, app.UI.Theme(), "loading adapters + registry…", func() (preload, error) {
 		adapterList, err := app.Adapters()
 		if err != nil {
 			return preload{}, fmt.Errorf("load adapters: %w", err)
 		}
-		reg, _, err := app.registryFetcher().Load()
-		if err != nil {
-			return preload{}, fmt.Errorf("load registry: %w", err)
+		loaded := app.loadRegistries()
+		merged := mergedRegistry(loaded)
+		if len(merged.Skills) == 0 {
+			for _, rs := range loaded {
+				if rs.Err != nil {
+					return preload{}, fmt.Errorf("load registry %q: %w", rs.Name, rs.Err)
+				}
+			}
 		}
-		return preload{adapters: adapterList, reg: reg}, nil
+		return preload{adapters: adapterList, loaded: loaded, merged: merged}, nil
 	})
 	if err != nil {
 		return err
 	}
-	adapterList, reg := pre.adapters, pre.reg
+	adapterList, loaded, reg := pre.adapters, pre.loaded, pre.merged
 
 	if skill == "" {
 		skill, err = pickSkill(app, reg, fromDashboard)
@@ -80,6 +86,13 @@ func runInstall(app *App, skill string, f installFlags, fromDashboard bool) erro
 			}
 			return err
 		}
+	}
+
+	// Resolve which registry actually holds the chosen skill so we plan and
+	// fetch against that registry's document (Source) and token.
+	target, ok := findRegistryForSkill(loaded, skill)
+	if !ok {
+		return fmt.Errorf("skill %q not found in any configured registry", skill)
 	}
 
 	p, err := profile.Load(app.Config.ProfilePath)
@@ -124,12 +137,12 @@ func runInstall(app *App, skill string, f installFlags, fromDashboard bool) erro
 		return fmt.Errorf("no platforms selected — run 'humblskills doctor' to see what's detected")
 	}
 
-	plan, err := install.Plan(reg, skill)
+	plan, err := install.Plan(target.Reg, skill)
 	if err != nil {
 		return err
 	}
 
-	engine := app.installEngine()
+	engine := app.installEngineForToken(target.Token)
 
 	if !useTUI {
 		app.UI.Detail("plan:")
@@ -144,7 +157,7 @@ func runInstall(app *App, skill string, f installFlags, fromDashboard bool) erro
 
 	var res install.Result
 	run := func(sink install.EventSink) error {
-		r, err := engine.Execute(reg, plan, install.ExecuteOpts{
+		r, err := engine.Execute(target.Reg, plan, install.ExecuteOpts{
 			Adapters:  adapterList,
 			Platforms: selected,
 			Scope:     scope,

--- a/cli/cmd/humblskills/registries.go
+++ b/cli/cmd/humblskills/registries.go
@@ -1,0 +1,160 @@
+package main
+
+import (
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/jjfantini/humblSKILLS/cli/internal/install"
+	"github.com/jjfantini/humblSKILLS/cli/internal/profile"
+	"github.com/jjfantini/humblSKILLS/cli/internal/registry"
+	"github.com/jjfantini/humblSKILLS/cli/internal/secrets"
+)
+
+// resolvedRegistry is one registry the CLI will read, with its auth token
+// already resolved.
+type resolvedRegistry struct {
+	Name  string
+	URL   string
+	Token string
+}
+
+// resolvedRegistries returns the registries to aggregate in multi-registry
+// views. When the profile lists named registries, those are used (each with its
+// own token); otherwise it falls back to the single resolved registry as one
+// entry named "default", preserving single-registry behaviour.
+func (a *App) resolvedRegistries() []resolvedRegistry {
+	if p, err := profile.Load(a.Config.ProfilePath); err == nil && p != nil && len(p.Registries) > 0 {
+		out := make([]resolvedRegistry, 0, len(p.Registries))
+		for _, r := range p.Registries {
+			tok, _ := secrets.GetRegistryTokenFor(r.Name)
+			out = append(out, resolvedRegistry{Name: r.Name, URL: r.URL, Token: tok})
+		}
+		return out
+	}
+	return []resolvedRegistry{{Name: "default", URL: a.Config.RegistryURL, Token: a.registryToken()}}
+}
+
+// multiRegistry reports whether more than one registry is configured, i.e.
+// whether grouped-by-registry rendering is meaningful.
+func (a *App) multiRegistry() bool {
+	return len(a.resolvedRegistries()) > 1
+}
+
+// fetcherForRegistry builds a Fetcher for one resolved registry, keyed to its
+// own on-disk cache slot so multiple registries can coexist.
+func (a *App) fetcherForRegistry(r resolvedRegistry) *registry.Fetcher {
+	f := registry.NewFetcher(r.URL, a.registryCacheDir(r.Name))
+	f.Token = r.Token
+	return f
+}
+
+// registryCacheDir returns the cache directory for a named registry. The
+// "default" fallback keeps using the base cache dir so existing caches and the
+// single-registry commands stay valid.
+func (a *App) registryCacheDir(name string) string {
+	if name == "" || name == "default" {
+		return a.Config.CacheDir
+	}
+	return filepath.Join(a.Config.CacheDir, "reg", sanitizeRegistryName(name))
+}
+
+func sanitizeRegistryName(name string) string {
+	var b strings.Builder
+	for _, r := range name {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '-', r == '_':
+			b.WriteRune(r)
+		default:
+			b.WriteRune('-')
+		}
+	}
+	if b.Len() == 0 {
+		return "registry"
+	}
+	return b.String()
+}
+
+// registrySkills is the outcome of loading one registry: its full document +
+// skills (tagged with the registry name) and resolved token, or the error that
+// prevented loading it.
+type registrySkills struct {
+	Name   string
+	URL    string
+	Token  string
+	Reg    *registry.Registry // full document, for Source (tarball fetch)
+	Skills []registry.Skill   // == Reg.Skills, tagged; convenience alias
+	Err    error
+}
+
+// loadRegistries loads every resolved registry, tagging each skill with its
+// source registry name. Load failures are captured per registry rather than
+// aborting the whole aggregation.
+func (a *App) loadRegistries() []registrySkills {
+	regs := a.resolvedRegistries()
+	out := make([]registrySkills, 0, len(regs))
+	for _, r := range regs {
+		reg, _, err := a.fetcherForRegistry(r).Load()
+		rs := registrySkills{Name: r.Name, URL: r.URL, Token: r.Token, Err: err}
+		if err == nil && reg != nil {
+			for i := range reg.Skills {
+				reg.Skills[i].Registry = r.Name
+			}
+			rs.Reg = reg
+			rs.Skills = reg.Skills
+		}
+		out = append(out, rs)
+	}
+	return out
+}
+
+// mergedRegistry flattens all successfully-loaded registries into one document
+// (Source left empty — it's for listing/picking only, not fetching), sorted by
+// (registry, name) so a picker renders grouped.
+func mergedRegistry(loaded []registrySkills) *registry.Registry {
+	skills, _ := aggregateSkills(loaded)
+	return &registry.Registry{SchemaVersion: registry.SchemaVersion, Skills: skills}
+}
+
+// findRegistryForSkill returns the loaded registry that contains skillName.
+func findRegistryForSkill(loaded []registrySkills, skillName string) (registrySkills, bool) {
+	for _, rs := range loaded {
+		for _, s := range rs.Skills {
+			if s.Name == skillName {
+				return rs, true
+			}
+		}
+	}
+	return registrySkills{}, false
+}
+
+// installEngineForToken builds an install Engine whose tarball fetcher carries
+// the given registry's token (tarballs are SHA-keyed so the shared cache dir is
+// safe across registries).
+func (a *App) installEngineForToken(token string) *install.Engine {
+	e := install.NewEngine(a.Config.CacheDir, a.Config.ManifestPath)
+	e.Fetcher.Token = token
+	return e
+}
+
+// aggregateSkills flattens loaded registries into a single slice sorted by
+// (registry name, skill name), so a stable grouped order can be rendered. It
+// also returns the per-registry load errors (name -> err) for reporting.
+func aggregateSkills(loaded []registrySkills) ([]registry.Skill, map[string]error) {
+	var all []registry.Skill
+	errs := map[string]error{}
+	for _, rs := range loaded {
+		if rs.Err != nil {
+			errs[rs.Name] = rs.Err
+			continue
+		}
+		all = append(all, rs.Skills...)
+	}
+	sort.SliceStable(all, func(i, j int) bool {
+		if all[i].Registry != all[j].Registry {
+			return all[i].Registry < all[j].Registry
+		}
+		return all[i].Name < all[j].Name
+	})
+	return all, errs
+}

--- a/cli/cmd/humblskills/registry.go
+++ b/cli/cmd/humblskills/registry.go
@@ -27,48 +27,161 @@ type refreshResult struct {
 func newRegistryCmd(app *App) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "registry",
-		Short: "Inspect and refresh the skill registry cache",
+		Short: "Manage skill registries (add/list/remove), refresh the cache, and auth",
 	}
 	cmd.AddCommand(
 		newRegistryRefreshCmd(app),
 		newRegistryLoginCmd(app),
 		newRegistryLogoutCmd(app),
+		newRegistryAddCmd(app),
+		newRegistryListCmd(app),
+		newRegistryRemoveCmd(app),
 	)
 	return cmd
 }
 
-func newRegistryLoginCmd(app *App) *cobra.Command {
+func newRegistryAddCmd(app *App) *cobra.Command {
 	return &cobra.Command{
+		Use:   "add <name> <url>",
+		Short: "Add (or update) a named registry shown in aggregated views",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runRegistryAdd(app, args[0], args[1])
+		},
+	}
+}
+
+func newRegistryListCmd(app *App) *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List configured registries",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runRegistryList(app)
+		},
+	}
+}
+
+func newRegistryRemoveCmd(app *App) *cobra.Command {
+	return &cobra.Command{
+		Use:     "remove <name>",
+		Aliases: []string{"rm"},
+		Short:   "Remove a named registry (and its stored token)",
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runRegistryRemove(app, args[0])
+		},
+	}
+}
+
+func runRegistryAdd(app *App, name, url string) error {
+	name = strings.TrimSpace(name)
+	url = strings.TrimSpace(url)
+	if name == "" {
+		return fmt.Errorf("registry name must not be empty")
+	}
+	if !isPlausibleRegistry(url) {
+		return fmt.Errorf("invalid registry URL %q — expected an http(s):// URL, a file:// URL, or a filesystem path", url)
+	}
+	p, err := profile.Load(app.Config.ProfilePath)
+	if err != nil {
+		return err
+	}
+	p.SetRegistry(name, url)
+	if err := profile.Save(app.Config.ProfilePath, p); err != nil {
+		return err
+	}
+	if app.Config.JSON {
+		return app.UI.JSON(map[string]string{"name": name, "url": url})
+	}
+	app.UI.Success("added registry %q → %s", name, url)
+	app.UI.Detail("store its token (if private) with: humblskills registry login --name %s", name)
+	return nil
+}
+
+func runRegistryList(app *App) error {
+	regs := app.resolvedRegistries()
+	if app.Config.JSON {
+		return app.UI.JSON(regs)
+	}
+	app.UI.Header("registries")
+	p, _ := profile.Load(app.Config.ProfilePath)
+	if p == nil || len(p.Registries) == 0 {
+		app.UI.Info("no named registries configured — using the single default:")
+	}
+	th := app.UI.Theme()
+	for _, r := range regs {
+		_, src := secrets.GetRegistryTokenFor(r.Name)
+		tok := "no token"
+		if src != secrets.SourceAbsent {
+			tok = "token: " + string(src)
+		}
+		fmt.Fprintln(app.UI.Out(), "  "+th.KVKey.Render(r.Name)+"  "+th.KVValue.Render(r.URL)+"  ("+tok+")")
+	}
+	return nil
+}
+
+func runRegistryRemove(app *App, name string) error {
+	p, err := profile.Load(app.Config.ProfilePath)
+	if err != nil {
+		return err
+	}
+	if !p.RemoveRegistry(name) {
+		return fmt.Errorf("no registry named %q", name)
+	}
+	if err := profile.Save(app.Config.ProfilePath, p); err != nil {
+		return err
+	}
+	_ = secrets.DeleteRegistryTokenFor(name) // best-effort token cleanup
+	if app.Config.JSON {
+		return app.UI.JSON(map[string]string{"removed": name})
+	}
+	app.UI.Success("removed registry %q", name)
+	return nil
+}
+
+func newRegistryLoginCmd(app *App) *cobra.Command {
+	var name string
+	cmd := &cobra.Command{
 		Use:   "login",
 		Short: "Store a registry auth token (for a private registry) in the OS keychain",
 		Long: "login saves the GitHub token used to read a private registry and download its skills. " +
 			"The token is stored in the OS keychain (falling back to a 0600 file if the keychain is " +
 			"unavailable) and used automatically on registry + skill fetches — no env var needed. " +
-			"Provide it with the global --token flag, by piping it on stdin, or via the masked prompt.",
+			"Provide it with the global --token flag, by piping it on stdin, or via the masked prompt. " +
+			"Use --name to attach the token to a specific named registry (see `registry add`).",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return runRegistryLogin(app)
+			return runRegistryLogin(app, name)
 		},
 	}
+	cmd.Flags().StringVar(&name, "name", "", "named registry to attach the token to (default: the single/default token)")
+	return cmd
 }
 
 func newRegistryLogoutCmd(app *App) *cobra.Command {
-	return &cobra.Command{
+	var name string
+	cmd := &cobra.Command{
 		Use:   "logout",
 		Short: "Remove the stored registry auth token from the keychain / secrets file",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			if err := secrets.DeleteRegistryToken(); err != nil {
+			if err := secrets.DeleteRegistryTokenFor(name); err != nil {
 				return err
 			}
 			if app.Config.JSON {
-				return app.UI.JSON(map[string]string{"status": "removed"})
+				return app.UI.JSON(map[string]string{"status": "removed", "name": name})
 			}
-			app.UI.Success("removed stored registry token")
+			if name != "" {
+				app.UI.Success("removed stored token for registry %q", name)
+			} else {
+				app.UI.Success("removed stored registry token")
+			}
 			return nil
 		},
 	}
+	cmd.Flags().StringVar(&name, "name", "", "named registry whose token to remove (default: the single/default token)")
+	return cmd
 }
 
-func runRegistryLogin(app *App) error {
+func runRegistryLogin(app *App, name string) error {
 	// Priority: global --token flag > piped stdin > interactive masked prompt.
 	token := strings.TrimSpace(app.Config.RegistryToken)
 	if token == "" {
@@ -90,14 +203,18 @@ func runRegistryLogin(app *App) error {
 		return fmt.Errorf("no token provided (use --token, pipe it on stdin, or enter it at the prompt)")
 	}
 
-	src, err := secrets.SetRegistryToken(token)
+	src, err := secrets.SetRegistryTokenFor(name, token)
 	if err != nil {
 		return err
 	}
 	if app.Config.JSON {
-		return app.UI.JSON(map[string]string{"stored": string(src)})
+		return app.UI.JSON(map[string]string{"stored": string(src), "name": name})
 	}
-	app.UI.Success("stored registry token in %s", src)
+	if name != "" {
+		app.UI.Success("stored token for registry %q in %s", name, src)
+	} else {
+		app.UI.Success("stored registry token in %s", src)
+	}
 	if src == secrets.SourceFile {
 		app.UI.Detail("OS keychain unavailable — stored in a 0600 secrets file instead")
 	}

--- a/cli/cmd/humblskills/search.go
+++ b/cli/cmd/humblskills/search.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"os"
-	"sort"
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
@@ -32,17 +31,33 @@ func newSearchCmd(app *App) *cobra.Command {
 				return fmt.Errorf("unknown --category %q (must be one of %s)", category, strings.Join(frontmatter.Categories, ", "))
 			}
 
-			reg, _, err := app.registryFetcher().Load()
-			if err != nil {
-				return err
+			loaded := app.loadRegistries()
+			all, loadErrs := aggregateSkills(loaded)
+			// A failed registry is reported but doesn't abort the others; only
+			// error out if every registry failed and nothing loaded.
+			if len(all) == 0 && len(loadErrs) > 0 {
+				for _, rs := range loaded {
+					if rs.Err != nil {
+						return fmt.Errorf("registry %q: %w", rs.Name, rs.Err)
+					}
+				}
+			}
+			if !app.Config.JSON {
+				for _, rs := range loaded {
+					if rs.Err != nil {
+						app.UI.Warn("registry %q unavailable: %v", rs.Name, rs.Err)
+					}
+				}
 			}
 			query := ""
 			if len(args) == 1 {
 				query = strings.ToLower(args[0])
 			}
 
+			// all is already sorted by (registry, name); filtering preserves
+			// that grouped order.
 			var hits []registry.Skill
-			for _, s := range reg.Skills {
+			for _, s := range all {
 				if category != "" && s.Category != category {
 					continue
 				}
@@ -50,7 +65,6 @@ func newSearchCmd(app *App) *cobra.Command {
 					hits = append(hits, s)
 				}
 			}
-			sort.Slice(hits, func(i, j int) bool { return hits[i].Name < hits[j].Name })
 
 			if app.Config.JSON {
 				return app.UI.JSON(struct {
@@ -150,7 +164,28 @@ func renderSearchResults(theme *ui.Theme, hits []registry.Skill, query string) s
 	sb.WriteString(theme.Count.Render(summary))
 	sb.WriteString("\n\n")
 
+	// Group hits under a "── <registry> ──" header when they span more than
+	// one registry (hits are already sorted by registry then name).
+	grouped := false
+	{
+		seen := map[string]struct{}{}
+		for _, s := range hits {
+			seen[s.Registry] = struct{}{}
+		}
+		grouped = len(seen) > 1
+	}
+	lastReg := ""
+	headerShown := false
+
 	for i, s := range hits {
+		if grouped && (!headerShown || s.Registry != lastReg) {
+			if headerShown {
+				sb.WriteString("\n")
+			}
+			sb.WriteString("  " + theme.SectionTitle.Render("── "+registryDisplayName(s.Registry)+" ──") + "\n\n")
+			lastReg = s.Registry
+			headerShown = true
+		}
 		left := theme.Bullet.Render("▌ ") + highlightName(s.Name, query, theme.Name, theme.Hit)
 		right := theme.Version.Render("v" + s.Version)
 		pad := inner - lipgloss.Width(left) - lipgloss.Width(right)

--- a/cli/internal/profile/profile.go
+++ b/cli/internal/profile/profile.go
@@ -44,8 +44,12 @@ type Profile struct {
 	// Registry, when set, is the default registry URL (or file:// path) used
 	// when neither --registry nor HUMBLSKILLS_REGISTRY is provided. Empty means
 	// the built-in hosted default.
-	Registry string       `json:"registry,omitempty"`
-	Eval     *EvalProfile `json:"eval,omitempty"`
+	Registry string `json:"registry,omitempty"`
+	// Registries is the set of named registries shown together in aggregated
+	// views (search, list, browse, doctor). When empty, those views fall back
+	// to the single resolved registry (flag/env/Registry/hosted default).
+	Registries []NamedRegistry `json:"registries,omitempty"`
+	Eval       *EvalProfile    `json:"eval,omitempty"`
 
 	// StatusAutoReturnSeconds controls how long a completed status screen
 	// (registry refresh, install, update) waits before automatically
@@ -55,6 +59,44 @@ type Profile struct {
 	// positive value is the number of seconds to wait. Only success
 	// screens auto-return - a failed run always waits for the user.
 	StatusAutoReturnSeconds *int `json:"status_auto_return_seconds,omitempty"`
+}
+
+// NamedRegistry is one entry in the multi-registry set (Profile.Registries).
+type NamedRegistry struct {
+	Name string `json:"name"`
+	URL  string `json:"url"`
+}
+
+// FindRegistry returns the named registry and true if present.
+func (p *Profile) FindRegistry(name string) (NamedRegistry, bool) {
+	for _, r := range p.Registries {
+		if r.Name == name {
+			return r, true
+		}
+	}
+	return NamedRegistry{}, false
+}
+
+// SetRegistry adds a named registry, or updates its URL if the name exists.
+func (p *Profile) SetRegistry(name, url string) {
+	for i := range p.Registries {
+		if p.Registries[i].Name == name {
+			p.Registries[i].URL = url
+			return
+		}
+	}
+	p.Registries = append(p.Registries, NamedRegistry{Name: name, URL: url})
+}
+
+// RemoveRegistry drops a named registry by name; reports whether it existed.
+func (p *Profile) RemoveRegistry(name string) bool {
+	for i := range p.Registries {
+		if p.Registries[i].Name == name {
+			p.Registries = append(p.Registries[:i], p.Registries[i+1:]...)
+			return true
+		}
+	}
+	return false
 }
 
 // EvalProfile captures eval-specific defaults. Secrets (API keys) do NOT

--- a/cli/internal/profile/registries_test.go
+++ b/cli/internal/profile/registries_test.go
@@ -1,0 +1,57 @@
+package profile
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestNamedRegistries_SetFindRemove(t *testing.T) {
+	p := &Profile{}
+	p.SetRegistry("public", "https://a")
+	p.SetRegistry("work", "https://b")
+	if len(p.Registries) != 2 {
+		t.Fatalf("want 2 registries, got %d", len(p.Registries))
+	}
+
+	// SetRegistry with an existing name updates in place (no duplicate).
+	p.SetRegistry("public", "https://a2")
+	if r, ok := p.FindRegistry("public"); !ok || r.URL != "https://a2" {
+		t.Fatalf("update failed: %+v (ok=%v)", r, ok)
+	}
+	if len(p.Registries) != 2 {
+		t.Fatalf("update must not add; got %d", len(p.Registries))
+	}
+
+	if _, ok := p.FindRegistry("missing"); ok {
+		t.Fatal("FindRegistry found a nonexistent name")
+	}
+
+	if !p.RemoveRegistry("public") {
+		t.Fatal("RemoveRegistry should report true for an existing name")
+	}
+	if _, ok := p.FindRegistry("public"); ok {
+		t.Fatal("registry still present after remove")
+	}
+	if p.RemoveRegistry("public") {
+		t.Fatal("second remove should report false")
+	}
+	if len(p.Registries) != 1 {
+		t.Fatalf("want 1 registry after remove, got %d", len(p.Registries))
+	}
+}
+
+func TestNamedRegistries_RoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "profile.json")
+	p := &Profile{SchemaVersion: SchemaVersion}
+	p.SetRegistry("work", "https://x")
+	if err := Save(path, p); err != nil {
+		t.Fatal(err)
+	}
+	got, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r, ok := got.FindRegistry("work"); !ok || r.URL != "https://x" {
+		t.Fatalf("round-trip failed: %+v", got.Registries)
+	}
+}

--- a/cli/internal/registry/types.go
+++ b/cli/internal/registry/types.go
@@ -32,4 +32,9 @@ type Skill struct {
 	Preserve    []string `json:"preserve,omitempty"`
 	Path        string   `json:"path"`
 	DirSHA      string   `json:"dir_sha"`
+	// Registry is the source-registry name, stamped at load time when skills
+	// from multiple registries are aggregated. It is never written to a
+	// registry.json on disk (build-registry leaves it empty), so it does not
+	// affect generation or the --check semantic diff.
+	Registry string `json:"registry,omitempty"`
 }

--- a/cli/internal/secrets/registry_token_test.go
+++ b/cli/internal/secrets/registry_token_test.go
@@ -52,6 +52,43 @@ func TestRegistryToken_RejectsEmpty(t *testing.T) {
 	}
 }
 
+func TestRegistryToken_NamedAccounts(t *testing.T) {
+	t.Setenv(RegistryTokenEnvVar, "")
+	path := filepath.Join(t.TempDir(), "secrets.json")
+
+	// Store a token for the "work" registry.
+	if _, err := setKeyedToken(path, registryAccount("work"), "work-tok"); err != nil {
+		t.Fatal(err)
+	}
+	if v, src := getKeyedToken(path, registryAccount("work")); v != "work-tok" || src == SourceAbsent {
+		t.Fatalf("work token = (%q,%s), want (work-tok, present)", v, src)
+	}
+	// A different name's account is isolated (absent).
+	if v, src := getKeyedToken(path, registryAccount("public")); v != "" || src != SourceAbsent {
+		t.Fatalf("public token = (%q,%s), want (\"\", absent)", v, src)
+	}
+	// The default account is also isolated from named ones.
+	if v, src := getKeyedToken(path, registryAccount("")); v != "" || src != SourceAbsent {
+		t.Fatalf("default token = (%q,%s), want (\"\", absent)", v, src)
+	}
+
+	if err := deleteKeyedToken(path, registryAccount("work")); err != nil {
+		t.Fatal(err)
+	}
+	if _, src := getKeyedToken(path, registryAccount("work")); src != SourceAbsent {
+		t.Fatal("work token should be absent after delete")
+	}
+}
+
+func TestRegistryToken_AccountNaming(t *testing.T) {
+	if got := registryAccount(""); got != "registry-token" {
+		t.Errorf("default account = %q, want registry-token", got)
+	}
+	if got := registryAccount("work"); got != "registry-token-work" {
+		t.Errorf("named account = %q, want registry-token-work", got)
+	}
+}
+
 func TestRegistryToken_KeyringAccountIsolated(t *testing.T) {
 	// The registry token must not collide with an LLM provider's "-api-key"
 	// keyring account.

--- a/cli/internal/secrets/secrets.go
+++ b/cli/internal/secrets/secrets.go
@@ -236,7 +236,17 @@ const RegistryTokenEnvVar = "HUMBLSKILLS_TOKEN"
 // registryTokenKey is the keyring account and secrets-file key for the token.
 const registryTokenKey = "registry-token"
 
-// GetRegistryToken resolves the registry auth token, preferring the
+// registryAccount is the keyring account / secrets-file key for a registry
+// token. The empty name is the default (single-registry) token; a named
+// registry gets "registry-token-<name>".
+func registryAccount(name string) string {
+	if name == "" {
+		return registryTokenKey
+	}
+	return registryTokenKey + "-" + name
+}
+
+// GetRegistryToken resolves the default registry token, preferring the
 // environment, then the OS keyring, then the 0600 secrets file. Returns
 // ("", SourceAbsent) when unset.
 func GetRegistryToken() (string, Source) {
@@ -248,19 +258,37 @@ func getRegistryToken(filePath string) (string, Source) {
 	if v := strings.TrimSpace(os.Getenv(RegistryTokenEnvVar)); v != "" {
 		return v, SourceEnv
 	}
-	if v, err := keyring.Get(Service, registryTokenKey); err == nil && v != "" {
+	return getKeyedToken(filePath, registryAccount(""))
+}
+
+// GetRegistryTokenFor resolves a named registry's token: its own keyring/file
+// entry first, then the default token (env > keyring > file) as a fallback, so a
+// single stored token can cover registries without a dedicated one.
+func GetRegistryTokenFor(name string) (string, Source) {
+	if name == "" {
+		return GetRegistryToken()
+	}
+	path, _ := defaultFilePath()
+	if v, src := getKeyedToken(path, registryAccount(name)); src != SourceAbsent {
+		return v, src
+	}
+	return GetRegistryToken()
+}
+
+func getKeyedToken(filePath, account string) (string, Source) {
+	if v, err := keyring.Get(Service, account); err == nil && v != "" {
 		return v, SourceKeyring
 	}
 	if filePath != "" {
-		if v, ok := readFile(filePath, registryTokenKey); ok {
+		if v, ok := readFile(filePath, account); ok {
 			return v, SourceFile
 		}
 	}
 	return "", SourceAbsent
 }
 
-// SetRegistryToken stores the registry token, preferring the OS keyring and
-// falling back to the 0600 secrets file when the keyring is unavailable.
+// SetRegistryToken stores the default registry token, preferring the OS keyring
+// and falling back to the 0600 secrets file when the keyring is unavailable.
 func SetRegistryToken(value string) (Source, error) {
 	path, err := defaultFilePath()
 	if err != nil {
@@ -270,23 +298,35 @@ func SetRegistryToken(value string) (Source, error) {
 }
 
 func setRegistryToken(filePath, value string) (Source, error) {
+	return setKeyedToken(filePath, registryAccount(""), value)
+}
+
+// SetRegistryTokenFor stores a named registry's token.
+func SetRegistryTokenFor(name, value string) (Source, error) {
+	path, err := defaultFilePath()
+	if err != nil {
+		return SourceAbsent, err
+	}
+	return setKeyedToken(path, registryAccount(name), value)
+}
+
+func setKeyedToken(filePath, account, value string) (Source, error) {
 	value = strings.TrimSpace(value)
 	if value == "" {
 		return SourceAbsent, errors.New("refusing to store empty token")
 	}
-	if err := keyring.Set(Service, registryTokenKey, value); err == nil {
+	if err := keyring.Set(Service, account, value); err == nil {
 		// Drop any stale file copy so file/keyring precedence can't disagree.
-		_ = writeFileSecret(filePath, registryTokenKey, "")
+		_ = writeFileSecret(filePath, account, "")
 		return SourceKeyring, nil
 	}
-	if err := writeFileSecret(filePath, registryTokenKey, value); err != nil {
+	if err := writeFileSecret(filePath, account, value); err != nil {
 		return SourceAbsent, fmt.Errorf("keyring unavailable and file fallback failed: %w", err)
 	}
 	return SourceFile, nil
 }
 
-// DeleteRegistryToken removes the stored registry token from both the keyring
-// and the secrets file.
+// DeleteRegistryToken removes the default registry token from keyring + file.
 func DeleteRegistryToken() error {
 	path, err := defaultFilePath()
 	if err != nil {
@@ -296,8 +336,21 @@ func DeleteRegistryToken() error {
 }
 
 func deleteRegistryToken(filePath string) error {
-	_ = keyring.Delete(Service, registryTokenKey)
-	return writeFileSecret(filePath, registryTokenKey, "")
+	return deleteKeyedToken(filePath, registryAccount(""))
+}
+
+// DeleteRegistryTokenFor removes a named registry's token.
+func DeleteRegistryTokenFor(name string) error {
+	path, err := defaultFilePath()
+	if err != nil {
+		return err
+	}
+	return deleteKeyedToken(path, registryAccount(name))
+}
+
+func deleteKeyedToken(filePath, account string) error {
+	_ = keyring.Delete(Service, account)
+	return writeFileSecret(filePath, account, "")
 }
 
 // KeyringAvailable reports whether the OS keyring appears reachable. Used by

--- a/cli/internal/tui/listdetail.go
+++ b/cli/internal/tui/listdetail.go
@@ -47,6 +47,20 @@ type SizedItem interface {
 	NaturalWidth(theme *ui.Theme) int
 }
 
+// HeaderItem marks a non-selectable section-header row (e.g. a "── group ──"
+// divider). Header rows are rendered in place but skipped during navigation and
+// never returned as a Result. While a filter is active, headers are hidden and
+// the list collapses to a flat matched view.
+type HeaderItem interface {
+	Item
+	IsHeader() bool
+}
+
+func isHeader(it Item) bool {
+	h, ok := it.(HeaderItem)
+	return ok && h.IsHeader()
+}
+
 // ActionSpec binds a key to a caller-named action. Pressing Key while an item
 // is highlighted exits the model with Result{Action, Item}.
 type ActionSpec struct {
@@ -138,7 +152,38 @@ func NewListDetail(cfg Config) Model {
 		keys:    DefaultKeys(),
 		actions: acts,
 	}
+	m.cursor = m.firstSelectable()
 	return m
+}
+
+// firstSelectable returns the index of the first non-header item, or 0.
+func (m Model) firstSelectable() int {
+	for i := range m.items {
+		if !isHeader(m.items[i]) {
+			return i
+		}
+	}
+	return 0
+}
+
+// nextSelectable / prevSelectable return the next non-header index in the given
+// direction, or -1 if there is none.
+func (m Model) nextSelectable(from int) int {
+	for i := from + 1; i < len(m.items); i++ {
+		if !isHeader(m.items[i]) {
+			return i
+		}
+	}
+	return -1
+}
+
+func (m Model) prevSelectable(from int) int {
+	for i := from - 1; i >= 0; i-- {
+		if !isHeader(m.items[i]) {
+			return i
+		}
+	}
+	return -1
 }
 
 // Selected returns the terminal state after the model exits.
@@ -220,14 +265,14 @@ func (m Model) updateNav(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.done = true
 		return m, tea.Quit
 	case key.Matches(msg, m.keys.Up):
-		if m.cursor > 0 {
-			m.cursor--
+		if n := m.prevSelectable(m.cursor); n >= 0 {
+			m.cursor = n
 			m.refreshPreview()
 		}
 		return m, nil
 	case key.Matches(msg, m.keys.Down):
-		if m.cursor < len(m.items)-1 {
-			m.cursor++
+		if n := m.nextSelectable(m.cursor); n >= 0 {
+			m.cursor = n
 			m.refreshPreview()
 		}
 		return m, nil
@@ -296,6 +341,9 @@ func (m Model) exitWith(action string) (tea.Model, tea.Cmd) {
 	var it Item
 	if len(m.items) > 0 && m.cursor < len(m.items) {
 		it = m.items[m.cursor]
+	}
+	if isHeader(it) { // never surface a header row as a selection
+		it = nil
 	}
 	m.result = Result{Action: action, Item: it}
 	m.done = true
@@ -389,20 +437,22 @@ func (m *Model) applyFilter() {
 	} else {
 		out := make([]Item, 0, len(m.cfg.Items))
 		for _, it := range m.cfg.Items {
+			// Headers are group dividers, not matches — hide them while
+			// filtering so the list collapses to a flat matched view.
+			if isHeader(it) {
+				continue
+			}
 			if strings.Contains(strings.ToLower(it.FilterValue()), q) {
 				out = append(out, it)
 			}
 		}
 		m.items = out
 	}
-	if m.cursor >= len(m.items) {
+	// Keep the cursor in range and off any header row.
+	if len(m.items) == 0 {
 		m.cursor = 0
-		if len(m.items) > 0 {
-			m.cursor = len(m.items) - 1
-			if m.cursor < 0 {
-				m.cursor = 0
-			}
-		}
+	} else if m.cursor >= len(m.items) || isHeader(m.items[m.cursor]) {
+		m.cursor = m.firstSelectable()
 	}
 }
 

--- a/cli/internal/tui/listdetail_header_test.go
+++ b/cli/internal/tui/listdetail_header_test.go
@@ -1,0 +1,49 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/jjfantini/humblSKILLS/cli/internal/ui"
+)
+
+type testRow struct{ k string }
+
+func (r testRow) Key() string                     { return r.k }
+func (r testRow) Row(*ui.Theme, int, bool) string { return r.k }
+func (r testRow) Detail(*ui.Theme, int) string    { return "" }
+func (r testRow) FilterValue() string             { return r.k }
+
+type testHeader struct{ k string }
+
+func (h testHeader) Key() string                     { return h.k }
+func (h testHeader) Row(*ui.Theme, int, bool) string { return h.k }
+func (h testHeader) Detail(*ui.Theme, int) string    { return "" }
+func (h testHeader) FilterValue() string             { return "" }
+func (h testHeader) IsHeader() bool                  { return true }
+
+// TestListDetail_HeaderSkip verifies non-selectable header rows are skipped by
+// cursor seeding and navigation.
+func TestListDetail_HeaderSkip(t *testing.T) {
+	m := NewListDetail(Config{Items: []Item{
+		testHeader{"h1"}, testRow{"a"}, testRow{"b"}, testHeader{"h2"}, testRow{"c"},
+	}})
+
+	if m.cursor != 1 {
+		t.Fatalf("firstSelectable should skip leading header: cursor=%d want 1", m.cursor)
+	}
+	if got := m.nextSelectable(1); got != 2 {
+		t.Fatalf("next from 1 = %d, want 2", got)
+	}
+	if got := m.nextSelectable(2); got != 4 {
+		t.Fatalf("next from 2 = %d, want 4 (skip h2)", got)
+	}
+	if got := m.nextSelectable(4); got != -1 {
+		t.Fatalf("next from 4 = %d, want -1", got)
+	}
+	if got := m.prevSelectable(4); got != 2 {
+		t.Fatalf("prev from 4 = %d, want 2 (skip h2)", got)
+	}
+	if got := m.prevSelectable(1); got != -1 {
+		t.Fatalf("prev from 1 = %d, want -1 (skip h1)", got)
+	}
+}

--- a/registry.json
+++ b/registry.json
@@ -1,10 +1,10 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-07-21T21:34:10Z",
+  "generated_at": "2026-07-21T22:15:26Z",
   "source": {
     "repo": "github.com/jjfantini/humblSKILLS",
-    "ref": "main",
-    "sha": "7610936cdb5ee7a28d1ec57c5cd2d810075de7a8"
+    "ref": "feat/multi-registry",
+    "sha": "b107028e88eeab05dce93882c0f192c70cc8eef2"
   },
   "skills": [
     {


### PR DESCRIPTION
## What

See multiple registries **at once**, grouped by registry.

- **Named registries** in the profile: `registry add <name> <url>`, `registry list`, `registry remove <name>`. Falls back to the single resolved registry when none are configured (backward compatible).
- **Per-registry auth + cache:** `registry login/logout --name <name>` stores a token under a dedicated keychain account (`registry-token-<name>`), falling back to the default token; each registry gets its own cache slot.
- **Grouped rendering:** skills are tagged with their source registry; `search` (static + TUI) and the shared browser render `── <registry> ──` section headers. Adds a non-selectable `HeaderItem` to the list widget (nav/cursor/filter skip headers).
- **Cross-registry install:** `install <skill>` resolves which registry holds the skill and fetches from that registry's Source with its token.

## Testing

- Full `go test -race ./...` (38 pkgs) + `vet` green.
- New tests: profile Registries set/find/remove + round-trip; secrets named-token accounts + isolation; listdetail header-skip navigation.
- **End-to-end verified** with two registries (public + a private one): `registry list`, grouped `search` (── public ── / ── work ──), and cross-registry `install` of both a private and a public skill.

## Not included (follow-ups)

`doctor` and `list` (installed) still show the single/default registry; grouping those is deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)