### PR TITLE
feat(registry): show registries in profile, rename command, interactive add

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,15 +131,19 @@ registry** (each skill tagged with its source). Each registry keeps its own toke
 ```sh
 humblskills registry add public https://raw.githubusercontent.com/jjfantini/humblSKILLS/main/registry.json
 humblskills registry add work   https://raw.githubusercontent.com/<org>/<private-repo>/main/registry.json
-humblskills registry login --name work    # token for the private one (keychain)
+humblskills registry add                   # no args → prompts for name, URL, and (optional) token
+humblskills registry login --name work     # token for the private one (keychain)
 humblskills registry list                  # show configured registries + token state
+humblskills registry rename work internal  # rename (moves its stored token too)
+humblskills registry add work <new-url>    # re-add with an existing name to change its URL
 humblskills search                         # grouped: "── public ──" then "── work ──"
 humblskills install <skill>                # resolves to whichever registry has it
 humblskills registry remove work           # drop it (and its stored token)
 ```
 
-When no named registries are configured, everything falls back to the single registry
-above (`--registry`/`HUMBLSKILLS_REGISTRY`/`profile set registry`/hosted default).
+Configured registries also show up in `humblskills profile show` (under **Registries**).
+When none are configured, everything falls back to the single registry above
+(`--registry`/`HUMBLSKILLS_REGISTRY`/`profile set registry`/hosted default).
 
 ### Sharing skill sets across a team
 

--- a/cli/cmd/humblskills/profile.go
+++ b/cli/cmd/humblskills/profile.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/jjfantini/humblSKILLS/cli/internal/adapters"
 	"github.com/jjfantini/humblSKILLS/cli/internal/profile"
+	"github.com/jjfantini/humblSKILLS/cli/internal/secrets"
 	"github.com/jjfantini/humblSKILLS/cli/internal/tui"
 )
 
@@ -148,6 +149,19 @@ func runProfileShow(app *App) error {
 		th.KVValue.Render(formatAutoReturn(p.StatusAutoReturnSeconds)))
 	fmt.Fprintln(app.UI.Out(), "  "+th.KVKey.Render("path")+"         "+
 		th.KVValue.Render(app.Config.ProfilePath))
+
+	if len(p.Registries) > 0 {
+		app.UI.Section("Registries")
+		for _, r := range p.Registries {
+			_, src := secrets.GetRegistryTokenFor(r.Name)
+			tok := "no token"
+			if src != secrets.SourceAbsent {
+				tok = "token: " + string(src)
+			}
+			fmt.Fprintln(app.UI.Out(), "  "+th.KVKey.Render(r.Name)+"  "+
+				th.KVValue.Render(r.URL)+"  "+th.Detail.Render("("+tok+")"))
+		}
+	}
 	return nil
 }
 

--- a/cli/cmd/humblskills/registry.go
+++ b/cli/cmd/humblskills/registry.go
@@ -36,17 +36,38 @@ func newRegistryCmd(app *App) *cobra.Command {
 		newRegistryAddCmd(app),
 		newRegistryListCmd(app),
 		newRegistryRemoveCmd(app),
+		newRegistryRenameCmd(app),
 	)
 	return cmd
 }
 
 func newRegistryAddCmd(app *App) *cobra.Command {
 	return &cobra.Command{
-		Use:   "add <name> <url>",
+		Use:   "add [name] [url]",
 		Short: "Add (or update) a named registry shown in aggregated views",
+		Long: "Add a named registry. Pass <name> <url> directly, or run with no args " +
+			"to be prompted for the name, URL, and (optionally) an auth token.",
+		Args: cobra.MaximumNArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			switch len(args) {
+			case 0:
+				return runRegistryAddInteractive(app)
+			case 2:
+				return runRegistryAdd(app, args[0], args[1])
+			default:
+				return fmt.Errorf("provide both <name> and <url>, or no args to add interactively")
+			}
+		},
+	}
+}
+
+func newRegistryRenameCmd(app *App) *cobra.Command {
+	return &cobra.Command{
+		Use:   "rename <old> <new>",
+		Short: "Rename a registry (moves its stored token too)",
 		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runRegistryAdd(app, args[0], args[1])
+			return runRegistryRename(app, args[0], args[1])
 		},
 	}
 }
@@ -73,21 +94,31 @@ func newRegistryRemoveCmd(app *App) *cobra.Command {
 	}
 }
 
-func runRegistryAdd(app *App, name, url string) error {
+// addRegistry validates and persists a named registry. Shared by the direct
+// and interactive add paths.
+func addRegistry(app *App, name, url string) (string, string, error) {
 	name = strings.TrimSpace(name)
 	url = strings.TrimSpace(url)
 	if name == "" {
-		return fmt.Errorf("registry name must not be empty")
+		return "", "", fmt.Errorf("registry name must not be empty")
 	}
 	if !isPlausibleRegistry(url) {
-		return fmt.Errorf("invalid registry URL %q — expected an http(s):// URL, a file:// URL, or a filesystem path", url)
+		return "", "", fmt.Errorf("invalid registry URL %q — expected an http(s):// URL, a file:// URL, or a filesystem path", url)
 	}
 	p, err := profile.Load(app.Config.ProfilePath)
 	if err != nil {
-		return err
+		return "", "", err
 	}
 	p.SetRegistry(name, url)
 	if err := profile.Save(app.Config.ProfilePath, p); err != nil {
+		return "", "", err
+	}
+	return name, url, nil
+}
+
+func runRegistryAdd(app *App, name, url string) error {
+	name, url, err := addRegistry(app, name, url)
+	if err != nil {
 		return err
 	}
 	if app.Config.JSON {
@@ -95,6 +126,67 @@ func runRegistryAdd(app *App, name, url string) error {
 	}
 	app.UI.Success("added registry %q → %s", name, url)
 	app.UI.Detail("store its token (if private) with: humblskills registry login --name %s", name)
+	return nil
+}
+
+func runRegistryAddInteractive(app *App) error {
+	name, err := app.Prompt.Text("Registry name", "e.g. work")
+	if err != nil {
+		return err
+	}
+	url, err := app.Prompt.Text("Registry URL", "https://raw.githubusercontent.com/<owner>/<repo>/main/registry.json")
+	if err != nil {
+		return err
+	}
+	name, url, err = addRegistry(app, name, url)
+	if err != nil {
+		return err
+	}
+	app.UI.Success("added registry %q → %s", name, url)
+
+	store, err := app.Prompt.Confirm("Store an auth token for this registry now? (private registries only)", false)
+	if err != nil {
+		return err
+	}
+	if store {
+		tok, err := app.Prompt.Secret("Registry auth token")
+		if err != nil {
+			return err
+		}
+		if strings.TrimSpace(tok) != "" {
+			src, err := secrets.SetRegistryTokenFor(name, tok)
+			if err != nil {
+				return err
+			}
+			app.UI.Success("stored token for %q in %s", name, src)
+		}
+	}
+	return nil
+}
+
+func runRegistryRename(app *App, old, name string) error {
+	old = strings.TrimSpace(old)
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return fmt.Errorf("new registry name must not be empty")
+	}
+	p, err := profile.Load(app.Config.ProfilePath)
+	if err != nil {
+		return err
+	}
+	if err := p.RenameRegistry(old, name); err != nil {
+		return err
+	}
+	if err := profile.Save(app.Config.ProfilePath, p); err != nil {
+		return err
+	}
+	if err := secrets.RenameRegistryToken(old, name); err != nil {
+		app.UI.Warn("registry renamed, but moving its stored token failed: %v", err)
+	}
+	if app.Config.JSON {
+		return app.UI.JSON(map[string]string{"old": old, "new": name})
+	}
+	app.UI.Success("renamed registry %q → %q", old, name)
 	return nil
 }
 

--- a/cli/internal/profile/profile.go
+++ b/cli/internal/profile/profile.go
@@ -99,6 +99,24 @@ func (p *Profile) RemoveRegistry(name string) bool {
 	return false
 }
 
+// RenameRegistry changes a registry's name in place. It errors if old doesn't
+// exist or if new is already taken.
+func (p *Profile) RenameRegistry(old, name string) error {
+	if old == name {
+		return nil
+	}
+	if _, ok := p.FindRegistry(name); ok {
+		return fmt.Errorf("a registry named %q already exists", name)
+	}
+	for i := range p.Registries {
+		if p.Registries[i].Name == old {
+			p.Registries[i].Name = name
+			return nil
+		}
+	}
+	return fmt.Errorf("no registry named %q", old)
+}
+
 // EvalProfile captures eval-specific defaults. Secrets (API keys) do NOT
 // live here - they go through cli/internal/secrets which supports env +
 // OS keyring + 0600 file fallback.

--- a/cli/internal/profile/registries_test.go
+++ b/cli/internal/profile/registries_test.go
@@ -40,6 +40,30 @@ func TestNamedRegistries_SetFindRemove(t *testing.T) {
 	}
 }
 
+func TestNamedRegistries_Rename(t *testing.T) {
+	p := &Profile{}
+	p.SetRegistry("old", "https://a")
+	p.SetRegistry("keep", "https://b")
+
+	if err := p.RenameRegistry("old", "new"); err != nil {
+		t.Fatalf("rename: %v", err)
+	}
+	if _, ok := p.FindRegistry("new"); !ok {
+		t.Fatal("renamed registry missing under new name")
+	}
+	if _, ok := p.FindRegistry("old"); ok {
+		t.Fatal("old name still present after rename")
+	}
+	// Collision with an existing name is rejected.
+	if err := p.RenameRegistry("new", "keep"); err == nil {
+		t.Fatal("expected error renaming onto an existing name")
+	}
+	// Renaming a missing registry is rejected.
+	if err := p.RenameRegistry("missing", "x"); err == nil {
+		t.Fatal("expected error renaming a nonexistent registry")
+	}
+}
+
 func TestNamedRegistries_RoundTrip(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "profile.json")
 	p := &Profile{SchemaVersion: SchemaVersion}

--- a/cli/internal/secrets/secrets.go
+++ b/cli/internal/secrets/secrets.go
@@ -353,6 +353,26 @@ func deleteKeyedToken(filePath, account string) error {
 	return writeFileSecret(filePath, account, "")
 }
 
+// RenameRegistryToken moves a named registry's own stored token from old to
+// new. If old has no dedicated token, this is a no-op (nil).
+func RenameRegistryToken(old, name string) error {
+	if old == name {
+		return nil
+	}
+	path, err := defaultFilePath()
+	if err != nil {
+		return err
+	}
+	v, src := getKeyedToken(path, registryAccount(old))
+	if src == SourceAbsent || v == "" {
+		return nil
+	}
+	if _, err := setKeyedToken(path, registryAccount(name), v); err != nil {
+		return err
+	}
+	return deleteKeyedToken(path, registryAccount(old))
+}
+
 // KeyringAvailable reports whether the OS keyring appears reachable. Used by
 // doctor to surface a helpful hint when secrets will land in the file.
 func KeyringAvailable() bool {

--- a/cli/internal/ui/prompt.go
+++ b/cli/internal/ui/prompt.go
@@ -133,6 +133,23 @@ func (p *Prompter) Secret(title string) (string, error) {
 	return v, nil
 }
 
+// Text asks for a single line of free text. Returns ErrNonInteractive when the
+// caller isn't on a TTY. placeholder, when non-empty, is shown as ghost text.
+func (p *Prompter) Text(title, placeholder string) (string, error) {
+	if !p.Interactive {
+		return "", ErrNonInteractive
+	}
+	var v string
+	in := huh.NewInput().Title(title).Value(&v)
+	if placeholder != "" {
+		in = in.Placeholder(placeholder)
+	}
+	if err := in.WithTheme(theme()).Run(); err != nil {
+		return "", fmt.Errorf("prompt: %w", err)
+	}
+	return v, nil
+}
+
 // SelectOption is one entry shown in a Select.
 type SelectOption struct {
 	// Label is the visible text. Falls back to Value when empty.

--- a/registry.json
+++ b/registry.json
@@ -1,10 +1,10 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-07-21T22:17:22Z",
+  "generated_at": "2026-07-22T00:04:38Z",
   "source": {
     "repo": "github.com/jjfantini/humblSKILLS",
-    "ref": "main",
-    "sha": "c1302883be9542a3ee2b31b4d7227729e72a6d95"
+    "ref": "feat/registry-management",
+    "sha": "9e6179cb83984575a5374710eff795537d4ca844"
   },
   "skills": [
     {


### PR DESCRIPTION
## What (registry management UX — pieces A/B/C)

- **A** — `profile show` lists configured registries (name, url, token state) under a **Registries** section (`--json` already included them).
- **B** — `registry rename <old> <new>` renames a registry and **moves its keychain token**. URL edits remain covered by re-adding an existing name (`registry add <name> <new-url>`).
- **C** — `registry add` with **no args** runs an interactive form (name → url → optional token) via a new `ui.Prompter.Text` input; explicit `add <name> <url>` unchanged.

Deferred (piece D): the full registry-manager TUI screen + dashboard tile.

## Testing
- Full `go test -race ./...` (38 pkgs) + `vet` green.
- New tests: `profile.RenameRegistry` (rename / collision / missing).
- End-to-end verified: `profile show` Registries block, `rename` with token move (`registry list` confirms), and the non-TTY guard on interactive `add`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)