### PR TITLE
fix(tui): wrap multi-registry loads in a spinner to stop the screen flash

### DIFF
--- a/cli/cmd/humblskills/list.go
+++ b/cli/cmd/humblskills/list.go
@@ -197,8 +197,16 @@ func runListTUI(app *App, m *manifest.Manifest, fromDashboard bool) error {
 	// Resolve each installed skill against its ORIGIN registry (across all
 	// configured registries) so drift + metadata are correct and the browser
 	// can group installs by source registry. Unreachable registries fall back
-	// to manifest versions.
-	ix := indexLoadedRegistries(app.loadRegistries())
+	// to manifest versions. Wrapped in a loading spinner so the (possibly
+	// multi-registry, networked) load runs inside the alt-screen rather than on
+	// the exposed terminal between programs (which shows as a flash).
+	useTUI := tui.ShouldUseTUI(app.Config.JSON, app.Config.Quiet, app.Config.Yes)
+	ix, err := tui.RunWithLoadingIf(useTUI, app.UI.Theme(), "loading registries…", func() (skillIndex, error) {
+		return indexLoadedRegistries(app.loadRegistries()), nil
+	})
+	if err != nil {
+		return err
+	}
 
 	installedSkills := uniqueSkillsFromManifest(m)
 	skills := make([]registry.Skill, 0, len(installedSkills))

--- a/cli/cmd/humblskills/registry_manager.go
+++ b/cli/cmd/humblskills/registry_manager.go
@@ -155,7 +155,11 @@ func runRegistryManager(app *App) error {
 				}
 			}
 		case "refresh":
-			if err := refreshAllRegistries(app); err != nil {
+			// Run inside a spinner so the network refresh happens in the
+			// alt-screen, not on the exposed terminal between list renders.
+			if _, err := tui.RunWithLoading(app.UI.Theme(), "refreshing registries…", func() (int, error) {
+				return 0, refreshAllRegistries(app)
+			}); err != nil {
 				return err
 			}
 		}

--- a/cli/cmd/humblskills/search.go
+++ b/cli/cmd/humblskills/search.go
@@ -31,7 +31,17 @@ func newSearchCmd(app *App) *cobra.Command {
 				return fmt.Errorf("unknown --category %q (must be one of %s)", category, strings.Join(frontmatter.Categories, ", "))
 			}
 
-			loaded := app.loadRegistries()
+			query := ""
+			if len(args) == 1 {
+				query = strings.ToLower(args[0])
+			}
+			// With no query on a TTY we'll open the browser; run the (possibly
+			// multi-registry, networked) load inside a spinner so it doesn't
+			// execute on the exposed terminal between programs (a visible flash).
+			willBrowse := query == "" && tui.ShouldUseTUI(app.Config.JSON, app.Config.Quiet, app.Config.Yes)
+			loaded, _ := tui.RunWithLoadingIf(willBrowse, app.UI.Theme(), "loading registries…", func() ([]registrySkills, error) {
+				return app.loadRegistries(), nil
+			})
 			all, loadErrs := aggregateSkills(loaded)
 			// A failed registry is reported but doesn't abort the others; only
 			// error out if every registry failed and nothing loaded.
@@ -49,11 +59,6 @@ func newSearchCmd(app *App) *cobra.Command {
 					}
 				}
 			}
-			query := ""
-			if len(args) == 1 {
-				query = strings.ToLower(args[0])
-			}
-
 			// all is already sorted by (registry, name); filtering preserves
 			// that grouped order.
 			var hits []registry.Skill

--- a/cli/cmd/humblskills/start.go
+++ b/cli/cmd/humblskills/start.go
@@ -159,12 +159,9 @@ func dispatchDashboardCommand(app *App, cmd string) error {
 	case "upgrade":
 		return runUpgrade(app, upgradeFlags{})
 	case "search":
-		hits, err := tui.RunWithLoading(app.UI.Theme(), "loading registry…", func() ([]registry.Skill, error) {
-			reg, _, err := app.registryFetcher().Load()
-			if err != nil {
-				return nil, err
-			}
-			return append([]registry.Skill(nil), reg.Skills...), nil
+		hits, err := tui.RunWithLoading(app.UI.Theme(), "loading registries…", func() ([]registry.Skill, error) {
+			all, _ := aggregateSkills(app.loadRegistries())
+			return all, nil
 		})
 		if err != nil {
 			return err


### PR DESCRIPTION
## Fix — terminal flash between screens (perf regression)

**Diagnosis:** the multi-registry work made `list` and `search` load every configured registry (networked, per-registry caches). Those loads ran on the **exposed terminal between programs** (dashboard → browser), which shows as a flash back to the shell — exactly what `loadingModel` documents. `install`/`update`/`doctor` already wrap their loads; `list`/`search` didn't.

**Fix:**
- `runListTUI`: wrap `indexLoadedRegistries(loadRegistries())` in `RunWithLoadingIf`.
- `search`: parse query first, then wrap `loadRegistries` in a spinner only when the browser will open (static/JSON stays spinner-free).
- dashboard `search`: aggregate across registries (was single) inside its existing spinner — also fixes grouped search from the dashboard.
- registry manager: run `refresh` inside a spinner.

## Testing
- Full `go test -race ./...` (38 pkgs) + `vet` green; non-TTY `search`/`list` paths verified unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)