### PR TITLE
feat(tui): single-program router foundation (stage 1, opt-in) — fixes inter-pane flash

### DIFF
--- a/cli/cmd/humblskills/main.go
+++ b/cli/cmd/humblskills/main.go
@@ -5,10 +5,17 @@ package main
 import (
 	"fmt"
 	"os"
+
+	"github.com/jjfantini/humblSKILLS/cli/internal/tui"
 )
 
 func main() {
-	if err := newRootCmd().Execute(); err != nil {
+	err := newRootCmd().Execute()
+	// Tear down the interactive session program (if the router started one) and
+	// restore the terminal on every path — os.Exit below skips defers, so this
+	// runs explicitly first.
+	tui.Shutdown()
+	if err != nil {
 		fmt.Fprintln(os.Stderr, "humblskills:", err)
 		os.Exit(1)
 	}

--- a/cli/cmd/humblskills/profile.go
+++ b/cli/cmd/humblskills/profile.go
@@ -47,7 +47,8 @@ func newProfileSetCmd(app *App) *cobra.Command {
 	return &cobra.Command{
 		Use: "set <key> <value>",
 		Short: "Set a profile value. Keys: platforms (csv), scope (global|user|project|adapter-default), " +
-			"registry (URL/file:// path, or \"\" to clear), status_auto_return_seconds (seconds, or default|off).",
+			"registry (URL/file:// path, or \"\" to clear), status_auto_return_seconds (seconds, or default|off), " +
+			"tui_router (on|off — experimental single-program TUI, no flash between panes).",
 		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runProfileSet(app, args[0], args[1])
@@ -146,6 +147,8 @@ func runProfileShow(app *App) error {
 		th.KVValue.Render(formatRegistry(p.Registry)))
 	fmt.Fprintln(app.UI.Out(), "  "+th.KVKey.Render("auto-return")+"  "+
 		th.KVValue.Render(formatAutoReturn(p.StatusAutoReturnSeconds)))
+	fmt.Fprintln(app.UI.Out(), "  "+th.KVKey.Render("tui-router")+"   "+
+		th.KVValue.Render(formatTUIRouter(p.TUIRouter)))
 	fmt.Fprintln(app.UI.Out(), "  "+th.KVKey.Render("path")+"         "+
 		th.KVValue.Render(app.Config.ProfilePath))
 
@@ -200,8 +203,14 @@ func runProfileSet(app *App, key, value string) error {
 			return err
 		}
 		p.StatusAutoReturnSeconds = seconds
+	case "tui_router":
+		on, err := parseTUIRouter(value)
+		if err != nil {
+			return err
+		}
+		p.TUIRouter = on
 	default:
-		return fmt.Errorf("unknown key %q — valid keys: platforms, scope, registry, status_auto_return_seconds", key)
+		return fmt.Errorf("unknown key %q — valid keys: platforms, scope, registry, status_auto_return_seconds, tui_router", key)
 	}
 
 	if err := profile.Save(app.Config.ProfilePath, p); err != nil {
@@ -299,6 +308,25 @@ func formatAutoReturn(seconds *int) string {
 	default:
 		return fmt.Sprintf("%ds", *seconds)
 	}
+}
+
+// parseTUIRouter parses the `profile set tui_router` value.
+func parseTUIRouter(value string) (bool, error) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "on", "true", "1":
+		return true, nil
+	case "off", "false", "0", "default", "":
+		return false, nil
+	}
+	return false, fmt.Errorf("invalid tui_router %q — expected on or off", value)
+}
+
+// formatTUIRouter renders Profile.TUIRouter for `profile show`.
+func formatTUIRouter(on bool) string {
+	if on {
+		return "on — experimental single-program TUI"
+	}
+	return "off (default)"
 }
 
 // formatRegistry renders Profile.Registry for `profile show`.

--- a/cli/cmd/humblskills/root.go
+++ b/cli/cmd/humblskills/root.go
@@ -173,6 +173,7 @@ func configureApp(_ *cobra.Command, app *App, g globalFlags) error {
 	var profileRegistry string
 	if p, perr := profile.Load(profilePath); perr == nil && p != nil {
 		profileRegistry = p.Registry
+		tui.SetRouterPreference(p.TUIRouter)
 	}
 
 	cfg := Config{

--- a/cli/internal/profile/profile.go
+++ b/cli/internal/profile/profile.go
@@ -59,6 +59,13 @@ type Profile struct {
 	// positive value is the number of seconds to wait. Only success
 	// screens auto-return - a failed run always waits for the user.
 	StatusAutoReturnSeconds *int `json:"status_auto_return_seconds,omitempty"`
+
+	// TUIRouter opts the interactive TUI into the experimental single-program
+	// router: every screen runs on one long-lived program so the alt-screen
+	// isn't torn down between panes (no flash). Off by default. The
+	// HUMBLSKILLS_TUI_ROUTER env var ("1" on, anything else off) overrides
+	// this when set.
+	TUIRouter bool `json:"tui_router,omitempty"`
 }
 
 // NamedRegistry is one entry in the multi-registry set (Profile.Registries).

--- a/cli/internal/profile/profile_test.go
+++ b/cli/internal/profile/profile_test.go
@@ -37,6 +37,7 @@ func TestSave_WritesAtomicallyAndRoundTrips(t *testing.T) {
 	in := &profile.Profile{
 		DefaultPlatforms: []string{"claude-code", "cursor"},
 		DefaultScope:     "project",
+		TUIRouter:        true,
 		Eval: &profile.EvalProfile{
 			Runner:                 "anthropic-api",
 			ExecutorModel:          "claude-sonnet-4-6",
@@ -68,6 +69,9 @@ func TestSave_WritesAtomicallyAndRoundTrips(t *testing.T) {
 	}
 	if out.Eval == nil || out.Eval.Runner != "anthropic-api" {
 		t.Errorf("Eval lost in round-trip: %+v", out.Eval)
+	}
+	if !out.TUIRouter {
+		t.Error("TUIRouter not round-tripped")
 	}
 	if !out.Eval.IncludeBlindComparator {
 		t.Error("IncludeBlindComparator not round-tripped")

--- a/cli/internal/tui/app.go
+++ b/cli/internal/tui/app.go
@@ -30,6 +30,11 @@ func ShouldUseTUI(jsonMode, quiet, yes bool) bool {
 // (alt-screen + mouse cell motion). It blocks until the model finishes and
 // returns the last rendered model so callers can extract results.
 func Run(m tea.Model) (tea.Model, error) {
+	// Opt-in single-program router: run every screen on one long-lived program
+	// so the alt-screen isn't torn down between panes (no flash). Off by default.
+	if RouterEnabled() {
+		return runOnSession(m)
+	}
 	p := tea.NewProgram(m, tea.WithAltScreen(), tea.WithMouseCellMotion())
 	return p.Run()
 }

--- a/cli/internal/tui/profile.go
+++ b/cli/internal/tui/profile.go
@@ -233,6 +233,11 @@ func (m profileModel) toggleCurrent() profileModel {
 			m.profile.StatusAutoReturnSeconds = autoReturnSettingOpts[m.valueIdx].value
 			m.changed = true
 		}
+	case 3: // tui router
+		if m.valueIdx >= 0 && m.valueIdx < len(tuiRouterSettingOpts) {
+			m.profile.TUIRouter = tuiRouterSettingOpts[m.valueIdx].value
+			m.changed = true
+		}
 	}
 	return m
 }
@@ -266,6 +271,16 @@ var autoReturnSettingOpts = []struct {
 
 func intPtr(n int) *int { return &n }
 
+// tuiRouterSettingOpts is the picker for Profile.TUIRouter — the experimental
+// single-program TUI router (no alt-screen teardown between panes).
+var tuiRouterSettingOpts = []struct {
+	label string
+	value bool
+}{
+	{"off (default)", false},
+	{"on — experimental, no flash between panes", true},
+}
+
 // currentSelectionIndex returns the index in the right-pane options list that
 // represents the profile's current value for the focused setting. Used to
 // place the cursor on the already-selected option when the user drills in.
@@ -284,6 +299,12 @@ func (m profileModel) currentSelectionIndex() int {
 		cur := m.profile.StatusAutoReturnSeconds
 		for i, opt := range autoReturnSettingOpts {
 			if autoReturnValueEqual(cur, opt.value) {
+				return i
+			}
+		}
+	case 3:
+		for i, opt := range tuiRouterSettingOpts {
+			if opt.value == m.profile.TUIRouter {
 				return i
 			}
 		}
@@ -309,6 +330,8 @@ func (m profileModel) valueCount() int {
 		return len(scopeSettingOpts)
 	case 2:
 		return len(autoReturnSettingOpts)
+	case 3:
+		return len(tuiRouterSettingOpts)
 	}
 	return 0
 }
@@ -332,6 +355,7 @@ var profileSettings = []profileSetting{
 	{key: "platforms", label: "default platforms", kind: settingMulti},
 	{key: "scope", label: "default scope", kind: settingRadio},
 	{key: "status_auto_return", label: "status auto-return", kind: settingRadio},
+	{key: "tui_router", label: "tui router", kind: settingRadio},
 }
 
 func (m profileModel) View() string {
@@ -460,6 +484,8 @@ func (m profileModel) renderRight(width int) string {
 		body = append(body, m.renderScopeOptions(bar, width)...)
 	case 2:
 		body = append(body, m.renderAutoReturnOptions(bar, width)...)
+	case 3:
+		body = append(body, m.renderTUIRouterOptions(bar, width)...)
 	}
 	return strings.Join(body, "\n")
 }
@@ -586,6 +612,43 @@ func (m profileModel) renderAutoReturnOptions(bar string, width int) []string {
 	return rows
 }
 
+// renderTUIRouterOptions renders the Profile.TUIRouter picker: whether the
+// interactive TUI runs every screen on one long-lived program (experimental).
+func (m profileModel) renderTUIRouterOptions(bar string, width int) []string {
+	th := m.theme
+	rows := make([]string, 0, len(tuiRouterSettingOpts)+4)
+	rows = append(rows, bar+" "+th.Detail.Render(
+		"Experimental: run every TUI screen on one long-lived program so the "+
+			"alt-screen isn't torn down between panes — no flash when navigating. "+
+			"The HUMBLSKILLS_TUI_ROUTER env var (1/0) overrides this when set."))
+	rows = append(rows, bar)
+	rows = append(rows, bar+" "+th.SectionTitle.Render("OPTIONS"))
+	for i, opt := range tuiRouterSettingOpts {
+		cursorHere := i == m.valueIdx && m.focus == focusValue
+		isCurrent := opt.value == m.profile.TUIRouter
+		marker := "( )"
+		if isCurrent {
+			marker = "(●)"
+		}
+		var styled string
+		switch {
+		case cursorHere:
+			styled = th.RowSelected.Render(marker + "  " + opt.label)
+		case isCurrent:
+			styled = th.Success.Render(marker) + "  " + th.RowUnselected.Render(opt.label)
+		default:
+			styled = th.RowDim.Render(marker) + "  " + th.RowUnselected.Render(opt.label)
+		}
+		prefix := bar + "   "
+		if cursorHere {
+			prefix = bar + " " + th.Bullet.Render("▸") + " "
+		}
+		rows = append(rows, prefix+styled)
+	}
+	_ = width
+	return rows
+}
+
 func (m profileModel) layoutRow(label, badge string, width int) string {
 	lw := lipgloss.Width(label)
 	bw := lipgloss.Width(badge)
@@ -618,6 +681,11 @@ func (m profileModel) settingBadge(key string) string {
 		}
 	case "status_auto_return":
 		return formatAutoReturnBadge(m.profile.StatusAutoReturnSeconds)
+	case "tui_router":
+		if m.profile.TUIRouter {
+			return "on (experimental)"
+		}
+		return "off (default)"
 	}
 	return ""
 }

--- a/cli/internal/tui/session.go
+++ b/cli/internal/tui/session.go
@@ -21,8 +21,22 @@ import (
 // programs that can't share the host's terminal, so RunGuard releases/restores
 // the host terminal around them (a flash at prompt time only, not navigation).
 
-// RouterEnabled reports whether the single-program router is turned on.
-func RouterEnabled() bool { return os.Getenv("HUMBLSKILLS_TUI_ROUTER") == "1" }
+// routerPref is the profile-backed default (Profile.TUIRouter), wired in from
+// root setup before any command runs. The env var overrides it when set.
+var routerPref bool
+
+// SetRouterPreference records the profile's tui_router setting.
+func SetRouterPreference(on bool) { routerPref = on }
+
+// RouterEnabled reports whether the single-program router is turned on:
+// HUMBLSKILLS_TUI_ROUTER ("1" on, anything else off) when set, otherwise the
+// profile's tui_router setting, otherwise off.
+func RouterEnabled() bool {
+	if v, ok := os.LookupEnv("HUMBLSKILLS_TUI_ROUTER"); ok {
+		return v == "1"
+	}
+	return routerPref
+}
 
 // --- messages driving the host --------------------------------------------
 

--- a/cli/internal/tui/session.go
+++ b/cli/internal/tui/session.go
@@ -1,0 +1,168 @@
+package tui
+
+import (
+	"os"
+	"sync"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/jjfantini/humblSKILLS/cli/internal/ui"
+)
+
+// This file implements the experimental single-program TUI "router". Normally
+// every screen is its own tea.Program (its own alt-screen), so moving between
+// panes tears the alternate-screen buffer down and back up — a visible flash to
+// the shell. The router instead runs ONE long-lived program for the whole
+// interactive session and swaps the active screen model in place, so the
+// alt-screen is entered once and never torn down between panes.
+//
+// It's opt-in (HUMBLSKILLS_TUI_ROUTER=1) while it's verified in real terminals;
+// with it off, Run behaves exactly as before. Prompts (huh) are separate
+// programs that can't share the host's terminal, so RunGuard releases/restores
+// the host terminal around them (a flash at prompt time only, not navigation).
+
+// RouterEnabled reports whether the single-program router is turned on.
+func RouterEnabled() bool { return os.Getenv("HUMBLSKILLS_TUI_ROUTER") == "1" }
+
+// --- messages driving the host --------------------------------------------
+
+type activateMsg struct {
+	model tea.Model
+	done  chan tea.Model
+}
+type shutdownMsg struct{}
+type childDoneMsg struct{ final tea.Model }
+
+// sessionModel is the host: it renders and forwards messages to whichever
+// screen model is currently active, and converts a screen's tea.Quit into a
+// "child done" signal (returning that screen's final state to the caller)
+// instead of quitting the whole program.
+type sessionModel struct {
+	active tea.Model
+	size   tea.WindowSizeMsg
+	done   chan tea.Model
+}
+
+func (m sessionModel) Init() tea.Cmd { return nil }
+
+func (m sessionModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case activateMsg:
+		m.active = msg.model
+		m.done = msg.done
+		cmd := m.active.Init()
+		if m.size.Width > 0 { // give the new screen its size immediately
+			var c2 tea.Cmd
+			m.active, c2 = m.active.Update(m.size)
+			cmd = tea.Batch(cmd, c2)
+		}
+		return m, cmd
+	case childDoneMsg:
+		if m.done != nil {
+			m.done <- msg.final
+			m.done = nil
+		}
+		m.active = msg.final // keep the last frame until the next screen activates
+		return m, nil
+	case shutdownMsg:
+		return m, tea.Quit
+	case tea.WindowSizeMsg:
+		m.size = msg // record, then fall through to forward to the active screen
+	}
+	if m.active != nil {
+		updated, cmd := m.active.Update(msg)
+		m.active = updated
+		return m, trapQuit(cmd, updated)
+	}
+	return m, nil
+}
+
+func (m sessionModel) View() string {
+	if m.active != nil {
+		return m.active.View()
+	}
+	return ""
+}
+
+// trapQuit wraps a child's command so a tea.Quit it emits becomes a childDoneMsg
+// (ending just that screen) rather than a QuitMsg (which would end the whole
+// session program). Only standalone quits are trapped — every screen model in
+// this codebase quits standalone.
+func trapQuit(cmd tea.Cmd, final tea.Model) tea.Cmd {
+	if cmd == nil {
+		return nil
+	}
+	return func() tea.Msg {
+		msg := cmd()
+		if _, ok := msg.(tea.QuitMsg); ok {
+			return childDoneMsg{final: final}
+		}
+		return msg
+	}
+}
+
+// --- session lifecycle -----------------------------------------------------
+
+var (
+	sessMu   sync.Mutex
+	sessProg *tea.Program
+	sessWG   sync.WaitGroup
+)
+
+func ensureSession() *tea.Program {
+	sessMu.Lock()
+	defer sessMu.Unlock()
+	if sessProg != nil {
+		return sessProg
+	}
+	ui.RunGuard = PauseForPrompt // route prompts through terminal release/restore
+	p := tea.NewProgram(sessionModel{}, tea.WithAltScreen(), tea.WithMouseCellMotion())
+	sessProg = p
+	sessWG.Add(1)
+	go func() {
+		defer sessWG.Done()
+		_, _ = p.Run()
+		sessMu.Lock()
+		sessProg = nil
+		sessMu.Unlock()
+	}()
+	return p
+}
+
+// runOnSession activates a screen model on the shared session program and blocks
+// until that screen finishes, returning its final model (mirrors Run's contract).
+func runOnSession(m tea.Model) (tea.Model, error) {
+	p := ensureSession()
+	done := make(chan tea.Model, 1)
+	p.Send(activateMsg{model: m, done: done})
+	return <-done, nil
+}
+
+// Shutdown ends the interactive session program, restoring the terminal. Safe to
+// call when no session is running (no-op). Call it once when the process is done
+// with interactive work (wired via a defer around command execution).
+func Shutdown() {
+	sessMu.Lock()
+	p := sessProg
+	sessMu.Unlock()
+	if p == nil {
+		return
+	}
+	p.Send(shutdownMsg{})
+	sessWG.Wait()
+	ui.RunGuard = func(fn func() error) error { return fn() }
+}
+
+// PauseForPrompt releases the session's terminal so a separate prompt program
+// (huh) can run, then restores it. No-op when no session is active.
+func PauseForPrompt(fn func() error) error {
+	sessMu.Lock()
+	p := sessProg
+	sessMu.Unlock()
+	if p == nil {
+		return fn()
+	}
+	p.ReleaseTerminal()
+	defer p.RestoreTerminal()
+	return fn()
+}

--- a/cli/internal/tui/session_test.go
+++ b/cli/internal/tui/session_test.go
@@ -1,0 +1,42 @@
+package tui
+
+import (
+	"os"
+	"testing"
+)
+
+// RouterEnabled precedence: the env var (when set) always wins — "1" on,
+// anything else off — and the profile preference only applies when it's unset.
+func TestRouterEnabled_Precedence(t *testing.T) {
+	restore := routerPref
+	defer SetRouterPreference(restore)
+
+	cases := []struct {
+		name string
+		env  *string // nil = unset
+		pref bool
+		want bool
+	}{
+		{"unset env, pref off", nil, false, false},
+		{"unset env, pref on", nil, true, true},
+		{"env 1 overrides pref off", strPtr("1"), false, true},
+		{"env 0 overrides pref on", strPtr("0"), true, false},
+		{"env empty overrides pref on", strPtr(""), true, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("HUMBLSKILLS_TUI_ROUTER", "") // registers restore of the real value
+			if tc.env != nil {
+				os.Setenv("HUMBLSKILLS_TUI_ROUTER", *tc.env)
+			} else {
+				os.Unsetenv("HUMBLSKILLS_TUI_ROUTER")
+			}
+			SetRouterPreference(tc.pref)
+			if got := RouterEnabled(); got != tc.want {
+				t.Errorf("RouterEnabled() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func strPtr(s string) *string { return &s }

--- a/cli/internal/ui/prompt.go
+++ b/cli/internal/ui/prompt.go
@@ -44,6 +44,17 @@ func NewPrompter(yes bool) *Prompter {
 // internally.
 func theme() *huh.Theme { return HuhTheme(DefaultTheme()) }
 
+// RunGuard, when set by a host TUI program, wraps every interactive prompt so
+// the host can release/restore the terminal around it — a prompt is its own
+// bubbletea program and can't share a running host program's terminal. Defaults
+// to calling fn directly (no host = no-op), so non-router callers are unaffected.
+var RunGuard = func(fn func() error) error { return fn() }
+
+type huhRunner interface{ Run() error }
+
+// guard runs a huh field/form through RunGuard.
+func guard(r huhRunner) error { return RunGuard(func() error { return r.Run() }) }
+
 // Confirm asks a yes/no question. When non-interactive, returns dflt.
 func (p *Prompter) Confirm(title string, dflt bool) (bool, error) {
 	if p.Yes {
@@ -53,13 +64,12 @@ func (p *Prompter) Confirm(title string, dflt bool) (bool, error) {
 		return dflt, nil
 	}
 	v := dflt
-	err := huh.NewConfirm().
+	err := guard(huh.NewConfirm().
 		Title(title).
 		Affirmative("Yes").
 		Negative("No").
 		Value(&v).
-		WithTheme(theme()).
-		Run()
+		WithTheme(theme()))
 	if err != nil {
 		return dflt, err
 	}
@@ -101,12 +111,11 @@ func (p *Prompter) MultiSelect(title string, options []MultiSelectOption) ([]str
 		opts = append(opts, huh.NewOption(label, o.Value).Selected(o.Selected))
 	}
 	var selected []string
-	err := huh.NewMultiSelect[string]().
+	err := guard(huh.NewMultiSelect[string]().
 		Title(title).
 		Options(opts...).
 		Value(&selected).
-		WithTheme(theme()).
-		Run()
+		WithTheme(theme()))
 	if err != nil {
 		return nil, fmt.Errorf("prompt: %w", err)
 	}
@@ -121,12 +130,11 @@ func (p *Prompter) Secret(title string) (string, error) {
 		return "", ErrNonInteractive
 	}
 	var v string
-	err := huh.NewInput().
+	err := guard(huh.NewInput().
 		Title(title).
 		EchoMode(huh.EchoModePassword).
 		Value(&v).
-		WithTheme(theme()).
-		Run()
+		WithTheme(theme()))
 	if err != nil {
 		return "", fmt.Errorf("prompt: %w", err)
 	}
@@ -144,7 +152,7 @@ func (p *Prompter) Text(title, placeholder string) (string, error) {
 	if placeholder != "" {
 		in = in.Placeholder(placeholder)
 	}
-	if err := in.WithTheme(theme()).Run(); err != nil {
+	if err := guard(in.WithTheme(theme())); err != nil {
 		return "", fmt.Errorf("prompt: %w", err)
 	}
 	return v, nil
@@ -192,7 +200,7 @@ func (p *Prompter) Select(title, description string, options []SelectOption) (st
 	if description != "" {
 		sel = sel.Description(description)
 	}
-	if err := sel.WithTheme(theme()).Run(); err != nil {
+	if err := guard(sel.WithTheme(theme())); err != nil {
 		return "", fmt.Errorf("prompt: %w", err)
 	}
 	return picked, nil

--- a/registry.json
+++ b/registry.json
@@ -1,10 +1,10 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-07-22T04:11:13Z",
+  "generated_at": "2026-07-23T15:37:42Z",
   "source": {
     "repo": "github.com/jjfantini/humblSKILLS",
     "ref": "feat/tui-router-foundation",
-    "sha": "2ce51d7b40977a2312f5fc5ab52e8b3310a7f6d2"
+    "sha": "031315abef8f76fa4cd0548cd1b6616b3e5e2759"
   },
   "skills": [
     {

--- a/registry.json
+++ b/registry.json
@@ -1,10 +1,10 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-07-22T02:06:02Z",
+  "generated_at": "2026-07-22T04:11:13Z",
   "source": {
     "repo": "github.com/jjfantini/humblSKILLS",
-    "ref": "main",
-    "sha": "55ffd853715aecafccc10df18493ce13e91feb52"
+    "ref": "feat/tui-router-foundation",
+    "sha": "2ce51d7b40977a2312f5fc5ab52e8b3310a7f6d2"
   },
   "skills": [
     {


### PR DESCRIPTION
## Stage 1 of the TUI router — REVIEW ONLY, do not merge until tested locally

Fixes the residual flash-to-shell when moving between panes. Each screen is currently its own alt-screen `tea.Program`, so navigation tears the alternate-screen buffer down and back up (the flash). This introduces one long-lived **session** program that swaps the active screen model in place — the alt-screen is entered once and never torn down between panes.

**Gated + safe:** off unless `HUMBLSKILLS_TUI_ROUTER=1`. With it unset, `Run()` and prompts behave exactly as before (full `-race` suite + `vet` green, no behavior change).

### How it works
- `internal/tui/session.go` — a host model that renders/forwards to the active screen; a screen's `tea.Quit` is *trapped* into a "child done" signal (returns that screen's final state to the blocking caller) instead of ending the program. `Shutdown()` ends the session and restores the terminal, wired via `main()` on every exit path.
- Prompts (`huh`) are separate programs that can't share the host terminal, so `ui.RunGuard` releases/restores the host terminal around each prompt (a flash at *prompt* time only — not navigation).

### ⚠️ Needs real-terminal testing (I can't drive a TTY in CI)
Check out locally and run with the flag:
```sh
HUMBLSKILLS_TUI_ROUTER=1 humblskills
```
Please verify:
- [ ] Navigating dashboard ↔ list ↔ doctor ↔ registry ↔ search — **no flash** between panes.
- [ ] `q` / `esc` return to the dashboard; quitting the dashboard exits cleanly and **restores the terminal** (no stuck alt-screen).
- [ ] `ctrl-C` behaves acceptably (exits current screen / app; terminal restored).
- [ ] Terminal **resize** reflows every screen.
- [ ] Prompt flows still work: `registry login` (masked), `registry add` (interactive), install platform modal, ambiguous `install <skill>` `--from` picker, update/uninstall confirms.
- [ ] Progress screens (install/update) render and return correctly.
- [ ] With the flag **unset**, everything behaves as it does today.

### Known limitations (future stages)
- Prompts still flash at the moment they open (terminal release/restore). Folding them into in-program input models is a later stage.
- `trapQuit` handles standalone `tea.Quit` (what every current screen uses); batched quits aren't trapped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)