### PR TITLE
feat(registry): verify token on login + friendlier auth errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ Icon
 
 # humblskills eval workspaces (opt-in per-project storage)
 .eval-workspace/
+
+# Nested cli build output
+/cli/bin/

--- a/cli/cmd/humblskills/registries.go
+++ b/cli/cmd/humblskills/registries.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -9,6 +10,7 @@ import (
 	"github.com/jjfantini/humblSKILLS/cli/internal/profile"
 	"github.com/jjfantini/humblSKILLS/cli/internal/registry"
 	"github.com/jjfantini/humblSKILLS/cli/internal/secrets"
+	"github.com/jjfantini/humblSKILLS/cli/internal/textutil"
 )
 
 // resolvedRegistry is one registry the CLI will read, with its auth token
@@ -126,6 +128,46 @@ func findRegistryForSkill(loaded []registrySkills, skillName string) (registrySk
 		}
 	}
 	return registrySkills{}, false
+}
+
+// verifyRegistryToken does one network fetch of a registry with the given token
+// to confirm it authenticates, returning the visible skill count. name selects
+// which registry URL to test (its profile URL; "" uses the default registry).
+func (a *App) verifyRegistryToken(name, token string) (int, error) {
+	url := a.Config.RegistryURL
+	if name != "" {
+		if p, err := profile.Load(a.Config.ProfilePath); err == nil && p != nil {
+			if r, ok := p.FindRegistry(name); ok {
+				url = r.URL
+			}
+		}
+	}
+	f := registry.NewFetcher(url, a.registryCacheDir(name))
+	f.Token = token
+	reg, _, err := f.Refresh() // Refresh forces a network hit so the token is actually exercised
+	if err != nil {
+		return 0, err
+	}
+	return len(reg.Skills), nil
+}
+
+// storeAndVerifyToken stores a registry token then verifies it can read the
+// registry. Returns a human message and whether verification succeeded. Shared
+// by the CLI `registry login` and the manager TUI so both behave identically.
+func storeAndVerifyToken(app *App, name, token string) (string, bool) {
+	label := name
+	if label == "" {
+		label = "registry"
+	}
+	src, err := secrets.SetRegistryTokenFor(name, token)
+	if err != nil {
+		return err.Error(), false
+	}
+	n, verr := app.verifyRegistryToken(name, token)
+	if verr != nil {
+		return fmt.Sprintf("stored token for %s in %s, but verification failed: %v", label, src, verr), false
+	}
+	return fmt.Sprintf("stored token for %s in %s — verified: %d skill%s readable", label, src, n, textutil.Plural(n)), true
 }
 
 // registryTokenLabel describes a registry's token state honestly: its own

--- a/cli/cmd/humblskills/registry.go
+++ b/cli/cmd/humblskills/registry.go
@@ -296,20 +296,14 @@ func runRegistryLogin(app *App, name string) error {
 		return fmt.Errorf("no token provided (use --token, pipe it on stdin, or enter it at the prompt)")
 	}
 
-	src, err := secrets.SetRegistryTokenFor(name, token)
-	if err != nil {
-		return err
-	}
+	msg, ok := storeAndVerifyToken(app, name, token)
 	if app.Config.JSON {
-		return app.UI.JSON(map[string]string{"stored": string(src), "name": name})
+		return app.UI.JSON(map[string]any{"name": name, "verified": ok, "detail": msg})
 	}
-	if name != "" {
-		app.UI.Success("stored token for registry %q in %s", name, src)
+	if ok {
+		app.UI.Success("%s", msg)
 	} else {
-		app.UI.Success("stored registry token in %s", src)
-	}
-	if src == secrets.SourceFile {
-		app.UI.Detail("OS keychain unavailable — stored in a 0600 secrets file instead")
+		app.UI.Warn("%s", msg)
 	}
 	return nil
 }

--- a/cli/cmd/humblskills/registry_manager.go
+++ b/cli/cmd/humblskills/registry_manager.go
@@ -125,8 +125,14 @@ func runRegistryManager(app *App) error {
 			if strings.TrimSpace(tok) == "" {
 				continue
 			}
-			if _, err := secrets.SetRegistryTokenFor(sel.name, tok); err != nil {
-				return err
+			msg, ok := storeAndVerifyToken(app, sel.name, tok)
+			if ok {
+				app.UI.Success("%s", msg)
+			} else {
+				// Pause so a verification failure is readable before the list
+				// re-renders over it.
+				app.UI.Warn("%s", msg)
+				_, _ = app.Prompt.Confirm("continue?", true)
 			}
 		case "logout":
 			if !hasSel {

--- a/cli/internal/fetch/tarball.go
+++ b/cli/internal/fetch/tarball.go
@@ -75,7 +75,7 @@ func (f *Fetcher) Fetch(repo, sha string) (string, error) {
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return "", fmt.Errorf("fetch %s: HTTP %d", url, resp.StatusCode)
+		return "", httpFetchError(url, resp.StatusCode, f.Token != "")
 	}
 
 	tmp := dest + ".tmp"
@@ -224,6 +224,22 @@ func writeFile(path string, r io.Reader, mode os.FileMode) error {
 func (f *Fetcher) tarPath(owner, name, sha string) string {
 	fname := fmt.Sprintf("%s-%s-%s.tar.gz", owner, name, sha)
 	return filepath.Join(f.CacheDir, "tars", fname)
+}
+
+// httpFetchError turns a non-2xx codeload status into an actionable message,
+// mapping private-repo auth failures to next steps instead of a bare code.
+func httpFetchError(url string, status int, hasToken bool) error {
+	switch status {
+	case 401, 403:
+		return fmt.Errorf("fetch %s: HTTP %d — registry token rejected (missing, expired, or lacks access); re-run `humblskills registry login`", url, status)
+	case 404:
+		if !hasToken {
+			return fmt.Errorf("fetch %s: HTTP %d — not found; if this skill's registry is private, add a token with `humblskills registry login`", url, status)
+		}
+		return fmt.Errorf("fetch %s: HTTP %d — not found; check the registry URL, or re-run `humblskills registry login` if the token is missing, expired, or lacks access", url, status)
+	default:
+		return fmt.Errorf("fetch %s: HTTP %d", url, status)
+	}
 }
 
 func splitRepo(repo string) (owner, name string, err error) {

--- a/cli/internal/registry/auth_test.go
+++ b/cli/internal/registry/auth_test.go
@@ -3,8 +3,22 @@ package registry
 import (
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
+
+// TestHTTPFetchError_ActionableMessages verifies auth failures map to guidance.
+func TestHTTPFetchError_ActionableMessages(t *testing.T) {
+	if err := httpFetchError("u", 401, true); err == nil || !strings.Contains(err.Error(), "registry login") {
+		t.Errorf("401 should mention `registry login`: %v", err)
+	}
+	if err := httpFetchError("u", 404, false); err == nil || !strings.Contains(err.Error(), "private registry") {
+		t.Errorf("404 without token should hint at a private registry: %v", err)
+	}
+	if err := httpFetchError("u", 500, false); err == nil || !strings.Contains(err.Error(), "HTTP 500") {
+		t.Errorf("other codes keep the bare status: %v", err)
+	}
+}
 
 // TestFetch_SendsBearerToken verifies that a configured Token is sent as a
 // Bearer Authorization header on the registry HTTP fetch, so a private registry

--- a/cli/internal/registry/fetcher.go
+++ b/cli/internal/registry/fetcher.go
@@ -186,7 +186,7 @@ func (f *Fetcher) fetchAndCache() (*Registry, error) {
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("fetch %s: HTTP %d", f.URL, resp.StatusCode)
+		return nil, httpFetchError(f.URL, resp.StatusCode, f.Token != "")
 	}
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -249,6 +249,22 @@ func parseRegistry(body []byte) (*Registry, error) {
 		return nil, fmt.Errorf("unsupported registry schema_version %d (expected %d)", r.SchemaVersion, SchemaVersion)
 	}
 	return &r, nil
+}
+
+// httpFetchError turns a non-2xx status into an actionable message, mapping the
+// common private-registry auth failures to next steps instead of a bare code.
+func httpFetchError(url string, status int, hasToken bool) error {
+	switch status {
+	case 401, 403:
+		return fmt.Errorf("fetch %s: HTTP %d — registry token rejected (missing, expired, or lacks access); re-run `humblskills registry login`", url, status)
+	case 404:
+		if !hasToken {
+			return fmt.Errorf("fetch %s: HTTP %d — not found; if this is a private registry, add a token with `humblskills registry login`", url, status)
+		}
+		return fmt.Errorf("fetch %s: HTTP %d — not found; check the registry URL, or re-run `humblskills registry login` if the token is missing, expired, or lacks access", url, status)
+	default:
+		return fmt.Errorf("fetch %s: HTTP %d", url, status)
+	}
 }
 
 func isLocal(u string) bool {

--- a/registry.json
+++ b/registry.json
@@ -1,10 +1,10 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-07-22T01:48:34Z",
+  "generated_at": "2026-07-22T02:05:38Z",
   "source": {
     "repo": "github.com/jjfantini/humblSKILLS",
-    "ref": "main",
-    "sha": "d77d80d66cbd7d80027b172f6af6a286c489e4b6"
+    "ref": "feat/auth-ergonomics",
+    "sha": "75a55a355a9d8a950e351c9a0bb897086821f1e5"
   },
   "skills": [
     {


### PR DESCRIPTION
## PR 2 of 3 — auth ergonomics (QOL)

- **Verify token on `registry login`** — one live fetch confirms the token works; reports "verified: N skills readable" or "verification failed: …". Fails fast on expired / under-scoped / wrong-account tokens. Mirrored in the manager TUI login action.
- **Friendlier auth errors** — HTTP status → guidance: 401/403 "token rejected; re-run registry login"; 404 hints a private registry needs a token / the token may be missing/expired. Applied to both the registry.json and codeload skill fetch, so it surfaces in search/install/update/doctor + TUI.

## Testing
- Full `go test -race ./...` (38 pkgs) + `vet` green; new `httpFetchError` test.
- End-to-end: good token → "verified: N skills readable"; wrong-account token → "verification failed"; friendly fetch errors on bad/no token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)