### PR TITLE
feat(registry): multi-registry coherence — provenance, updates, doctor, tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,8 +146,10 @@ interactive **registry manager** — add, rename, login, logout, remove, and ref
 one screen (falls back to `registry list` when not on a TTY).
 
 Configured registries also show up in `humblskills profile show` (under **Registries**).
-When none are configured, everything falls back to the single registry above
-(`--registry`/`HUMBLSKILLS_REGISTRY`/`profile set registry`/hosted default).
+`list` tags each installed skill with the registry it came from, `update` checks each
+skill against **its** registry, and `doctor` reports each registry's reachability, token,
+and skill count. When none are configured, everything falls back to the single registry
+above (`--registry`/`HUMBLSKILLS_REGISTRY`/`profile set registry`/hosted default).
 
 ### Sharing skill sets across a team
 

--- a/cli/cmd/humblskills/doctor.go
+++ b/cli/cmd/humblskills/doctor.go
@@ -94,9 +94,11 @@ func runDoctorTUI(app *App, r doctorReport) (bool, error) {
 	for _, a := range r.Adapters {
 		items = append(items, adapterItem{a: a})
 	}
+	items = append(items, manifestItem{m: r.Manifest, issue: firstIssue(r.Issues, "manifest:")})
+	for _, rr := range r.Registries {
+		items = append(items, registryItem{reg: rr})
+	}
 	items = append(items,
-		manifestItem{m: r.Manifest, issue: firstIssue(r.Issues, "manifest:")},
-		registryItem{reg: r.Registry},
 		updatesItem{u: r.Updates},
 		evalItem{e: r.Eval},
 	)
@@ -107,14 +109,20 @@ func runDoctorTUI(app *App, r doctorReport) (bool, error) {
 			detected++
 		}
 	}
+	totalSkills, regErrs := 0, 0
+	for _, rr := range r.Registries {
+		totalSkills += rr.Skills
+		if rr.Error != "" {
+			regErrs++
+		}
+	}
 	localMeta := func(_ []tui.Item, _ int) string {
 		parts := []string{
 			fmt.Sprintf("%d / %d detected", detected, len(r.Adapters)),
 		}
-		if r.Registry.Error == "" {
-			parts = append(parts, fmt.Sprintf("%d skills", r.Registry.Skills))
-		} else {
-			parts = append(parts, "registry error")
+		parts = append(parts, fmt.Sprintf("%d skills", totalSkills))
+		if regErrs > 0 {
+			parts = append(parts, fmt.Sprintf("%d registry error%s", regErrs, textutil.Plural(regErrs)))
 		}
 		if r.Updates.Count > 0 {
 			parts = append(parts, fmt.Sprintf("%d update%s", r.Updates.Count, textutil.Plural(r.Updates.Count)))

--- a/cli/cmd/humblskills/doctor_report.go
+++ b/cli/cmd/humblskills/doctor_report.go
@@ -11,7 +11,6 @@ import (
 	"github.com/jjfantini/humblSKILLS/cli/internal/adapters"
 	"github.com/jjfantini/humblSKILLS/cli/internal/eval/evalruntime"
 	"github.com/jjfantini/humblSKILLS/cli/internal/eval/workspace"
-	"github.com/jjfantini/humblSKILLS/cli/internal/install"
 	"github.com/jjfantini/humblSKILLS/cli/internal/manifest"
 	"github.com/jjfantini/humblSKILLS/cli/internal/registry"
 	"github.com/jjfantini/humblSKILLS/cli/internal/secrets"
@@ -22,12 +21,12 @@ import (
 // doctor_view.go; command wiring lives in doctor.go.
 
 type doctorReport struct {
-	Adapters []adapterReport `json:"adapters"`
-	Manifest manifestReport  `json:"manifest"`
-	Registry registryReport  `json:"registry"`
-	Updates  updatesReport   `json:"updates"`
-	Eval     evalReport      `json:"eval"`
-	Issues   []string        `json:"issues,omitempty"`
+	Adapters   []adapterReport  `json:"adapters"`
+	Manifest   manifestReport   `json:"manifest"`
+	Registries []registryReport `json:"registries"`
+	Updates    updatesReport    `json:"updates"`
+	Eval       evalReport       `json:"eval"`
+	Issues     []string         `json:"issues,omitempty"`
 }
 
 // evalReport is the eval-prerequisite block: per-runner availability,
@@ -90,6 +89,7 @@ type manifestReport struct {
 }
 
 type registryReport struct {
+	Name      string        `json:"name"`
 	URL       string        `json:"url"`
 	Source    string        `json:"source"`
 	Cached    bool          `json:"cached"`
@@ -133,32 +133,49 @@ func buildDoctorReport(app *App) (doctorReport, error) {
 		}
 	}
 
-	f := app.registryFetcher()
-	// No spinner here - the caller (runDoctor) already wraps this whole
-	// function in one loading/spinner screen, so a second nested spinner
-	// would just fight it for the terminal.
-	reg, origin, rErr := f.Load()
-	rr := registryReport{URL: app.Config.RegistryURL, Source: string(origin)}
-	if rErr != nil {
-		rr.Error = rErr.Error()
-		report.Issues = append(report.Issues, fmt.Sprintf("registry: %s", rErr))
-	} else {
-		rr.Skills = len(reg.Skills)
-		for _, issue := range registry.ValidateDeps(reg) {
-			rr.DepIssues = append(rr.DepIssues, issue.Error())
+	// One report per configured registry. No spinner here - the caller
+	// (runDoctor) already wraps this whole function in one loading screen.
+	ix := newSkillIndex()
+	anyRegOK := false
+	for _, r := range app.resolvedRegistries() {
+		f := app.fetcherForRegistry(r)
+		reg, origin, rErr := f.Load()
+		rr := registryReport{Name: r.Name, URL: r.URL, Source: string(origin)}
+		if rErr != nil {
+			rr.Error = rErr.Error()
+			report.Issues = append(report.Issues, fmt.Sprintf("registry %q: %s", r.Name, rErr))
+		} else {
+			anyRegOK = true
+			rr.Skills = len(reg.Skills)
+			ix.add(r.Name, reg.Skills)
+			for _, issue := range registry.ValidateDeps(reg) {
+				rr.DepIssues = append(rr.DepIssues, issue.Error())
+			}
 		}
+		info := f.Inspect()
+		rr.Cached = info.Exists
+		rr.FetchedAt = info.FetchedAt
+		rr.Age = info.Age
+		report.Registries = append(report.Registries, rr)
 	}
-	info := f.Inspect()
-	rr.Cached = info.Exists
-	rr.FetchedAt = info.FetchedAt
-	rr.Age = info.Age
-	report.Registry = rr
 
-	if mErr == nil && rErr == nil {
-		plans := install.PlanUpdates(reg, m, nil)
-		report.Updates.Count = len(plans)
-		for _, p := range plans {
-			report.Updates.Skills = append(report.Updates.Skills, p.Skill)
+	// Update count: each installed skill checked against its ORIGIN registry.
+	if mErr == nil && anyRegOK {
+		seen := map[string]bool{}
+		for _, inst := range m.Installations {
+			if seen[inst.Skill] {
+				continue
+			}
+			origin := inst.RegistryName
+			if origin == "" {
+				origin = ix.registryOf(inst.Skill)
+			}
+			rs, ok := ix.find(origin, inst.Skill)
+			if ok && (inst.Version != rs.Version || inst.RegistryRef != rs.DirSHA) {
+				seen[inst.Skill] = true
+				report.Updates.Count++
+				report.Updates.Skills = append(report.Updates.Skills, inst.Skill)
+			}
 		}
 	}
 
@@ -248,8 +265,10 @@ func hasFailures(r doctorReport) bool {
 	if len(r.Issues) > 0 {
 		return true
 	}
-	if r.Registry.Error != "" || len(r.Registry.DepIssues) > 0 {
-		return true
+	for _, rr := range r.Registries {
+		if rr.Error != "" || len(rr.DepIssues) > 0 {
+			return true
+		}
 	}
 	// Eval: default runner must be available for CI to claim "healthy".
 	if r.Eval.DefaultRunner == "" && len(r.Eval.Runners) > 0 {

--- a/cli/cmd/humblskills/doctor_test.go
+++ b/cli/cmd/humblskills/doctor_test.go
@@ -60,8 +60,8 @@ func TestDoctor_ReportsAdapters(t *testing.T) {
 	if !found {
 		t.Errorf("claude-code absent from doctor report")
 	}
-	if got.Registry.Skills != 1 {
-		t.Errorf("registry.skills = %d, want 1", got.Registry.Skills)
+	if len(got.Registries) != 1 || got.Registries[0].Skills != 1 {
+		t.Errorf("registries = %+v, want one with 1 skill", got.Registries)
 	}
 }
 
@@ -135,7 +135,7 @@ func TestDoctor_RegistryUnreachableSurfacedAsIssue(t *testing.T) {
 		"--json",
 	)
 	got := extractDoctorJSON(t, res.Out)
-	if got.Registry.Error == "" {
+	if len(got.Registries) == 0 || got.Registries[0].Error == "" {
 		t.Error("expected registry error on unreachable URL")
 	}
 }

--- a/cli/cmd/humblskills/doctor_view.go
+++ b/cli/cmd/humblskills/doctor_view.go
@@ -108,8 +108,9 @@ func (m manifestItem) Detail(th *ui.Theme, width int) string {
 
 type registryItem struct{ reg registryReport }
 
-func (r registryItem) Key() string         { return "registry" }
-func (r registryItem) FilterValue() string { return "registry " + r.reg.URL }
+func (r registryItem) label() string       { return registryDisplayName(r.reg.Name) }
+func (r registryItem) Key() string         { return "registry:" + r.reg.Name }
+func (r registryItem) FilterValue() string { return "registry " + r.reg.Name + " " + r.reg.URL }
 func (r registryItem) NaturalWidth(th *ui.Theme) int {
 	var badge string
 	switch {
@@ -120,7 +121,7 @@ func (r registryItem) NaturalWidth(th *ui.Theme) int {
 	default:
 		badge = tui.Badge(th, tui.BadgeDetected, fmt.Sprintf("%d skills", r.reg.Skills))
 	}
-	return rowNaturalWidth("registry", lipgloss.Width(badge))
+	return rowNaturalWidth(r.label(), lipgloss.Width(badge))
 }
 func (r registryItem) Row(th *ui.Theme, width int, selected bool) string {
 	ok := r.reg.Error == "" && len(r.reg.DepIssues) == 0
@@ -135,11 +136,11 @@ func (r registryItem) Row(th *ui.Theme, width int, selected bool) string {
 		dot = th.DotOK.Render("●")
 		badge = tui.Badge(th, tui.BadgeDetected, fmt.Sprintf("%d skills", r.reg.Skills))
 	}
-	return rowWithTrailingBadge(dot+" "+rowName(th, "registry", selected, ok), badge, width)
+	return rowWithTrailingBadge(dot+" "+rowName(th, r.label(), selected, ok), badge, width)
 }
 func (r registryItem) Detail(th *ui.Theme, width int) string {
 	var sb strings.Builder
-	sb.WriteString(th.DetailTitle.Render("registry") + "  " +
+	sb.WriteString(th.DetailTitle.Render(r.label()) + "  " +
 		th.DetailSub.Render(r.reg.URL) + "\n\n")
 	sb.WriteString(kvRow(th, "source", th.KVValue.Render(r.reg.Source)))
 	sb.WriteString(kvRow(th, "skills", th.KVValue.Render(fmt.Sprintf("%d", r.reg.Skills))))
@@ -398,17 +399,19 @@ func printDoctorStatic(app *App, r doctorReport) {
 		app.UI.Detail("  %s (not yet created)", r.Manifest.Path)
 	}
 
-	app.UI.Section("Registry")
-	app.UI.Info("  %s %s", th.Label.Render("url"), th.Name.Render(r.Registry.URL))
-	if r.Registry.Error != "" {
-		app.UI.Error("registry unreachable: %s", r.Registry.Error)
-	} else {
-		app.UI.Success("%d skill%s available (via %s)", r.Registry.Skills, textutil.Plural(r.Registry.Skills), r.Registry.Source)
-		if r.Registry.Cached {
-			app.UI.Detail("  cache fetched %s ago", r.Registry.Age.Round(time.Second))
+	app.UI.Section("Registries")
+	for _, rr := range r.Registries {
+		app.UI.Info("  %s %s  %s", th.Label.Render("•"), th.Name.Render(registryDisplayName(rr.Name)), th.Detail.Render(rr.URL))
+		if rr.Error != "" {
+			app.UI.Error("  unreachable: %s", rr.Error)
+			continue
 		}
-		for _, issue := range r.Registry.DepIssues {
-			app.UI.Warn("dep issue: %s", issue)
+		app.UI.Success("  %d skill%s available (via %s)", rr.Skills, textutil.Plural(rr.Skills), rr.Source)
+		if rr.Cached {
+			app.UI.Detail("    cache fetched %s ago", rr.Age.Round(time.Second))
+		}
+		for _, issue := range rr.DepIssues {
+			app.UI.Warn("  dep issue: %s", issue)
 		}
 	}
 

--- a/cli/cmd/humblskills/install.go
+++ b/cli/cmd/humblskills/install.go
@@ -158,12 +158,13 @@ func runInstall(app *App, skill string, f installFlags, fromDashboard bool) erro
 	var res install.Result
 	run := func(sink install.EventSink) error {
 		r, err := engine.Execute(target.Reg, plan, install.ExecuteOpts{
-			Adapters:  adapterList,
-			Platforms: selected,
-			Scope:     scope,
-			Force:     f.force,
-			Global:    global,
-			OnEvent:   sink,
+			Adapters:     adapterList,
+			Platforms:    selected,
+			Scope:        scope,
+			Force:        f.force,
+			Global:       global,
+			OnEvent:      sink,
+			RegistryName: target.Name,
 		})
 		res = r
 		return err

--- a/cli/cmd/humblskills/list.go
+++ b/cli/cmd/humblskills/list.go
@@ -68,17 +68,12 @@ func runList(app *App, fromDashboard bool) error {
 // registry is read from the local cache only (never fetched); if no cached
 // registry is available the map is nil and callers show no drift.
 func availableUpdates(app *App, m *manifest.Manifest) map[string]string {
-	reg, ok := app.registryFetcher().LoadCached()
-	if !ok || reg == nil {
-		return nil
-	}
-	idx := make(map[string]registry.Skill, len(reg.Skills))
-	for _, s := range reg.Skills {
-		idx[s.Name] = s
-	}
+	ix := app.cachedSkillIndex()
 	out := map[string]string{}
 	for _, inst := range m.Installations {
-		rs, found := idx[inst.Skill]
+		// Compare each install against its ORIGIN registry (falling back to any),
+		// so a skill from registry A isn't mismarked against registry B.
+		rs, found := ix.find(inst.RegistryName, inst.Skill)
 		if !found {
 			continue
 		}
@@ -134,6 +129,14 @@ func renderListTable(app *App, installs []manifest.Installation, avail map[strin
 	th := app.UI.Theme()
 	app.UI.Header("list")
 
+	// Show a Registry column only when installs actually span more than one
+	// registry, so single-registry output stays uncluttered.
+	regs := map[string]struct{}{}
+	for _, inst := range installs {
+		regs[inst.RegistryName] = struct{}{}
+	}
+	showRegistry := len(regs) > 1
+
 	outdated := 0
 	rows := make([][]string, 0, len(installs))
 	for _, inst := range installs {
@@ -150,19 +153,27 @@ func renderListTable(app *App, installs []manifest.Installation, avail map[strin
 			version = th.DotWarn.Render("↑ ") + th.Version.Render("v"+inst.Version) +
 				th.Detail.Render(" → ") + th.DotWarn.Render("v"+to)
 		}
-		rows = append(rows, []string{
-			th.Name.Render(inst.Skill),
-			version,
+		row := []string{th.Name.Render(inst.Skill), version}
+		if showRegistry {
+			row = append(row, th.Category.Render(registryDisplayName(inst.RegistryName)))
+		}
+		row = append(row,
 			th.Platform.Render(inst.Platform),
 			th.Label.Render(inst.Scope),
 			th.Detail.Render(inst.Path),
 			th.Detail.Render(source),
-		})
+		)
+		rows = append(rows, row)
 	}
+	headers := []string{"Skill", "Version"}
+	if showRegistry {
+		headers = append(headers, "Registry")
+	}
+	headers = append(headers, "Platform", "Scope", "Path", "Source")
 	tbl := table.New().
 		Border(lipgloss.RoundedBorder()).
 		BorderStyle(th.RuleLine).
-		Headers("Skill", "Version", "Platform", "Scope", "Path", "Source").
+		Headers(headers...).
 		Rows(rows...).
 		StyleFunc(func(row, _ int) lipgloss.Style {
 			if row == table.HeaderRow {
@@ -183,29 +194,29 @@ func renderListTable(app *App, installs []manifest.Installation, avail map[strin
 // looks identical to search, differing only in which skills are shown and
 // which actions are wired up.
 func runListTUI(app *App, m *manifest.Manifest, fromDashboard bool) error {
-	// Pull the registry to know whether each installed skill has drifted. If
-	// the registry is unreachable, fall back to the manifest versions.
-	reg, _, _ := app.registryFetcher().Load()
+	// Resolve each installed skill against its ORIGIN registry (across all
+	// configured registries) so drift + metadata are correct and the browser
+	// can group installs by source registry. Unreachable registries fall back
+	// to manifest versions.
+	ix := indexLoadedRegistries(app.loadRegistries())
 
-	// Build a "virtual" registry view of only the skills we have installed,
-	// preferring the registry version when available so `outdated` can render.
 	installedSkills := uniqueSkillsFromManifest(m)
 	skills := make([]registry.Skill, 0, len(installedSkills))
 	for _, name := range installedSkills {
-		if s := findRegistrySkill(reg, name); s != nil {
-			skills = append(skills, *s)
-			continue
-		}
-		// Registry missing this skill — synthesise from the manifest entry so
-		// it still shows in the browser.
 		inst := m.FindAll(name)
 		if len(inst) == 0 {
 			continue
 		}
-		skills = append(skills, registry.Skill{
-			Name:    name,
-			Version: inst[0].Version,
-		})
+		regName := inst[0].RegistryName
+		sk, ok := ix.find(regName, name)
+		if !ok {
+			// No registry has it — synthesise from the manifest entry.
+			sk = registry.Skill{Name: name, Version: inst[0].Version}
+		}
+		// Tag with the true origin from the manifest so grouping reflects where
+		// it was installed from (not a fallback registry that happens to list it).
+		sk.Registry = regName
+		skills = append(skills, sk)
 	}
 
 	items := buildSkillItems(skills, m)

--- a/cli/cmd/humblskills/profile.go
+++ b/cli/cmd/humblskills/profile.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/jjfantini/humblSKILLS/cli/internal/adapters"
 	"github.com/jjfantini/humblSKILLS/cli/internal/profile"
-	"github.com/jjfantini/humblSKILLS/cli/internal/secrets"
 	"github.com/jjfantini/humblSKILLS/cli/internal/tui"
 )
 
@@ -153,13 +152,8 @@ func runProfileShow(app *App) error {
 	if len(p.Registries) > 0 {
 		app.UI.Section("Registries")
 		for _, r := range p.Registries {
-			_, src := secrets.GetRegistryTokenFor(r.Name)
-			tok := "no token"
-			if src != secrets.SourceAbsent {
-				tok = "token: " + string(src)
-			}
 			fmt.Fprintln(app.UI.Out(), "  "+th.KVKey.Render(r.Name)+"  "+
-				th.KVValue.Render(r.URL)+"  "+th.Detail.Render("("+tok+")"))
+				th.KVValue.Render(r.URL)+"  "+th.Detail.Render("("+registryTokenLabel(r.Name)+")"))
 		}
 	}
 	return nil

--- a/cli/cmd/humblskills/registries.go
+++ b/cli/cmd/humblskills/registries.go
@@ -128,6 +128,100 @@ func findRegistryForSkill(loaded []registrySkills, skillName string) (registrySk
 	return registrySkills{}, false
 }
 
+// registryTokenLabel describes a registry's token state honestly: its own
+// stored token (keyring/file), an inherited default token, or none. A public
+// registry with no dedicated token reads "no token" rather than misleadingly
+// showing the shared default.
+func registryTokenLabel(name string) string {
+	if own := secrets.OwnRegistryTokenSource(name); own != secrets.SourceAbsent {
+		return "token: " + string(own)
+	}
+	if v, _ := secrets.GetRegistryTokenFor(name); v != "" {
+		return "token: inherited default"
+	}
+	return "no token"
+}
+
+// registryHasToken reports whether a registry will send any token (own or
+// inherited) — used for a status dot.
+func registryHasToken(name string) bool {
+	v, _ := secrets.GetRegistryTokenFor(name)
+	return v != ""
+}
+
+// skillIndex indexes skills by registry-name then skill-name, with a name-only
+// fallback (first registry seen wins). Used to resolve an installed skill
+// against its origin registry for drift/metadata.
+type skillIndex struct {
+	byReg  map[string]map[string]registry.Skill
+	global map[string]registry.Skill
+}
+
+func newSkillIndex() skillIndex {
+	return skillIndex{byReg: map[string]map[string]registry.Skill{}, global: map[string]registry.Skill{}}
+}
+
+func (ix skillIndex) add(regName string, skills []registry.Skill) {
+	m := ix.byReg[regName]
+	if m == nil {
+		m = map[string]registry.Skill{}
+		ix.byReg[regName] = m
+	}
+	for _, s := range skills {
+		m[s.Name] = s
+		if _, ok := ix.global[s.Name]; !ok {
+			ix.global[s.Name] = s
+		}
+	}
+}
+
+// find resolves a skill preferring its origin registry, then any registry.
+func (ix skillIndex) find(regName, name string) (registry.Skill, bool) {
+	if regName != "" {
+		if m, ok := ix.byReg[regName]; ok {
+			if s, ok := m[name]; ok {
+				return s, true
+			}
+		}
+	}
+	s, ok := ix.global[name]
+	return s, ok
+}
+
+// registryOf returns the name of a registry that lists the skill, or "" if
+// none. Used to attribute legacy installs (no recorded origin) to a registry.
+func (ix skillIndex) registryOf(name string) string {
+	for regName, m := range ix.byReg {
+		if _, ok := m[name]; ok {
+			return regName
+		}
+	}
+	return ""
+}
+
+// cachedSkillIndex builds a skillIndex from each registry's on-disk cache only
+// (never fetches) — for fast, offline-friendly reads like `list`.
+func (a *App) cachedSkillIndex() skillIndex {
+	ix := newSkillIndex()
+	for _, r := range a.resolvedRegistries() {
+		if reg, ok := a.fetcherForRegistry(r).LoadCached(); ok && reg != nil {
+			ix.add(r.Name, reg.Skills)
+		}
+	}
+	return ix
+}
+
+// indexLoadedRegistries builds a skillIndex from already-loaded registries.
+func indexLoadedRegistries(loaded []registrySkills) skillIndex {
+	ix := newSkillIndex()
+	for _, rs := range loaded {
+		if rs.Err == nil {
+			ix.add(rs.Name, rs.Skills)
+		}
+	}
+	return ix
+}
+
 // installEngineForToken builds an install Engine whose tarball fetcher carries
 // the given registry's token (tarballs are SHA-keyed so the shared cache dir is
 // safe across registries).

--- a/cli/cmd/humblskills/registries_test.go
+++ b/cli/cmd/humblskills/registries_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/jjfantini/humblSKILLS/cli/internal/registry"
+)
+
+func TestSkillIndex_FindAndRegistryOf(t *testing.T) {
+	ix := newSkillIndex()
+	ix.add("public", []registry.Skill{{Name: "a"}, {Name: "shared"}})
+	ix.add("work", []registry.Skill{{Name: "b"}, {Name: "shared"}})
+
+	// find prefers the named origin registry.
+	if _, ok := ix.find("work", "b"); !ok {
+		t.Fatal("b not found in work")
+	}
+	// find falls back to any registry when the origin doesn't have it.
+	if _, ok := ix.find("nonexistent", "a"); !ok {
+		t.Fatal("a not found via fallback")
+	}
+	if _, ok := ix.find("", "missing"); ok {
+		t.Fatal("missing should not resolve")
+	}
+
+	// registryOf attributes a skill to a registry that lists it.
+	if got := ix.registryOf("a"); got != "public" {
+		t.Fatalf("registryOf(a) = %q, want public", got)
+	}
+	if got := ix.registryOf("b"); got != "work" {
+		t.Fatalf("registryOf(b) = %q, want work", got)
+	}
+	if got := ix.registryOf("missing"); got != "" {
+		t.Fatalf("registryOf(missing) = %q, want empty", got)
+	}
+}
+
+func TestSanitizeRegistryName(t *testing.T) {
+	cases := map[string]string{
+		"work":        "work",
+		"happy robot": "happy-robot",
+		"a/b:c":       "a-b-c",
+		"":            "registry",
+	}
+	for in, want := range cases {
+		if got := sanitizeRegistryName(in); got != want {
+			t.Errorf("sanitizeRegistryName(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/cli/cmd/humblskills/registry.go
+++ b/cli/cmd/humblskills/registry.go
@@ -208,12 +208,7 @@ func runRegistryList(app *App) error {
 	}
 	th := app.UI.Theme()
 	for _, r := range regs {
-		_, src := secrets.GetRegistryTokenFor(r.Name)
-		tok := "no token"
-		if src != secrets.SourceAbsent {
-			tok = "token: " + string(src)
-		}
-		fmt.Fprintln(app.UI.Out(), "  "+th.KVKey.Render(r.Name)+"  "+th.KVValue.Render(r.URL)+"  ("+tok+")")
+		fmt.Fprintln(app.UI.Out(), "  "+th.KVKey.Render(r.Name)+"  "+th.KVValue.Render(r.URL)+"  ("+registryTokenLabel(r.Name)+")")
 	}
 	return nil
 }

--- a/cli/cmd/humblskills/registry_manager.go
+++ b/cli/cmd/humblskills/registry_manager.go
@@ -13,9 +13,8 @@ import (
 
 // registryMgrItem adapts a configured registry to the shared list widget.
 type registryMgrItem struct {
-	name     string
-	url      string
-	tokenSrc secrets.Source
+	name string
+	url  string
 }
 
 func (r registryMgrItem) Key() string { return r.name }
@@ -28,7 +27,7 @@ func (r registryMgrItem) NaturalWidth(th *ui.Theme) int {
 
 func (r registryMgrItem) Row(th *ui.Theme, width int, selected bool) string {
 	dot := th.DotNo.Render("●")
-	if r.tokenSrc != secrets.SourceAbsent {
+	if registryHasToken(r.name) {
 		dot = th.DotOK.Render("●")
 	}
 	row := dot + " " + rowName(th, r.name, selected, true)
@@ -42,11 +41,7 @@ func (r registryMgrItem) Detail(th *ui.Theme, width int) string {
 	var sb strings.Builder
 	sb.WriteString(th.DetailTitle.Render(r.name) + "\n\n")
 	sb.WriteString(kvRow(th, "url", th.KVValue.Render(r.url)))
-	tok := "none"
-	if r.tokenSrc != secrets.SourceAbsent {
-		tok = "stored (" + string(r.tokenSrc) + ")"
-	}
-	sb.WriteString(kvRow(th, "token", th.KVValue.Render(tok)))
+	sb.WriteString(kvRow(th, "token", th.KVValue.Render(registryTokenLabel(r.name))))
 	return sb.String()
 }
 
@@ -66,8 +61,7 @@ func runRegistryManager(app *App) error {
 		}
 		items := make([]tui.Item, 0, len(p.Registries))
 		for _, r := range p.Registries {
-			_, src := secrets.GetRegistryTokenFor(r.Name)
-			items = append(items, registryMgrItem{name: r.Name, url: r.URL, tokenSrc: src})
+			items = append(items, registryMgrItem{name: r.Name, url: r.URL})
 		}
 
 		cfg := tui.Config{

--- a/cli/cmd/humblskills/update.go
+++ b/cli/cmd/humblskills/update.go
@@ -23,6 +23,14 @@ type updateFlags struct {
 	force bool
 }
 
+// regUpdatePlan records which registry (document + token + name) an update plan
+// must be fetched from, so multi-registry updates hit the right source.
+type regUpdatePlan struct {
+	reg   *registry.Registry
+	token string
+	name  string
+}
+
 func newUpdateCmd(app *App) *cobra.Command {
 	var f updateFlags
 	cmd := &cobra.Command{
@@ -63,18 +71,47 @@ func runUpdate(app *App, only []string, f updateFlags) error {
 		return nil
 	}
 
-	reg, err := tui.RunWithLoadingIf(useTUI, app.UI.Theme(), "loading registry…", func() (*registry.Registry, error) {
-		reg, _, err := app.registryFetcher().Load()
-		if err != nil {
-			return nil, fmt.Errorf("load registry: %w", err)
-		}
-		return reg, nil
+	loaded, err := tui.RunWithLoadingIf(useTUI, app.UI.Theme(), "loading registries…", func() ([]registrySkills, error) {
+		return app.loadRegistries(), nil
 	})
 	if err != nil {
 		return err
 	}
 
-	plans := install.PlanUpdates(reg, m, only)
+	// Plan updates per ORIGIN registry so each installed skill is checked (and
+	// later fetched) against the registry it came from, with that registry's
+	// token. Legacy installs (no recorded origin) are attributed to whichever
+	// registry currently lists the skill.
+	ix := indexLoadedRegistries(loaded)
+	regByName := make(map[string]registrySkills, len(loaded))
+	for _, rs := range loaded {
+		regByName[rs.Name] = rs
+	}
+	partitions := map[string][]manifest.Installation{}
+	for _, inst := range m.Installations {
+		origin := inst.RegistryName
+		if origin == "" {
+			origin = ix.registryOf(inst.Skill)
+		}
+		if origin == "" && len(loaded) > 0 {
+			origin = loaded[0].Name
+		}
+		partitions[origin] = append(partitions[origin], inst)
+	}
+
+	bySkill := map[string]regUpdatePlan{}
+	var plans []install.UpdatePlan
+	for name, insts := range partitions {
+		rs, ok := regByName[name]
+		if !ok || rs.Reg == nil {
+			continue // registry unavailable/unknown — skip its installs
+		}
+		fm := &manifest.Manifest{SchemaVersion: m.SchemaVersion, Installations: insts}
+		for _, pl := range install.PlanUpdates(rs.Reg, fm, only) {
+			bySkill[pl.Skill] = regUpdatePlan{reg: rs.Reg, token: rs.Token, name: name}
+			plans = append(plans, pl)
+		}
+	}
 	sort.Slice(plans, func(i, j int) bool { return plans[i].Skill < plans[j].Skill })
 
 	if f.check {
@@ -108,12 +145,17 @@ func runUpdate(app *App, only []string, f updateFlags) error {
 		adapterKnown[a.Name] = struct{}{}
 	}
 
-	engine := app.installEngine()
 	var aggregate install.Result
 
 	run := func(sink install.EventSink) error {
 		for _, plan := range selected {
-			stepPlan, err := install.Plan(reg, plan.Skill)
+			rp, ok := bySkill[plan.Skill]
+			if !ok || rp.reg == nil {
+				app.UI.Warn("skipping %s: source registry unresolved", plan.Skill)
+				continue
+			}
+			engine := app.installEngineForToken(rp.token)
+			stepPlan, err := install.Plan(rp.reg, plan.Skill)
 			if err != nil {
 				return err
 			}
@@ -149,13 +191,14 @@ func runUpdate(app *App, only []string, f updateFlags) error {
 			for _, group := range groups {
 				plats := byGroup[group]
 				sort.Strings(plats)
-				res, err := engine.Execute(reg, stepPlan, install.ExecuteOpts{
-					Adapters:  adapters,
-					Platforms: plats,
-					Scope:     group.scope,
-					Force:     f.force,
-					Global:    group.global,
-					OnEvent:   sink,
+				res, err := engine.Execute(rp.reg, stepPlan, install.ExecuteOpts{
+					Adapters:     adapters,
+					Platforms:    plats,
+					Scope:        group.scope,
+					Force:        f.force,
+					Global:       group.global,
+					OnEvent:      sink,
+					RegistryName: rp.name,
 				})
 				if err != nil {
 					return fmt.Errorf("%s: %w", plan.Skill, err)

--- a/cli/internal/install/engine.go
+++ b/cli/internal/install/engine.go
@@ -100,6 +100,10 @@ type ExecuteOpts struct {
 	// Callers that don't need progress (tests, --json, scripts) can leave it
 	// nil. See events.go for Phase semantics.
 	OnEvent EventSink
+	// RegistryName is the name of the registry these skills are installed from,
+	// recorded on each manifest entry for origin grouping + registry-aware
+	// updates. Empty is fine (single-registry / legacy).
+	RegistryName string
 }
 
 // Execute runs the plan: fetch each skill, verify its content hash, and place
@@ -354,9 +358,9 @@ func (e *Engine) installOne(
 				return nil, fmt.Errorf("clean store staging: %w", err)
 			}
 			defer os.RemoveAll(perStore)
-		if err := fsutil.CopyTree(staging, perStore, fsutil.Options{RejectSymlinks: true}); err != nil {
-			return nil, fmt.Errorf("copy store staging: %w", err)
-		}
+			if err := fsutil.CopyTree(staging, perStore, fsutil.Options{RejectSymlinks: true}); err != nil {
+				return nil, fmt.Errorf("copy store staging: %w", err)
+			}
 			if len(preserveList) > 0 {
 				if err := applyPreserve(preserveSource, perStore, preserveList); err != nil {
 					return nil, err
@@ -391,16 +395,17 @@ func (e *Engine) installOne(
 			return nil, fmt.Errorf("link %s -> %s: %w", pt.pending.final, storePath, err)
 		}
 		m.Upsert(manifest.Installation{
-			Skill:       skill.Name,
-			Version:     skill.Version,
-			Platform:    pt.pending.adapter.Name,
-			Scope:       pt.pending.target.Scope,
-			Path:        pt.pending.final,
-			StorePath:   storePath,
-			InstallMode: mode,
-			InstalledAt: e.Now().UTC(),
-			SourceSHA:   reg.Source.SHA,
-			RegistryRef: skill.DirSHA,
+			Skill:        skill.Name,
+			Version:      skill.Version,
+			Platform:     pt.pending.adapter.Name,
+			Scope:        pt.pending.target.Scope,
+			Path:         pt.pending.final,
+			StorePath:    storePath,
+			InstallMode:  mode,
+			InstalledAt:  e.Now().UTC(),
+			SourceSHA:    reg.Source.SHA,
+			RegistryRef:  skill.DirSHA,
+			RegistryName: opts.RegistryName,
 		})
 		results = append(results, TargetResult{
 			Skill:     skill.Name,

--- a/cli/internal/manifest/manifest.go
+++ b/cli/internal/manifest/manifest.go
@@ -35,6 +35,10 @@ type Installation struct {
 	InstalledAt time.Time `json:"installed_at"`
 	SourceSHA   string    `json:"source_sha"`
 	RegistryRef string    `json:"registry_ref"`
+	// RegistryName is the name of the registry this skill was installed from
+	// (empty for installs written before multi-registry support). Used to group
+	// `list` by origin and to check updates against the right registry.
+	RegistryName string `json:"registry_name,omitempty"`
 }
 
 // DefaultPath resolves the manifest path using XDG_STATE_HOME (falling back

--- a/cli/internal/secrets/secrets.go
+++ b/cli/internal/secrets/secrets.go
@@ -275,6 +275,15 @@ func GetRegistryTokenFor(name string) (string, Source) {
 	return GetRegistryToken()
 }
 
+// OwnRegistryTokenSource reports where a registry's DEDICATED token is stored
+// (keyring or file), or SourceAbsent if it has none of its own — ignoring the
+// env var and the default-token fallback. Used to show "own" vs "inherited".
+func OwnRegistryTokenSource(name string) Source {
+	path, _ := defaultFilePath()
+	_, src := getKeyedToken(path, registryAccount(name))
+	return src
+}
+
 func getKeyedToken(filePath, account string) (string, Source) {
 	if v, err := keyring.Get(Service, account); err == nil && v != "" {
 		return v, SourceKeyring

--- a/registry.json
+++ b/registry.json
@@ -1,10 +1,10 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-07-22T00:16:17Z",
+  "generated_at": "2026-07-22T01:48:04Z",
   "source": {
     "repo": "github.com/jjfantini/humblSKILLS",
-    "ref": "main",
-    "sha": "e688eb88082c0d7dfbb6094362ef2359ca0ab1c9"
+    "ref": "feat/multi-registry-coherence",
+    "sha": "833ee844c0e13db864461b354473a81f7bba5aa7"
   },
   "skills": [
     {


### PR DESCRIPTION
## PR 1 of 3 — multi-registry coherence (QOL)

Makes list/update/doctor and token display registry-aware, closing the multi-registry gaps. CLI + TUI both covered.

- **Install provenance** — `manifest.Installation.RegistryName` recorded on install.
- **`update`** — per-origin: each installed skill checked + re-fetched against its own registry (with that registry's token). TUI picker + static.
- **`list`** — TUI groups installs by registry; static table gains a **Registry** column when installs span >1 registry; drift computed per-origin (no cross-registry false drift).
- **`doctor`** — one entry per registry (reachability, source, cache, dep issues, skills) in TUI + static.
- **Honest tokens** — `registry list` / `profile show` / manager TUI distinguish a registry's **own** token vs an **inherited default** vs none.

## Testing
- Full `go test -race ./...` (38 pkgs) + `vet` green.
- New unit tests: `skillIndex` (find/registryOf), `sanitizeRegistryName`; updated doctor tests for the registries slice.
- **End-to-end** across two registries: provenance in the manifest, `list` Registry column + origin, honest token labels (`inherited default` vs `keyring`), doctor per-registry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)