### PR TITLE
feat(registry): interactive registry manager TUI + dashboard tile

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,10 @@ humblskills install <skill>                # resolves to whichever registry has 
 humblskills registry remove work           # drop it (and its stored token)
 ```
 
+Run bare **`humblskills registry`** (or the dashboard's **registry** tile) to open the
+interactive **registry manager** — add, rename, login, logout, remove, and refresh from
+one screen (falls back to `registry list` when not on a TTY).
+
 Configured registries also show up in `humblskills profile show` (under **Registries**).
 When none are configured, everything falls back to the single registry above
 (`--registry`/`HUMBLSKILLS_REGISTRY`/`profile set registry`/hosted default).

--- a/cli/cmd/humblskills/registry.go
+++ b/cli/cmd/humblskills/registry.go
@@ -28,6 +28,12 @@ func newRegistryCmd(app *App) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "registry",
 		Short: "Manage skill registries (add/list/remove), refresh the cache, and auth",
+		Long: "Run bare to open the interactive registry manager (add / rename / login / " +
+			"logout / remove / refresh), or use a subcommand for scripting.",
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runRegistryManager(app)
+		},
 	}
 	cmd.AddCommand(
 		newRegistryRefreshCmd(app),

--- a/cli/cmd/humblskills/registry_manager.go
+++ b/cli/cmd/humblskills/registry_manager.go
@@ -1,0 +1,172 @@
+package main
+
+import (
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/jjfantini/humblSKILLS/cli/internal/profile"
+	"github.com/jjfantini/humblSKILLS/cli/internal/secrets"
+	"github.com/jjfantini/humblSKILLS/cli/internal/tui"
+	"github.com/jjfantini/humblSKILLS/cli/internal/ui"
+)
+
+// registryMgrItem adapts a configured registry to the shared list widget.
+type registryMgrItem struct {
+	name     string
+	url      string
+	tokenSrc secrets.Source
+}
+
+func (r registryMgrItem) Key() string { return r.name }
+func (r registryMgrItem) FilterValue() string {
+	return strings.ToLower(r.name + " " + r.url)
+}
+func (r registryMgrItem) NaturalWidth(th *ui.Theme) int {
+	return 1 + 1 + lipgloss.Width(r.name)
+}
+
+func (r registryMgrItem) Row(th *ui.Theme, width int, selected bool) string {
+	dot := th.DotNo.Render("●")
+	if r.tokenSrc != secrets.SourceAbsent {
+		dot = th.DotOK.Render("●")
+	}
+	row := dot + " " + rowName(th, r.name, selected, true)
+	if rw := lipgloss.Width(row); rw < width {
+		row += strings.Repeat(" ", width-rw)
+	}
+	return row
+}
+
+func (r registryMgrItem) Detail(th *ui.Theme, width int) string {
+	var sb strings.Builder
+	sb.WriteString(th.DetailTitle.Render(r.name) + "\n\n")
+	sb.WriteString(kvRow(th, "url", th.KVValue.Render(r.url)))
+	tok := "none"
+	if r.tokenSrc != secrets.SourceAbsent {
+		tok = "stored (" + string(r.tokenSrc) + ")"
+	}
+	sb.WriteString(kvRow(th, "token", th.KVValue.Render(tok)))
+	return sb.String()
+}
+
+// runRegistryManager opens the interactive registry manager: a list of
+// configured registries with add / rename / login / logout / remove / refresh
+// actions. Falls back to a static list on non-TTY.
+func runRegistryManager(app *App) error {
+	if !tui.ShouldUseTUI(app.Config.JSON, app.Config.Quiet, app.Config.Yes) {
+		return runRegistryList(app)
+	}
+
+	fromDashboard := app.Nav.Crumb != ""
+	for {
+		p, err := profile.Load(app.Config.ProfilePath)
+		if err != nil {
+			return err
+		}
+		items := make([]tui.Item, 0, len(p.Registries))
+		for _, r := range p.Registries {
+			_, src := secrets.GetRegistryTokenFor(r.Name)
+			items = append(items, registryMgrItem{name: r.Name, url: r.URL, tokenSrc: src})
+		}
+
+		cfg := tui.Config{
+			Theme:      app.UI.Theme(),
+			Version:    resolveVersion().Version,
+			Section:    app.headerSection("Registries"),
+			Items:      items,
+			LeftTitle:  "REGISTRIES",
+			RightTitle: "DETAIL",
+			EmptyMsg:   "no registries — press a to add one",
+			Actions: []tui.ActionSpec{
+				{Key: "l", Label: "login", Action: "login"},
+				{Key: "a", Label: "add", Action: "add"},
+				{Key: "e", Label: "rename", Action: "rename"},
+				{Key: "o", Label: "logout", Action: "logout"},
+				{Key: "x", Label: "remove", Action: "remove"},
+				{Key: "r", Label: "refresh", Action: "refresh"},
+			},
+		}
+		if fromDashboard {
+			cfg.BackKey = "esc"
+			cfg.BackLabel = "back"
+		}
+
+		res, err := tui.RunListDetail(cfg)
+		if err != nil {
+			return err
+		}
+		if res.Quit {
+			return nil
+		}
+
+		sel, hasSel := res.Item.(registryMgrItem)
+		switch res.Action {
+		case "add":
+			if err := runRegistryAddInteractive(app); err != nil {
+				return err
+			}
+		case "rename":
+			if !hasSel {
+				continue
+			}
+			newName, err := app.Prompt.Text("New name for "+sel.name, "")
+			if err != nil {
+				return err
+			}
+			if strings.TrimSpace(newName) == "" {
+				continue
+			}
+			if err := runRegistryRename(app, sel.name, newName); err != nil {
+				return err
+			}
+		case "login":
+			if !hasSel {
+				continue
+			}
+			tok, err := app.Prompt.Secret("Auth token for " + sel.name)
+			if err != nil {
+				return err
+			}
+			if strings.TrimSpace(tok) == "" {
+				continue
+			}
+			if _, err := secrets.SetRegistryTokenFor(sel.name, tok); err != nil {
+				return err
+			}
+		case "logout":
+			if !hasSel {
+				continue
+			}
+			if err := secrets.DeleteRegistryTokenFor(sel.name); err != nil {
+				return err
+			}
+		case "remove":
+			if !hasSel {
+				continue
+			}
+			ok, err := app.Prompt.Confirm("Remove registry "+sel.name+"?", false)
+			if err != nil {
+				return err
+			}
+			if ok {
+				if err := runRegistryRemove(app, sel.name); err != nil {
+					return err
+				}
+			}
+		case "refresh":
+			if err := refreshAllRegistries(app); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+// refreshAllRegistries forces a network refresh of every configured registry's
+// cache, ignoring per-registry failures (they'll surface on next load).
+func refreshAllRegistries(app *App) error {
+	for _, r := range app.resolvedRegistries() {
+		_, _, _ = app.fetcherForRegistry(r).Refresh()
+	}
+	return nil
+}

--- a/cli/cmd/humblskills/start.go
+++ b/cli/cmd/humblskills/start.go
@@ -181,7 +181,7 @@ func dispatchDashboardCommand(app *App, cmd string) error {
 	case "doctor":
 		return runDoctor(app)
 	case "registry":
-		return runRegistryRefresh(app)
+		return runRegistryManager(app)
 	case "version":
 		return runVersion(app)
 	}

--- a/cli/internal/tui/dashboard.go
+++ b/cli/internal/tui/dashboard.go
@@ -84,7 +84,7 @@ func DefaultDashboardTiles() []DashboardTile {
 		{Command: "profile", Label: "profile", Hotkey: "p", Desc: "edit install defaults (platforms, scope)", Sub: "user-wide preferences", Aliases: []string{"config", "prefs"}},
 		{Command: "eval", Label: "eval", Hotkey: "e", Desc: "benchmark skills · three-arm · longitudinal", Sub: "runners · trajectories · reports", Aliases: []string{"test", "benchmark", "evaluate"}},
 		{Command: "doctor", Label: "doctor", Hotkey: "d", Desc: "inspect platforms and environment health", Sub: "platforms · writability", Aliases: []string{"check", "status"}},
-		{Command: "registry", Label: "registry", Hotkey: "R", Desc: "refresh the local registry cache", Sub: "http · etag", Aliases: []string{"refresh", "sync"}},
+		{Command: "registry", Label: "registry", Hotkey: "R", Desc: "manage registries — add, rename, login, remove", Sub: "sources · tokens · refresh", Aliases: []string{"registries", "refresh"}},
 		{Command: "version", Label: "version", Hotkey: "V", Desc: "show build info", Sub: "version · commit", Aliases: []string{"about", "ver"}},
 		{Command: "upgrade", Label: "upgrade", Hotkey: "U", Desc: "upgrade the humblskills CLI itself", Sub: "github releases · checksum verified", Aliases: []string{"self-update"}},
 	}

--- a/registry.json
+++ b/registry.json
@@ -1,10 +1,10 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-07-22T00:05:06Z",
+  "generated_at": "2026-07-22T00:15:35Z",
   "source": {
     "repo": "github.com/jjfantini/humblSKILLS",
-    "ref": "main",
-    "sha": "9b2be206ba009f71f512ad8c5cef84108d75345f"
+    "ref": "feat/registry-manager-tui",
+    "sha": "512f4caead6fa0fc04733ce435f2dad892273371"
   },
   "skills": [
     {


### PR DESCRIPTION
## What (piece D)

Bare `humblskills registry` (and the dashboard **registry** tile) now open an **interactive registry manager** — a list of configured registries with **add / rename / login / logout / remove / refresh** actions, built on the shared `listdetail` widget with an action loop (inline prompts, re-enter after each). Falls back to `registry list` on non-TTY. The dashboard "registry" command is repointed from cache-refresh to the manager.

## Testing
- Full `go test -race ./...` (38 pkgs) + `vet` green.
- Non-TTY fallback verified (bare `registry` → list).
- The interactive screen isn't driven in CI (same as the other TUI surfaces); it reuses the tested list widget + the skill-browser's action-loop pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)