### PR TITLE
feat(registry): add shorthand, ambiguous-name handling, shell completions

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,17 +129,23 @@ Register several registries and `search`/`browse` show them **together, grouped 
 registry** (each skill tagged with its source). Each registry keeps its own token.
 
 ```sh
-humblskills registry add public https://raw.githubusercontent.com/jjfantini/humblSKILLS/main/registry.json
-humblskills registry add work   https://raw.githubusercontent.com/<org>/<private-repo>/main/registry.json
-humblskills registry add                   # no args → prompts for name, URL, and (optional) token
-humblskills registry login --name work     # token for the private one (keychain)
-humblskills registry list                  # show configured registries + token state
-humblskills registry rename work internal  # rename (moves its stored token too)
-humblskills registry add work <new-url>    # re-add with an existing name to change its URL
-humblskills search                         # grouped: "── public ──" then "── work ──"
-humblskills install <skill>                # resolves to whichever registry has it
-humblskills registry remove work           # drop it (and its stored token)
+# Shorthand: pass owner/repo (or a github.com URL) — it expands to the raw
+# registry.json URL. owner/repo@branch selects a branch.
+humblskills registry add public    jjfantini/humblSKILLS
+humblskills registry add happyrobot happyrobot-ai/happySKILLS
+humblskills registry add                       # no args → prompts for name, URL, and (optional) token
+humblskills registry login --name happyrobot   # token for the private one; verifies it can read the registry
+humblskills registry list                      # show configured registries + token state
+humblskills registry rename happyrobot hr      # rename (moves its stored token too)
+humblskills registry add happyrobot <new-url>  # re-add with an existing name to change its URL
+humblskills search                             # grouped: "── happyrobot ──" then "── public ──"
+humblskills install <skill>                    # resolves to whichever registry has it
+humblskills install <skill> --from public      # disambiguate when a name is in several registries
+humblskills registry remove happyrobot         # drop it (and its stored token)
 ```
+
+Tab-completion (skill names, registry names, `--from`/`--name`) works after installing the
+completion script — e.g. `humblskills completion zsh` (see `humblskills completion --help`).
 
 Run bare **`humblskills registry`** (or the dashboard's **registry** tile) to open the
 interactive **registry manager** — add, rename, login, logout, remove, and refresh from

--- a/cli/cmd/humblskills/install.go
+++ b/cli/cmd/humblskills/install.go
@@ -13,6 +13,7 @@ import (
 	"github.com/jjfantini/humblSKILLS/cli/internal/registry"
 	"github.com/jjfantini/humblSKILLS/cli/internal/textutil"
 	"github.com/jjfantini/humblSKILLS/cli/internal/tui"
+	"github.com/jjfantini/humblSKILLS/cli/internal/ui"
 )
 
 type installFlags struct {
@@ -22,6 +23,7 @@ type installFlags struct {
 	scopeSet     bool
 	force        bool
 	global       bool
+	from         string // registry name to disambiguate a skill present in several
 }
 
 func newInstallCmd(app *App) *cobra.Command {
@@ -46,6 +48,16 @@ func newInstallCmd(app *App) *cobra.Command {
 	cmd.Flags().StringVar(&f.scope, "scope", "", "install scope: global|user|project|adapter-default (default: your profile's default scope, itself global unless changed)")
 	cmd.Flags().BoolVar(&f.force, "force", false, "reinstall even if already up-to-date")
 	cmd.Flags().BoolVar(&f.global, "global", false, "alias for --scope global: install once into ~/.humblskills and symlink to the selected platforms")
+	cmd.Flags().StringVar(&f.from, "from", "", "registry to install from when a skill name exists in more than one")
+	cmd.ValidArgsFunction = func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) != 0 {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+		return app.completeSkillNames(toComplete), cobra.ShellCompDirectiveNoFileComp
+	}
+	_ = cmd.RegisterFlagCompletionFunc("from", func(_ *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return app.completeRegistryNames(toComplete), cobra.ShellCompDirectiveNoFileComp
+	})
 	return cmd
 }
 
@@ -88,11 +100,44 @@ func runInstall(app *App, skill string, f installFlags, fromDashboard bool) erro
 		}
 	}
 
-	// Resolve which registry actually holds the chosen skill so we plan and
-	// fetch against that registry's document (Source) and token.
-	target, ok := findRegistryForSkill(loaded, skill)
-	if !ok {
+	// Resolve which registry holds the chosen skill so we plan and fetch against
+	// that registry's document (Source) and token. When several registries list
+	// the same name, honor --from, else prompt (TUI), else ask for --from.
+	matches := allRegistriesForSkill(loaded, skill)
+	var target registrySkills
+	switch {
+	case len(matches) == 0:
 		return fmt.Errorf("skill %q not found in any configured registry", skill)
+	case len(matches) == 1:
+		target = matches[0]
+	default:
+		picked := ""
+		if f.from != "" {
+			picked = f.from
+		} else if useTUI {
+			opts := make([]ui.SelectOption, 0, len(matches))
+			for _, m := range matches {
+				opts = append(opts, ui.SelectOption{Label: m.Name + "  —  " + m.URL, Value: m.Name})
+			}
+			sel, err := app.Prompt.Select(fmt.Sprintf("%q is in %d registries — install from?", skill, len(matches)), "", opts)
+			if err != nil {
+				return err
+			}
+			picked = sel
+		} else {
+			return fmt.Errorf("skill %q exists in multiple registries (%s) — choose one with --from <registry>", skill, registryNames(matches))
+		}
+		found := false
+		for _, m := range matches {
+			if m.Name == picked {
+				target = m
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("skill %q is not in registry %q (available in: %s)", skill, picked, registryNames(matches))
+		}
 	}
 
 	p, err := profile.Load(app.Config.ProfilePath)

--- a/cli/cmd/humblskills/profile.go
+++ b/cli/cmd/humblskills/profile.go
@@ -189,9 +189,9 @@ func runProfileSet(app *App, key, value string) error {
 		}
 		p.DefaultScope = value
 	case "registry":
-		reg := strings.TrimSpace(value)
+		reg := normalizeRegistryURL(strings.TrimSpace(value))
 		if reg != "" && !isPlausibleRegistry(reg) {
-			return fmt.Errorf("invalid registry %q — expected an http(s):// URL, a file:// URL, or a filesystem path", value)
+			return fmt.Errorf("invalid registry %q — expected owner/repo, a github.com URL, an http(s):// URL, a file:// path, or a filesystem path", value)
 		}
 		p.Registry = reg
 	case "status_auto_return_seconds":

--- a/cli/cmd/humblskills/registries.go
+++ b/cli/cmd/humblskills/registries.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"net/url"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -12,6 +13,61 @@ import (
 	"github.com/jjfantini/humblSKILLS/cli/internal/secrets"
 	"github.com/jjfantini/humblSKILLS/cli/internal/textutil"
 )
+
+// normalizeRegistryURL expands convenient shorthands into a raw registry.json
+// URL: `owner/repo` (optionally `owner/repo@branch`), a github.com repo URL
+// (optionally .../tree/<branch>). A full URL, file:// path, or anything ending
+// in .json is returned unchanged.
+func normalizeRegistryURL(in string) string {
+	s := strings.TrimSpace(in)
+	if s == "" || strings.HasPrefix(s, "file://") || strings.HasSuffix(s, ".json") {
+		return s
+	}
+	if strings.HasPrefix(s, "http://") || strings.HasPrefix(s, "https://") {
+		if owner, repo, branch, ok := parseGitHubRepoURL(s); ok {
+			return rawRegistryURL(owner, repo, branch)
+		}
+		return s
+	}
+	if owner, repo, branch, ok := parseOwnerRepo(s); ok {
+		return rawRegistryURL(owner, repo, branch)
+	}
+	return s
+}
+
+func rawRegistryURL(owner, repo, branch string) string {
+	if branch == "" {
+		branch = "main"
+	}
+	return fmt.Sprintf("https://raw.githubusercontent.com/%s/%s/%s/registry.json", owner, repo, branch)
+}
+
+func parseOwnerRepo(s string) (owner, repo, branch string, ok bool) {
+	if i := strings.Index(s, "@"); i >= 0 {
+		branch = s[i+1:]
+		s = s[:i]
+	}
+	parts := strings.Split(s, "/")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", "", false
+	}
+	return parts[0], strings.TrimSuffix(parts[1], ".git"), branch, true
+}
+
+func parseGitHubRepoURL(s string) (owner, repo, branch string, ok bool) {
+	u, err := url.Parse(s)
+	if err != nil || u.Host != "github.com" {
+		return "", "", "", false
+	}
+	parts := strings.Split(strings.Trim(u.Path, "/"), "/")
+	if len(parts) < 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", "", false
+	}
+	if len(parts) >= 4 && parts[2] == "tree" {
+		branch = parts[3]
+	}
+	return parts[0], strings.TrimSuffix(parts[1], ".git"), branch, true
+}
 
 // resolvedRegistry is one registry the CLI will read, with its auth token
 // already resolved.
@@ -116,18 +172,6 @@ func (a *App) loadRegistries() []registrySkills {
 func mergedRegistry(loaded []registrySkills) *registry.Registry {
 	skills, _ := aggregateSkills(loaded)
 	return &registry.Registry{SchemaVersion: registry.SchemaVersion, Skills: skills}
-}
-
-// findRegistryForSkill returns the loaded registry that contains skillName.
-func findRegistryForSkill(loaded []registrySkills, skillName string) (registrySkills, bool) {
-	for _, rs := range loaded {
-		for _, s := range rs.Skills {
-			if s.Name == skillName {
-				return rs, true
-			}
-		}
-	}
-	return registrySkills{}, false
 }
 
 // verifyRegistryToken does one network fetch of a registry with the given token
@@ -262,6 +306,60 @@ func indexLoadedRegistries(loaded []registrySkills) skillIndex {
 		}
 	}
 	return ix
+}
+
+// completeSkillNames returns skill names (from the offline cache) matching the
+// given prefix — used for shell tab-completion of `install <skill>`.
+func (a *App) completeSkillNames(prefix string) []string {
+	ix := a.cachedSkillIndex()
+	var out []string
+	for name := range ix.global {
+		if prefix == "" || strings.HasPrefix(name, prefix) {
+			out = append(out, name)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// completeRegistryNames returns configured registry names matching prefix —
+// used for tab-completion of registry subcommands and `install --from`.
+func (a *App) completeRegistryNames(prefix string) []string {
+	p, err := profile.Load(a.Config.ProfilePath)
+	if err != nil || p == nil {
+		return nil
+	}
+	var out []string
+	for _, r := range p.Registries {
+		if prefix == "" || strings.HasPrefix(r.Name, prefix) {
+			out = append(out, r.Name)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// allRegistriesForSkill returns every loaded registry that lists skillName.
+func allRegistriesForSkill(loaded []registrySkills, skillName string) []registrySkills {
+	var out []registrySkills
+	for _, rs := range loaded {
+		for _, s := range rs.Skills {
+			if s.Name == skillName {
+				out = append(out, rs)
+				break
+			}
+		}
+	}
+	return out
+}
+
+// registryNames joins the names of the given registries for messages.
+func registryNames(rs []registrySkills) string {
+	names := make([]string, len(rs))
+	for i := range rs {
+		names[i] = rs[i].Name
+	}
+	return strings.Join(names, ", ")
 }
 
 // installEngineForToken builds an install Engine whose tarball fetcher carries

--- a/cli/cmd/humblskills/registries_test.go
+++ b/cli/cmd/humblskills/registries_test.go
@@ -35,6 +35,25 @@ func TestSkillIndex_FindAndRegistryOf(t *testing.T) {
 	}
 }
 
+func TestNormalizeRegistryURL(t *testing.T) {
+	cases := map[string]string{
+		// owner/repo shorthand → raw main registry.json
+		"happyrobot-ai/happySKILLS":        "https://raw.githubusercontent.com/happyrobot-ai/happySKILLS/main/registry.json",
+		"happyrobot-ai/happySKILLS@dev":    "https://raw.githubusercontent.com/happyrobot-ai/happySKILLS/dev/registry.json",
+		"https://github.com/o/r":           "https://raw.githubusercontent.com/o/r/main/registry.json",
+		"https://github.com/o/r/tree/next": "https://raw.githubusercontent.com/o/r/next/registry.json",
+		// already-concrete locations are untouched
+		"https://raw.githubusercontent.com/o/r/main/registry.json": "https://raw.githubusercontent.com/o/r/main/registry.json",
+		"file:///tmp/registry.json":                                "file:///tmp/registry.json",
+		"./local/registry.json":                                    "./local/registry.json",
+	}
+	for in, want := range cases {
+		if got := normalizeRegistryURL(in); got != want {
+			t.Errorf("normalizeRegistryURL(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
 func TestSanitizeRegistryName(t *testing.T) {
 	cases := map[string]string{
 		"work":        "work",

--- a/cli/cmd/humblskills/registry.go
+++ b/cli/cmd/humblskills/registry.go
@@ -72,6 +72,12 @@ func newRegistryRenameCmd(app *App) *cobra.Command {
 		Use:   "rename <old> <new>",
 		Short: "Rename a registry (moves its stored token too)",
 		Args:  cobra.ExactArgs(2),
+		ValidArgsFunction: func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			if len(args) == 0 {
+				return app.completeRegistryNames(toComplete), cobra.ShellCompDirectiveNoFileComp
+			}
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runRegistryRename(app, args[0], args[1])
 		},
@@ -94,6 +100,12 @@ func newRegistryRemoveCmd(app *App) *cobra.Command {
 		Aliases: []string{"rm"},
 		Short:   "Remove a named registry (and its stored token)",
 		Args:    cobra.ExactArgs(1),
+		ValidArgsFunction: func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			if len(args) != 0 {
+				return nil, cobra.ShellCompDirectiveNoFileComp
+			}
+			return app.completeRegistryNames(toComplete), cobra.ShellCompDirectiveNoFileComp
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runRegistryRemove(app, args[0])
 		},
@@ -104,7 +116,8 @@ func newRegistryRemoveCmd(app *App) *cobra.Command {
 // and interactive add paths.
 func addRegistry(app *App, name, url string) (string, string, error) {
 	name = strings.TrimSpace(name)
-	url = strings.TrimSpace(url)
+	// Expand shorthands (owner/repo, github.com URLs) into a raw registry.json URL.
+	url = normalizeRegistryURL(strings.TrimSpace(url))
 	if name == "" {
 		return "", "", fmt.Errorf("registry name must not be empty")
 	}
@@ -247,6 +260,9 @@ func newRegistryLoginCmd(app *App) *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&name, "name", "", "named registry to attach the token to (default: the single/default token)")
+	_ = cmd.RegisterFlagCompletionFunc("name", func(_ *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return app.completeRegistryNames(toComplete), cobra.ShellCompDirectiveNoFileComp
+	})
 	return cmd
 }
 
@@ -271,6 +287,9 @@ func newRegistryLogoutCmd(app *App) *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&name, "name", "", "named registry whose token to remove (default: the single/default token)")
+	_ = cmd.RegisterFlagCompletionFunc("name", func(_ *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return app.completeRegistryNames(toComplete), cobra.ShellCompDirectiveNoFileComp
+	})
 	return cmd
 }
 


### PR DESCRIPTION
## PR 3 of 3 — entry & discovery (QOL)

- **`registry add` shorthand** — `owner/repo` (or `owner/repo@branch`) and github.com URLs expand to the raw registry.json URL. Applied to `registry add` (direct/interactive/manager) and `profile set registry`.
- **Ambiguous-name install** — `install <skill>` with a name in multiple registries: `--from <registry>` picks one; on a TTY it prompts; non-interactive it errors with the options (no silent first-wins).
- **Shell completions** — `install` completes skill names; `install --from`, `registry remove/rename`, `registry login/logout --name` complete registry names (cobra's `completion` script was already built in).

## Testing
- Full `go test -race ./...` (38 pkgs) + `vet` green; new `normalizeRegistryURL` tests.
- End-to-end: shorthand expansion (`owner/repo` → raw URL), ambiguity error + `--from`, skill/registry name completions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)