### PR TITLE
feat(registry): role taxonomy — group and filter skills by target role

### DIFF
--- a/cli/cmd/build-registry/main.go
+++ b/cli/cmd/build-registry/main.go
@@ -108,6 +108,7 @@ func run(skillsDir, outFile, repo, ref, sha string, check bool) error {
 			Version:     p.fm.Version(),
 			Description: p.fm.Description,
 			Category:    p.fm.Category(),
+			Role:        p.fm.Role(),
 			Tags:        p.fm.Tags(),
 			Platforms:   p.fm.Platforms(),
 			Requires:    p.fm.Requires(),

--- a/cli/cmd/build-registry/main_test.go
+++ b/cli/cmd/build-registry/main_test.go
@@ -292,3 +292,50 @@ func TestSemanticDiff_DetectsSkillChange(t *testing.T) {
 		t.Error("expected diff detected")
 	}
 }
+
+func TestRun_RoleFlowsIntoRegistry(t *testing.T) {
+	root := t.TempDir()
+	skillsDir := filepath.Join(root, "skills")
+	d := filepath.Join(skillsDir, "fdeskill")
+	if err := os.MkdirAll(d, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := "---\nname: fdeskill\ndescription: role-tagged on purpose\nversion: 1.0.0\nmetadata:\n  category: development\n  role: fde\n---\nBody.\n"
+	if err := os.WriteFile(filepath.Join(d, "SKILL.md"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	out := filepath.Join(root, "registry.json")
+	if err := run(skillsDir, out, "r", "main", "sha", false); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	data, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var reg registry.Registry
+	if err := json.Unmarshal(data, &reg); err != nil {
+		t.Fatal(err)
+	}
+	if len(reg.Skills) != 1 || reg.Skills[0].Role != "fde" {
+		t.Errorf("skills = %+v, want one skill with role fde", reg.Skills)
+	}
+}
+
+func TestRun_UnknownRole_Rejected(t *testing.T) {
+	root := t.TempDir()
+	skillsDir := filepath.Join(root, "skills")
+	d := filepath.Join(skillsDir, "badrole")
+	if err := os.MkdirAll(d, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := "---\nname: badrole\ndescription: unknown role on purpose\nversion: 1.0.0\nmetadata:\n  category: development\n  role: astronaut\n---\nBody.\n"
+	if err := os.WriteFile(filepath.Join(d, "SKILL.md"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := run(skillsDir, filepath.Join(root, "registry.json"), "r", "main", "sha", false)
+	if err == nil || !strings.Contains(err.Error(), `unknown role "astronaut"`) {
+		t.Fatalf("expected unknown-role validation error, got %v", err)
+	}
+}

--- a/cli/cmd/humblskills/browse_skills.go
+++ b/cli/cmd/humblskills/browse_skills.go
@@ -51,7 +51,7 @@ func (s skillItem) primary() *manifest.Installation {
 
 func (s skillItem) Key() string { return s.s.Name }
 func (s skillItem) FilterValue() string {
-	return strings.ToLower(s.s.Name + " " + s.s.Category + " " + strings.Join(s.s.Tags, " ") + " " + s.s.Description)
+	return strings.ToLower(s.s.Name + " " + s.s.Category + " " + s.s.Role + " " + strings.Join(s.s.Tags, " ") + " " + s.s.Description)
 }
 
 // NaturalWidth reports the row's display width: dot + space + name + 2-gap
@@ -106,6 +106,9 @@ func (s skillItem) Detail(th *ui.Theme, width int) string {
 	}
 	if s.s.Category != "" {
 		sb.WriteString(kvRow(th, "category", th.Category.Render(s.s.Category)))
+	}
+	if s.s.Role != "" {
+		sb.WriteString(kvRow(th, "role", th.Platform.Render(s.s.Role)))
 	}
 	if len(s.s.Tags) > 0 {
 		chips := make([]string, 0, len(s.s.Tags))
@@ -205,26 +208,41 @@ func buildSkillItems(skills []registry.Skill, m *manifest.Manifest) []skillItem 
 	}
 	sort.SliceStable(items, func(i, j int) bool {
 		// Group by source registry (empty registry — single-registry views —
-		// all collapse into one group), then by skill name within a group.
+		// all collapse into one group), then by role within a registry
+		// (role-less skills first, directly under the registry header),
+		// then by skill name. Must stay in step with aggregateSkills.
 		if items[i].s.Registry != items[j].s.Registry {
 			return items[i].s.Registry < items[j].s.Registry
+		}
+		if items[i].s.Role != items[j].s.Role {
+			return items[i].s.Role < items[j].s.Role
 		}
 		return items[i].s.Name < items[j].s.Name
 	})
 	return items
 }
 
-// registryHeaderItem is a non-selectable section-header row rendered above each
-// registry's skills when more than one registry is shown.
-type registryHeaderItem struct{ name string }
+// registryHeaderItem is a non-selectable section-header row rendered above
+// each registry's skills when more than one registry is shown, and — with
+// sub set — as the lighter role sub-header within a registry's block. One
+// type for both levels so the list's header handling (nav skipping, filter
+// hiding, countSkills) needs no second case.
+type registryHeaderItem struct {
+	name     string
+	registry string // owning registry, part of Key so same-named role headers don't collide
+	sub      bool   // true = role sub-header
+}
 
 func (h registryHeaderItem) IsHeader() bool      { return true }
-func (h registryHeaderItem) Key() string         { return "__header__:" + h.name }
+func (h registryHeaderItem) Key() string         { return "__header__:" + h.registry + ":" + h.name }
 func (h registryHeaderItem) FilterValue() string { return "" }
 func (h registryHeaderItem) NaturalWidth(th *ui.Theme) int {
 	return lipgloss.Width(h.render(th))
 }
 func (h registryHeaderItem) render(th *ui.Theme) string {
+	if h.sub {
+		return th.Meta.Render("· " + h.name + " ·")
+	}
 	return th.SectionTitle.Render("── " + h.name + " ──")
 }
 func (h registryHeaderItem) Row(th *ui.Theme, width int, _ bool) string {
@@ -232,19 +250,32 @@ func (h registryHeaderItem) Row(th *ui.Theme, width int, _ bool) string {
 }
 func (h registryHeaderItem) Detail(th *ui.Theme, width int) string { return "" }
 
-// interleaveRegistryHeaders turns a (registry, name)-sorted item list into a
-// tui.Item slice with a "── <registry> ──" header before each registry's
-// block. When only one registry is present, no headers are added.
+// interleaveRegistryHeaders turns a (registry, role, name)-sorted item list
+// into a tui.Item slice with a "── <registry> ──" header before each
+// registry's block (only when grouped, i.e. >1 registry) and a lighter
+// "· <role> ·" sub-header before each role's block. Role sub-headers appear
+// whenever any skill carries a role — independent of registry grouping.
+// Role-less skills sort first within their registry and get no sub-header.
 func interleaveRegistryHeaders(skills []skillItem, grouped bool) []tui.Item {
-	items := make([]tui.Item, 0, len(skills)+4)
-	last := ""
-	first := true
+	hasRoles := false
 	for _, s := range skills {
-		if grouped && (first || s.s.Registry != last) {
-			items = append(items, registryHeaderItem{name: registryDisplayName(s.s.Registry)})
-			last = s.s.Registry
-			first = false
+		if s.s.Role != "" {
+			hasRoles = true
+			break
 		}
+	}
+	items := make([]tui.Item, 0, len(skills)+4)
+	prevReg, prevRole := "", ""
+	started := false
+	for _, s := range skills {
+		regChanged := !started || s.s.Registry != prevReg
+		if grouped && regChanged {
+			items = append(items, registryHeaderItem{name: registryDisplayName(s.s.Registry), registry: s.s.Registry})
+		}
+		if hasRoles && s.s.Role != "" && (regChanged || s.s.Role != prevRole) {
+			items = append(items, registryHeaderItem{name: s.s.Role, registry: s.s.Registry, sub: true})
+		}
+		prevReg, prevRole, started = s.s.Registry, s.s.Role, true
 		items = append(items, s)
 	}
 	return items

--- a/cli/cmd/humblskills/browse_skills_test.go
+++ b/cli/cmd/humblskills/browse_skills_test.go
@@ -99,3 +99,97 @@ func TestSkillItem_Detail_NotInstalled_NoInstalledSection(t *testing.T) {
 		t.Errorf("uninstalled skill should not render an INSTALLED section:\n%s", detail)
 	}
 }
+
+func TestBuildSkillItems_RolelessFirstThenByRoleWithinRegistry(t *testing.T) {
+	items := buildSkillItems([]registry.Skill{
+		{Name: "zeta", Version: "1.0.0", Registry: "work", Role: "sdr"},
+		{Name: "alpha", Version: "1.0.0", Registry: "work", Role: "fde"},
+		{Name: "misc", Version: "1.0.0", Registry: "work"},
+		{Name: "other", Version: "1.0.0", Registry: "personal"},
+	}, nil)
+	got := make([]string, 0, len(items))
+	for _, it := range items {
+		got = append(got, it.s.Registry+"/"+it.s.Role+"/"+it.s.Name)
+	}
+	want := []string{"personal//other", "work//misc", "work/fde/alpha", "work/sdr/zeta"}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("order = %v, want %v", got, want)
+		}
+	}
+}
+
+func TestInterleaveHeaders_RoleSubHeaders(t *testing.T) {
+	skills := buildSkillItems([]registry.Skill{
+		{Name: "misc", Version: "1.0.0", Registry: "work"},
+		{Name: "alpha", Version: "1.0.0", Registry: "work", Role: "fde"},
+		{Name: "beta", Version: "1.0.0", Registry: "work", Role: "fde"},
+		{Name: "zeta", Version: "1.0.0", Registry: "work", Role: "sdr"},
+		{Name: "other", Version: "1.0.0", Registry: "personal"},
+	}, nil)
+	items := interleaveRegistryHeaders(skills, true)
+
+	got := make([]string, 0, len(items))
+	for _, it := range items {
+		switch v := it.(type) {
+		case registryHeaderItem:
+			if v.sub {
+				got = append(got, "role:"+v.name)
+			} else {
+				got = append(got, "reg:"+v.name)
+			}
+		case skillItem:
+			got = append(got, v.s.Name)
+		}
+	}
+	want := []string{"reg:personal", "other", "reg:work", "misc", "role:fde", "alpha", "beta", "role:sdr", "zeta"}
+	if len(got) != len(want) {
+		t.Fatalf("items = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("items = %v, want %v", got, want)
+		}
+	}
+}
+
+func TestInterleaveHeaders_RoleSubHeadersWithoutRegistryGrouping(t *testing.T) {
+	// Single registry (grouped=false): role sub-headers still appear.
+	skills := buildSkillItems([]registry.Skill{
+		{Name: "misc", Version: "1.0.0"},
+		{Name: "alpha", Version: "1.0.0", Role: "fde"},
+	}, nil)
+	items := interleaveRegistryHeaders(skills, false)
+
+	if len(items) != 3 {
+		t.Fatalf("items = %d, want 3 (skill, sub-header, skill)", len(items))
+	}
+	h, ok := items[1].(registryHeaderItem)
+	if !ok || !h.sub || h.name != "fde" {
+		t.Fatalf("items[1] = %#v, want fde sub-header", items[1])
+	}
+}
+
+func TestInterleaveHeaders_NoRoleSubHeadersWhenNoRoles(t *testing.T) {
+	skills := buildSkillItems([]registry.Skill{
+		{Name: "a", Version: "1.0.0", Registry: "work"},
+		{Name: "b", Version: "1.0.0", Registry: "personal"},
+	}, nil)
+	items := interleaveRegistryHeaders(skills, true)
+	for _, it := range items {
+		if h, ok := it.(registryHeaderItem); ok && h.sub {
+			t.Fatalf("unexpected role sub-header %q", h.name)
+		}
+	}
+}
+
+func TestSkillItem_RoleInDetailAndFilterValue(t *testing.T) {
+	it := skillItem{s: registry.Skill{Name: "alpha", Version: "1.0.0", Role: "fde"}}
+	th := ui.DefaultTheme()
+	if !strings.Contains(it.Detail(th, 80), "fde") {
+		t.Error("Detail missing role")
+	}
+	if !strings.Contains(it.FilterValue(), "fde") {
+		t.Error("FilterValue missing role")
+	}
+}

--- a/cli/cmd/humblskills/registries.go
+++ b/cli/cmd/humblskills/registries.go
@@ -388,6 +388,11 @@ func aggregateSkills(loaded []registrySkills) ([]registry.Skill, map[string]erro
 		if all[i].Registry != all[j].Registry {
 			return all[i].Registry < all[j].Registry
 		}
+		// Role-less skills ("") sort first, directly under the registry
+		// header; role-tagged skills follow, block per role.
+		if all[i].Role != all[j].Role {
+			return all[i].Role < all[j].Role
+		}
 		return all[i].Name < all[j].Name
 	})
 	return all, errs

--- a/cli/cmd/humblskills/search.go
+++ b/cli/cmd/humblskills/search.go
@@ -18,17 +18,22 @@ import (
 
 func newSearchCmd(app *App) *cobra.Command {
 	var category string
+	var role string
 	cmd := &cobra.Command{
 		Use:   "search [query]",
 		Short: "Search the registry by name, description, or tag",
 		Long: "search matches a query against each skill's name, description, and " +
-			"tags. Narrow to one category with --category (see " +
-			"'humblskills search --category=' for the list of valid values).",
+			"tags. Narrow to one category with --category or to one target role " +
+			"with --role (see the flag help for the valid values).",
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			category = strings.ToLower(strings.TrimSpace(category))
 			if category != "" && !frontmatter.IsKnownCategory(category) {
 				return fmt.Errorf("unknown --category %q (must be one of %s)", category, strings.Join(frontmatter.Categories, ", "))
+			}
+			role = strings.ToLower(strings.TrimSpace(role))
+			if role != "" && !frontmatter.IsKnownRole(role) {
+				return fmt.Errorf("unknown --role %q (must be one of %s)", role, strings.Join(frontmatter.Roles, ", "))
 			}
 
 			query := ""
@@ -66,6 +71,9 @@ func newSearchCmd(app *App) *cobra.Command {
 				if category != "" && s.Category != category {
 					continue
 				}
+				if role != "" && s.Role != role {
+					continue
+				}
 				if query == "" || matches(s, query) {
 					hits = append(hits, s)
 				}
@@ -75,8 +83,9 @@ func newSearchCmd(app *App) *cobra.Command {
 				return app.UI.JSON(struct {
 					Query    string           `json:"query,omitempty"`
 					Category string           `json:"category,omitempty"`
+					Role     string           `json:"role,omitempty"`
 					Results  []registry.Skill `json:"results"`
-				}{query, category, hits})
+				}{query, category, role, hits})
 			}
 			if len(hits) == 0 {
 				app.UI.Warn("no skills matched %q", query)
@@ -95,6 +104,7 @@ func newSearchCmd(app *App) *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&category, "category", "", "restrict results to one category ("+strings.Join(frontmatter.Categories, ", ")+")")
+	cmd.Flags().StringVar(&role, "role", "", "restrict results to one target role ("+strings.Join(frontmatter.Roles, ", ")+")")
 	return cmd
 }
 
@@ -170,27 +180,37 @@ func renderSearchResults(theme *ui.Theme, hits []registry.Skill, query string) s
 	sb.WriteString("\n\n")
 
 	// Group hits under a "── <registry> ──" header when they span more than
-	// one registry (hits are already sorted by registry then name).
+	// one registry, and under a lighter "· <role> ·" sub-header when any hit
+	// carries a role (hits are already sorted by registry, role, name;
+	// role-less hits sort first within their registry).
 	grouped := false
+	hasRoles := false
 	{
 		seen := map[string]struct{}{}
 		for _, s := range hits {
 			seen[s.Registry] = struct{}{}
+			if s.Role != "" {
+				hasRoles = true
+			}
 		}
 		grouped = len(seen) > 1
 	}
 	lastReg := ""
-	headerShown := false
+	lastRole := ""
+	started := false
 
 	for i, s := range hits {
-		if grouped && (!headerShown || s.Registry != lastReg) {
-			if headerShown {
+		regChanged := !started || s.Registry != lastReg
+		if grouped && regChanged {
+			if started {
 				sb.WriteString("\n")
 			}
 			sb.WriteString("  " + theme.SectionTitle.Render("── "+registryDisplayName(s.Registry)+" ──") + "\n\n")
-			lastReg = s.Registry
-			headerShown = true
 		}
+		if hasRoles && s.Role != "" && (regChanged || s.Role != lastRole) {
+			sb.WriteString("  " + theme.Meta.Render("· "+s.Role+" ·") + "\n\n")
+		}
+		lastReg, lastRole, started = s.Registry, s.Role, true
 		left := theme.Bullet.Render("▌ ") + highlightName(s.Name, query, theme.Name, theme.Hit)
 		right := theme.Version.Render("v" + s.Version)
 		pad := inner - lipgloss.Width(left) - lipgloss.Width(right)
@@ -207,6 +227,9 @@ func renderSearchResults(theme *ui.Theme, hits []registry.Skill, query string) s
 		}
 		if s.Category != "" {
 			sb.WriteString("    " + theme.Label.Render("category ") + theme.Category.Render(s.Category) + "\n")
+		}
+		if s.Role != "" {
+			sb.WriteString("    " + theme.Label.Render("role    ") + theme.Platform.Render(s.Role) + "\n")
 		}
 		if len(s.Tags) > 0 {
 			chips := make([]string, 0, len(s.Tags))

--- a/cli/cmd/humblskills/search_test.go
+++ b/cli/cmd/humblskills/search_test.go
@@ -211,3 +211,61 @@ func TestMatches_NameDescriptionTag(t *testing.T) {
 		t.Errorf("tag match: got %d", n)
 	}
 }
+
+func TestSearch_RoleFilter_JSON(t *testing.T) {
+	s := testutil.NewSandbox(t)
+
+	regURL := seedTestRegistry(t, s, []testutil.SkillFixture{
+		{Name: "alpha", Version: "1.0.0", Category: "development", Role: "fde",
+			Files: testutil.SkillTree{"SKILL.md": sampleSkillMD}},
+		{Name: "beta", Version: "1.0.0", Category: "development", Role: "sdr",
+			Files: testutil.SkillTree{"SKILL.md": sampleSkillMD}},
+		{Name: "gamma", Version: "1.0.0", Category: "development",
+			Files: testutil.SkillTree{"SKILL.md": sampleSkillMD}},
+	})
+	res := runCLIWithStdoutCapture(t,
+		"search",
+		"--role", "fde",
+		"--registry", regURL,
+		"--cache-dir", s.CacheDir,
+		"--json",
+	)
+	if res.RunErr != nil {
+		t.Fatalf("run: %v\n%s", res.RunErr, res.Err)
+	}
+	idx := strings.Index(res.Out, "{")
+	var out struct {
+		Role    string `json:"role"`
+		Results []struct {
+			Name string `json:"name"`
+			Role string `json:"role"`
+		} `json:"results"`
+	}
+	if err := json.Unmarshal([]byte(res.Out[idx:]), &out); err != nil {
+		t.Fatalf("parse: %v\n%s", err, res.Out)
+	}
+	if out.Role != "fde" {
+		t.Errorf("echoed role = %q, want fde", out.Role)
+	}
+	if len(out.Results) != 1 || out.Results[0].Name != "alpha" || out.Results[0].Role != "fde" {
+		t.Errorf("results = %+v", out.Results)
+	}
+}
+
+func TestSearch_UnknownRole_Errors(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	regURL := seedTestRegistry(t, s, []testutil.SkillFixture{
+		{Name: "alpha", Version: "1.0.0", Category: "development",
+			Files: testutil.SkillTree{"SKILL.md": sampleSkillMD}},
+	})
+	res := runCLIWithStdoutCapture(t,
+		"search",
+		"--role", "astronaut",
+		"--registry", regURL,
+		"--cache-dir", s.CacheDir,
+		"--json",
+	)
+	if res.RunErr == nil {
+		t.Fatal("expected error for unknown --role")
+	}
+}

--- a/cli/internal/frontmatter/frontmatter.go
+++ b/cli/internal/frontmatter/frontmatter.go
@@ -13,6 +13,7 @@
 //	  author: jjfantini
 //	  version: 1.0.0                   # humblSKILLS requires this
 //	  category: development            # humblSKILLS requires this, one of a closed set
+//	  role: fde                        # optional, one of a closed set (see validate.Roles)
 //	  tags: [...]
 //	  platforms: [claude-code]
 //	  requires: [...]
@@ -42,6 +43,7 @@ type Metadata struct {
 	Author    string   `yaml:"author,omitempty"`
 	Version   string   `yaml:"version,omitempty"`
 	Category  string   `yaml:"category,omitempty"`
+	Role      string   `yaml:"role,omitempty"`
 	Requires  []string `yaml:"requires,omitempty"`
 	Platforms []string `yaml:"platforms,omitempty"`
 	Tags      []string `yaml:"tags,omitempty"`
@@ -90,6 +92,14 @@ func (f Frontmatter) Version() string {
 // the legacy-field migration window, so metadata is the only source.
 func (f Frontmatter) Category() string {
 	return f.Metadata.Category
+}
+
+// Role returns the skill's target role (e.g. "fde", "sdr"), used to group
+// and filter skills by who they serve. Optional; empty means unscoped. Like
+// Category there is no deprecated top-level fallback - role postdates the
+// legacy-field migration window, so metadata is the only source.
+func (f Frontmatter) Role() string {
+	return f.Metadata.Role
 }
 
 // Requires returns the humblSKILLS dep list: metadata.requires first,

--- a/cli/internal/frontmatter/frontmatter_test.go
+++ b/cli/internal/frontmatter/frontmatter_test.go
@@ -208,3 +208,34 @@ func TestParse_EmptyFrontmatterBlock(t *testing.T) {
 		t.Errorf("body: got %q", string(body))
 	}
 }
+
+func TestParse_MetadataRole(t *testing.T) {
+	src := []byte(`---
+name: foo
+description: A foo skill.
+metadata:
+  version: 1.0.0
+  category: development
+  role: fde
+---
+Body.
+`)
+	fm, _, err := Parse(src)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if fm.Role() != "fde" {
+		t.Errorf("Role() = %q, want %q", fm.Role(), "fde")
+	}
+}
+
+func TestParse_RoleAbsent_Empty(t *testing.T) {
+	src := []byte("---\nname: foo\ndescription: d\nmetadata:\n  version: 1.0.0\n  category: development\n---\nBody.\n")
+	fm, _, err := Parse(src)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if fm.Role() != "" {
+		t.Errorf("Role() = %q, want empty", fm.Role())
+	}
+}

--- a/cli/internal/frontmatter/validate.go
+++ b/cli/internal/frontmatter/validate.go
@@ -34,6 +34,25 @@ func IsKnownCategory(c string) bool {
 	return false
 }
 
+// Roles is the closed, stable set of roles a skill can be scoped to:
+// fde (forward-deployed engineer), ds (data scientist), sdr (sales
+// development representative). Optional per skill (empty = unscoped),
+// single-valued like category. Adding a role is a taxonomy decision that
+// ships in a CLI release, same as adding a category.
+var Roles = []string{"fde", "ds", "sdr"}
+
+// IsKnownRole reports whether r is one of Roles. Exported so callers
+// outside this package (e.g. the search command's --role flag) can validate
+// against the same closed set used at registry-build time.
+func IsKnownRole(r string) bool {
+	for _, known := range Roles {
+		if r == known {
+			return true
+		}
+	}
+	return false
+}
+
 // isStrictSemver accepts only MAJOR.MINOR.PATCH, optionally with prerelease
 // or build metadata. Go's x/mod/semver treats "1.2" as valid (v1.2.0); we
 // want to reject shortened forms.
@@ -157,6 +176,10 @@ func (fm Frontmatter) Validate(dirName string, ctx ValidationContext) error {
 		errs = append(errs, fmt.Sprintf("category is required (set `metadata.category` to one of %s)", strings.Join(Categories, ", ")))
 	case !IsKnownCategory(category):
 		errs = append(errs, fmt.Sprintf("unknown category %q (must be one of %s)", category, strings.Join(Categories, ", ")))
+	}
+
+	if role := fm.Role(); role != "" && !IsKnownRole(role) {
+		errs = append(errs, fmt.Sprintf("unknown role %q (must be one of %s, or omitted)", role, strings.Join(Roles, ", ")))
 	}
 
 	for _, plat := range fm.Platforms() {

--- a/cli/internal/frontmatter/validate_test.go
+++ b/cli/internal/frontmatter/validate_test.go
@@ -270,3 +270,33 @@ func TestDepSatisfies(t *testing.T) {
 		})
 	}
 }
+
+func TestValidate_RoleOptional(t *testing.T) {
+	fm := mkFM("foo", "0.1.0", func(f *Frontmatter) {
+		f.Metadata.Role = ""
+	})
+	if err := fm.Validate("foo", ctxWith(nil)); err != nil {
+		t.Fatalf("empty role should validate: %v", err)
+	}
+}
+
+func TestValidate_RoleUnknown(t *testing.T) {
+	fm := mkFM("foo", "0.1.0", func(f *Frontmatter) {
+		f.Metadata.Role = "astronaut"
+	})
+	err := fm.Validate("foo", ctxWith(nil))
+	if err == nil || !strings.Contains(err.Error(), `unknown role "astronaut"`) {
+		t.Fatalf("expected unknown-role error, got %v", err)
+	}
+}
+
+func TestValidate_RoleEveryKnownValueAccepted(t *testing.T) {
+	for _, r := range Roles {
+		fm := mkFM("foo", "0.1.0", func(f *Frontmatter) {
+			f.Metadata.Role = r
+		})
+		if err := fm.Validate("foo", ctxWith(nil)); err != nil {
+			t.Errorf("role %q should validate: %v", r, err)
+		}
+	}
+}

--- a/cli/internal/registry/types.go
+++ b/cli/internal/registry/types.go
@@ -26,7 +26,11 @@ type Skill struct {
 	Version     string   `json:"version"`
 	Description string   `json:"description"`
 	Category    string   `json:"category,omitempty"`
-	Tags        []string `json:"tags,omitempty"`
+	// Role is the optional target role this skill is scoped to (closed set,
+	// see frontmatter.Roles). Empty means unscoped; single-valued like
+	// Category. Used to sub-group skills within a registry when browsing.
+	Role string   `json:"role,omitempty"`
+	Tags []string `json:"tags,omitempty"`
 	Platforms   []string `json:"platforms,omitempty"`
 	Requires    []string `json:"requires,omitempty"`
 	Preserve    []string `json:"preserve,omitempty"`

--- a/cli/internal/testutil/skillfixture.go
+++ b/cli/internal/testutil/skillfixture.go
@@ -15,6 +15,7 @@ type SkillFixture struct {
 	Version     string
 	Description string
 	Category    string
+	Role        string
 	Tags        []string
 	Platforms   []string
 	Requires    []string
@@ -65,6 +66,7 @@ func BuildRegistry(t testing.TB, cacheDir, owner, name, sha string, fixtures []S
 			Version:     f.Version,
 			Description: f.Description,
 			Category:    f.Category,
+			Role:        f.Role,
 			Tags:        f.Tags,
 			Platforms:   f.Platforms,
 			Requires:    f.Requires,

--- a/registry.json
+++ b/registry.json
@@ -1,10 +1,10 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-07-28T17:55:55Z",
+  "generated_at": "2026-07-28T17:56:04Z",
   "source": {
     "repo": "github.com/jjfantini/humblSKILLS",
     "ref": "feat/role-taxonomy",
-    "sha": "e6bd59b428469859389e233a78f7b8183e983eb9"
+    "sha": "b8ead48633e1891095d5b90c4d5a3834050f120d"
   },
   "skills": [
     {

--- a/registry.json
+++ b/registry.json
@@ -1,10 +1,10 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-07-27T20:34:11Z",
+  "generated_at": "2026-07-28T17:55:55Z",
   "source": {
     "repo": "github.com/jjfantini/humblSKILLS",
-    "ref": "main",
-    "sha": "0dbff94be2ea0c4d6b929be945cc4e711c0c75d0"
+    "ref": "feat/role-taxonomy",
+    "sha": "e6bd59b428469859389e233a78f7b8183e983eb9"
   },
   "skills": [
     {


### PR DESCRIPTION
## What

Skills can carry an optional `metadata.role` from a closed set — **fde**, **ds**, **sdr** — that flows SKILL.md → build-registry → `registry.json` (additive `omitempty`, no schema bump; old registries keep working).

## Surfaces

- **TUI browser** (search/install/list/uninstall): aggregated views now sort `(registry, role, name)` and render lighter `· role ·` sub-headers within each registry block. Role-less skills sit first, directly under the registry header — no "(no role)" pseudo-header. Role shows in the detail pane and joins the `/`-filter haystack. One header type (`sub` flag) so nav-skipping/filter-hiding/counting needed zero changes.
- **CLI**: `humblskills search --role fde` (validated like `--category`, unknown role errors with the valid list); role kv line per hit; the same role sub-headers in grouped non-TTY output; `--json` echoes the filter and results carry `"role"`.
- **Validation**: `frontmatter.Roles` + `IsKnownRole` mirror the category machinery; role is optional, unknown roles fail `build-registry`.

## Verified

- Full `-race` suite + vet green; new tests for frontmatter parse/validate, build-registry flow-through + rejection, `--role` filter + JSON, roleless-first ordering, header interleave (multi-registry, single-registry, no-roles cases), detail/filter-value.
- `make registry` — no drift on this repo's skills (none tagged).
- End-to-end against two file:// fixture registries: grouped output shows `── registry ──` headers with `· ds · / · fde · / · sdr ·` sub-sections exactly as designed.

## Rollout note

After this releases, happySKILLS needs one PR bumping `HUMBLSKILLS_VERSION` in its registry workflow **and** tagging `example-skill` with `role: fde` (the old pinned tool would silently strip the key). Merge THIS PR with an empty squash body (registry-bot `[skip ci]` trap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)