### PR TITLE
feat(cli): skillset registry bootstrap + Claude Desktop zip export

### DIFF
--- a/cli/cmd/humblskills/desktop.go
+++ b/cli/cmd/humblskills/desktop.go
@@ -1,0 +1,220 @@
+package main
+
+import (
+	"archive/zip"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/spf13/cobra"
+
+	"github.com/jjfantini/humblSKILLS/cli/internal/install"
+	"github.com/jjfantini/humblSKILLS/cli/internal/manifest"
+	"github.com/jjfantini/humblSKILLS/cli/internal/profile"
+	"github.com/jjfantini/humblSKILLS/cli/internal/textutil"
+)
+
+// Claude Desktop and claude.ai can't read filesystem skills — they take an
+// account-level zip upload (skill folder at the zip root, SKILL.md inside).
+// This file is the bridge: `export desktop` writes upload-ready zips from the
+// canonical store, and the profile's desktop_exports setting regenerates them
+// automatically after install/update.
+
+const desktopUploadHint = "upload at claude.ai (or the Claude desktop app): Settings → Capabilities → Skills → upload the zip. Uploads don't auto-update — re-export after 'humblskills update'."
+
+// desktopZipInfo is one written zip, for JSON envelopes and printing.
+type desktopZipInfo struct {
+	Skill   string `json:"skill"`
+	Version string `json:"version"`
+	Zip     string `json:"zip"`
+}
+
+func newExportDesktopCmd(app *App) *cobra.Command {
+	var outDir string
+	cmd := &cobra.Command{
+		Use:   "desktop [skill...]",
+		Short: "Write claude.ai / Claude Desktop upload zips for installed skills",
+		Long: "Claude Desktop and claude.ai don't read skills from the filesystem — " +
+			"they take a zip upload (the skill folder at the zip root). " +
+			"'export desktop' writes one upload-ready zip per installed skill " +
+			"(or just the ones you name) from the canonical humblskills store. " +
+			"Set 'humblskills profile set desktop_exports on' to regenerate the " +
+			"zips automatically on every install/update.",
+		Args: cobra.ArbitraryArgs,
+		RunE: func(_ *cobra.Command, args []string) error {
+			return runExportDesktop(app, args, outDir)
+		},
+	}
+	cmd.Flags().StringVarP(&outDir, "output-dir", "o", "", "directory for the zips (default: ~/.humblskills/desktop)")
+	return cmd
+}
+
+func runExportDesktop(app *App, names []string, outDir string) error {
+	m, err := manifest.Load(app.Config.ManifestPath)
+	if err != nil {
+		return err
+	}
+	if len(names) == 0 {
+		names = uniqueSkillsFromManifest(m)
+	}
+	if len(names) == 0 {
+		return fmt.Errorf("no skills installed — nothing to export")
+	}
+	if outDir == "" {
+		if outDir, err = defaultDesktopDir(); err != nil {
+			return err
+		}
+	}
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
+		return fmt.Errorf("create %s: %w", outDir, err)
+	}
+
+	var infos []desktopZipInfo
+	for _, name := range names {
+		inst := installWithStorePath(m, name)
+		if inst == nil {
+			return fmt.Errorf("%q has no canonical store recorded — is it installed? (older installs: reinstall once with the current CLI)", name)
+		}
+		zipPath := filepath.Join(outDir, name+"-"+inst.Version+".zip")
+		if err := writeDesktopZip(inst.StorePath, name, zipPath); err != nil {
+			return fmt.Errorf("zip %s: %w", name, err)
+		}
+		infos = append(infos, desktopZipInfo{Skill: name, Version: inst.Version, Zip: zipPath})
+	}
+
+	if app.Config.JSON {
+		return app.UI.JSON(struct {
+			Zips []desktopZipInfo `json:"zips"`
+		}{infos})
+	}
+	for _, z := range infos {
+		app.UI.Success("desktop zip → %s", z.Zip)
+	}
+	app.UI.Info("%s", desktopUploadHint)
+	app.UI.Info("wrote %d zip%s", len(infos), textutil.Plural(len(infos)))
+	return nil
+}
+
+// installWithStorePath returns an installation of skill that records the
+// canonical store path (any platform — the store is shared), or nil.
+func installWithStorePath(m *manifest.Manifest, skill string) *manifest.Installation {
+	for _, inst := range m.FindAll(skill) {
+		if inst.StorePath != "" {
+			return inst
+		}
+	}
+	return nil
+}
+
+// defaultDesktopDir is where auto-exports and no-flag runs put the zips:
+// ~/.humblskills/desktop, next to the canonical global store.
+func defaultDesktopDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve home: %w", err)
+	}
+	return filepath.Join(home, ".humblskills", "desktop"), nil
+}
+
+// writeDesktopZip zips the skill's store directory in claude.ai's required
+// layout: every file under a single "<skillName>/…" folder at the zip root.
+// Regular files only (symlinks skipped), sorted walk for deterministic output.
+func writeDesktopZip(storePath, skillName, outPath string) error {
+	var files []string
+	err := filepath.WalkDir(storePath, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.Type().IsRegular() {
+			files = append(files, p)
+		}
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("walk %s: %w", storePath, err)
+	}
+	if len(files) == 0 {
+		return fmt.Errorf("store %s has no files", storePath)
+	}
+	sort.Strings(files)
+
+	f, err := os.Create(outPath)
+	if err != nil {
+		return err
+	}
+	zw := zip.NewWriter(f)
+	for _, p := range files {
+		rel, err := filepath.Rel(storePath, p)
+		if err != nil {
+			zw.Close()
+			f.Close()
+			return err
+		}
+		w, err := zw.Create(skillName + "/" + filepath.ToSlash(rel))
+		if err != nil {
+			zw.Close()
+			f.Close()
+			return err
+		}
+		data, err := os.ReadFile(p)
+		if err != nil {
+			zw.Close()
+			f.Close()
+			return err
+		}
+		if _, err := w.Write(data); err != nil {
+			zw.Close()
+			f.Close()
+			return err
+		}
+	}
+	if err := zw.Close(); err != nil {
+		f.Close()
+		return err
+	}
+	return f.Close()
+}
+
+// maybeDesktopExport regenerates upload zips for the run's changed skills
+// when the profile's desktop_exports setting is on. Returns the zip info for
+// JSON envelopes; prints success lines + the upload hint on the text path.
+// Never fails the install — zip problems are warnings.
+func maybeDesktopExport(app *App, res install.Result) []desktopZipInfo {
+	p, err := profile.Load(app.Config.ProfilePath)
+	if err != nil || p == nil || !p.DesktopExports {
+		return nil
+	}
+	outDir, err := defaultDesktopDir()
+	if err != nil {
+		app.UI.Warn("desktop zips: %v", err)
+		return nil
+	}
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
+		app.UI.Warn("desktop zips: %v", err)
+		return nil
+	}
+
+	seen := map[string]bool{}
+	var infos []desktopZipInfo
+	for _, t := range res.Results {
+		if seen[t.Skill] || t.StorePath == "" || t.Outcome == install.OutcomeSkipped {
+			continue
+		}
+		seen[t.Skill] = true
+		zipPath := filepath.Join(outDir, t.Skill+"-"+t.Version+".zip")
+		if err := writeDesktopZip(t.StorePath, t.Skill, zipPath); err != nil {
+			app.UI.Warn("desktop zip for %s: %v", t.Skill, err)
+			continue
+		}
+		infos = append(infos, desktopZipInfo{Skill: t.Skill, Version: t.Version, Zip: zipPath})
+	}
+	if len(infos) > 0 && !app.Config.JSON {
+		for _, z := range infos {
+			app.UI.Success("desktop zip → %s", z.Zip)
+		}
+		app.UI.Info("%s", desktopUploadHint)
+	}
+	return infos
+}

--- a/cli/cmd/humblskills/desktop_test.go
+++ b/cli/cmd/humblskills/desktop_test.go
@@ -1,0 +1,200 @@
+package main
+
+import (
+	"archive/zip"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jjfantini/humblSKILLS/cli/internal/testutil"
+)
+
+func installFixtureSkill(t *testing.T, s *testutil.Sandbox, name string) {
+	t.Helper()
+	regURL := seedTestRegistry(t, s, []testutil.SkillFixture{
+		{
+			Name: name, Version: "1.0.0",
+			Platforms: []string{"claude-code"},
+			Files: testutil.SkillTree{
+				"SKILL.md":            sampleSkillMD,
+				"references/notes.md": "# notes\n",
+			},
+		},
+	})
+	res := runCLIWithStdoutCapture(t,
+		"install", name,
+		"--registry", regURL,
+		"--cache-dir", s.CacheDir,
+		"--manifest", s.ManifestPath,
+		"--profile", s.ProfilePath,
+		"--platform", "claude-code",
+		"--scope", "user",
+		"--yes",
+	)
+	if res.RunErr != nil {
+		t.Fatalf("install: %v\n%s", res.RunErr, res.Err)
+	}
+}
+
+func zipNames(t *testing.T, path string) []string {
+	t.Helper()
+	zr, err := zip.OpenReader(path)
+	if err != nil {
+		t.Fatalf("open zip %s: %v", path, err)
+	}
+	defer zr.Close()
+	var names []string
+	for _, f := range zr.File {
+		names = append(names, f.Name)
+	}
+	return names
+}
+
+func TestExportDesktop_WritesUploadReadyZip(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	enableClaudeCode(t, s)
+	installFixtureSkill(t, s, "foo")
+
+	outDir := filepath.Join(s.Root, "zips")
+	res := runCLIWithStdoutCapture(t,
+		"export", "desktop", "foo",
+		"--manifest", s.ManifestPath,
+		"--profile", s.ProfilePath,
+		"-o", outDir,
+		"--yes",
+	)
+	if res.RunErr != nil {
+		t.Fatalf("export desktop: %v\n%s", res.RunErr, res.Err)
+	}
+
+	zipPath := filepath.Join(outDir, "foo-1.0.0.zip")
+	names := zipNames(t, zipPath)
+	want := map[string]bool{"foo/SKILL.md": false, "foo/references/notes.md": false}
+	for _, n := range names {
+		if _, ok := want[n]; ok {
+			want[n] = true
+		}
+		if !strings.HasPrefix(n, "foo/") {
+			t.Errorf("entry %q not under the skill folder at zip root", n)
+		}
+	}
+	for n, seen := range want {
+		if !seen {
+			t.Errorf("zip missing %q; entries: %v", n, names)
+		}
+	}
+	assertContains(t, res.Out+res.Err, "upload at claude.ai")
+}
+
+func TestExportDesktop_NoArgs_CoversAllInstalled(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	enableClaudeCode(t, s)
+	installFixtureSkill(t, s, "foo")
+
+	outDir := filepath.Join(s.Root, "zips")
+	res := runCLIWithStdoutCapture(t,
+		"export", "desktop",
+		"--manifest", s.ManifestPath,
+		"--profile", s.ProfilePath,
+		"-o", outDir,
+		"--json", "--yes",
+	)
+	if res.RunErr != nil {
+		t.Fatalf("export desktop: %v\n%s", res.RunErr, res.Err)
+	}
+	idx := strings.Index(res.Out, "{")
+	var out struct {
+		Zips []struct {
+			Skill string `json:"skill"`
+			Zip   string `json:"zip"`
+		} `json:"zips"`
+	}
+	if err := json.Unmarshal([]byte(res.Out[idx:]), &out); err != nil {
+		t.Fatalf("parse: %v\n%s", err, res.Out)
+	}
+	if len(out.Zips) != 1 || out.Zips[0].Skill != "foo" {
+		t.Fatalf("zips = %+v", out.Zips)
+	}
+	if _, err := os.Stat(out.Zips[0].Zip); err != nil {
+		t.Errorf("zip not on disk: %v", err)
+	}
+}
+
+func TestExportDesktop_NotInstalled_Errors(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	res := runCLIWithStdoutCapture(t,
+		"export", "desktop", "ghost",
+		"--manifest", s.ManifestPath,
+		"--profile", s.ProfilePath,
+		"--yes",
+	)
+	if res.RunErr == nil {
+		t.Fatal("expected error for a skill that isn't installed")
+	}
+}
+
+func TestInstall_DesktopExportsSetting_WritesZip(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	enableClaudeCode(t, s)
+
+	if err := os.MkdirAll(filepath.Dir(s.ProfilePath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(s.ProfilePath, []byte(`{"schema_version":1,"desktop_exports":true}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	regURL := seedTestRegistry(t, s, []testutil.SkillFixture{
+		{
+			Name: "foo", Version: "1.0.0",
+			Platforms: []string{"claude-code"},
+			Files:     testutil.SkillTree{"SKILL.md": sampleSkillMD},
+		},
+	})
+	res := runCLIWithStdoutCapture(t,
+		"install", "foo",
+		"--registry", regURL,
+		"--cache-dir", s.CacheDir,
+		"--manifest", s.ManifestPath,
+		"--profile", s.ProfilePath,
+		"--platform", "claude-code",
+		"--scope", "user",
+		"--json", "--yes",
+	)
+	if res.RunErr != nil {
+		t.Fatalf("install: %v\n%s", res.RunErr, res.Err)
+	}
+	idx := strings.Index(res.Out, "{")
+	var out struct {
+		DesktopZips []struct {
+			Zip string `json:"zip"`
+		} `json:"desktop_zips"`
+	}
+	if err := json.Unmarshal([]byte(res.Out[idx:]), &out); err != nil {
+		t.Fatalf("parse: %v\n%s", err, res.Out)
+	}
+	if len(out.DesktopZips) != 1 {
+		t.Fatalf("desktop_zips = %+v, want 1 entry", out.DesktopZips)
+	}
+	if _, err := os.Stat(out.DesktopZips[0].Zip); err != nil {
+		t.Errorf("auto-exported zip not on disk: %v", err)
+	}
+	names := zipNames(t, out.DesktopZips[0].Zip)
+	if len(names) == 0 || !strings.HasPrefix(names[0], "foo/") {
+		t.Errorf("zip layout wrong: %v", names)
+	}
+}
+
+func TestInstall_DesktopExportsOff_NoZip(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	enableClaudeCode(t, s)
+	installFixtureSkill(t, s, "foo")
+
+	home, _ := os.UserHomeDir()
+	dir := filepath.Join(home, ".humblskills", "desktop")
+	if entries, err := os.ReadDir(dir); err == nil && len(entries) > 0 {
+		t.Errorf("desktop dir should be empty with the setting off; got %v", entries)
+	}
+}

--- a/cli/cmd/humblskills/install.go
+++ b/cli/cmd/humblskills/install.go
@@ -220,8 +220,10 @@ func runInstall(app *App, skill string, f installFlags, fromDashboard bool) erro
 			return err
 		}
 		// Feedback already lives in the progress model's blocking done/summary
-		// screen — printing to the normal buffer here would just get hidden
-		// the instant the dashboard loop re-enters the alt-screen.
+		// screen; the desktop-zip lines below are the exception (they don't
+		// exist in the progress model) — the dashboard loop captures them
+		// onto its status screen, one-shot runs print them normally.
+		maybeDesktopExport(app, res)
 		return nil
 	}
 	if err := run(nil); err != nil {
@@ -229,10 +231,15 @@ func runInstall(app *App, skill string, f installFlags, fromDashboard bool) erro
 	}
 
 	if app.Config.JSON {
-		return app.UI.JSON(res)
+		zips := maybeDesktopExport(app, res)
+		return app.UI.JSON(struct {
+			install.Result
+			DesktopZips []desktopZipInfo `json:"desktop_zips,omitempty"`
+		}{res, zips})
 	}
 
 	printInstall(app, res)
+	maybeDesktopExport(app, res)
 	return nil
 }
 

--- a/cli/cmd/humblskills/profile.go
+++ b/cli/cmd/humblskills/profile.go
@@ -47,7 +47,8 @@ func newProfileSetCmd(app *App) *cobra.Command {
 	return &cobra.Command{
 		Use: "set <key> <value>",
 		Short: "Set a profile value. Keys: platforms (csv), scope (global|user|project|adapter-default), " +
-			"registry (URL/file:// path, or \"\" to clear), status_auto_return_seconds (seconds, or default|off).",
+			"registry (URL/file:// path, or \"\" to clear), status_auto_return_seconds (seconds, or default|off), " +
+			"desktop_exports (on|off — write claude.ai upload zips on every install/update).",
 		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runProfileSet(app, args[0], args[1])
@@ -146,6 +147,8 @@ func runProfileShow(app *App) error {
 		th.KVValue.Render(formatRegistry(p.Registry)))
 	fmt.Fprintln(app.UI.Out(), "  "+th.KVKey.Render("auto-return")+"  "+
 		th.KVValue.Render(formatAutoReturn(p.StatusAutoReturnSeconds)))
+	fmt.Fprintln(app.UI.Out(), "  "+th.KVKey.Render("desktop-zips")+" "+
+		th.KVValue.Render(formatOnOff(p.DesktopExports)))
 	fmt.Fprintln(app.UI.Out(), "  "+th.KVKey.Render("path")+"         "+
 		th.KVValue.Render(app.Config.ProfilePath))
 
@@ -200,8 +203,14 @@ func runProfileSet(app *App, key, value string) error {
 			return err
 		}
 		p.StatusAutoReturnSeconds = seconds
+	case "desktop_exports":
+		on, err := parseOnOff(value)
+		if err != nil {
+			return fmt.Errorf("invalid desktop_exports %q — expected on or off", value)
+		}
+		p.DesktopExports = on
 	default:
-		return fmt.Errorf("unknown key %q — valid keys: platforms, scope, registry, status_auto_return_seconds", key)
+		return fmt.Errorf("unknown key %q — valid keys: platforms, scope, registry, status_auto_return_seconds, desktop_exports", key)
 	}
 
 	if err := profile.Save(app.Config.ProfilePath, p); err != nil {
@@ -299,6 +308,25 @@ func formatAutoReturn(seconds *int) string {
 	default:
 		return fmt.Sprintf("%ds", *seconds)
 	}
+}
+
+// parseOnOff parses a boolean profile value.
+func parseOnOff(value string) (bool, error) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "on", "true", "1":
+		return true, nil
+	case "off", "false", "0", "":
+		return false, nil
+	}
+	return false, fmt.Errorf("expected on or off")
+}
+
+// formatOnOff renders a boolean profile value for `profile show`.
+func formatOnOff(on bool) string {
+	if on {
+		return "on"
+	}
+	return "off (default)"
 }
 
 // formatRegistry renders Profile.Registry for `profile show`.

--- a/cli/cmd/humblskills/skillset.go
+++ b/cli/cmd/humblskills/skillset.go
@@ -3,14 +3,17 @@ package main
 import (
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
 	"sort"
+	"strings"
 
 	"github.com/spf13/cobra"
 
 	"github.com/jjfantini/humblSKILLS/cli/internal/install"
 	"github.com/jjfantini/humblSKILLS/cli/internal/manifest"
 	"github.com/jjfantini/humblSKILLS/cli/internal/profile"
+	"github.com/jjfantini/humblSKILLS/cli/internal/secrets"
 	"github.com/jjfantini/humblSKILLS/cli/internal/skillset"
 	"github.com/jjfantini/humblSKILLS/cli/internal/textutil"
 	"github.com/jjfantini/humblSKILLS/cli/internal/tui"
@@ -100,6 +103,7 @@ func newExportCmd(app *App) *cobra.Command {
 	}
 	cmd.Flags().StringVarP(&output, "output", "o", skillset.DefaultFilename,
 		"skillset file to write")
+	cmd.AddCommand(newExportDesktopCmd(app))
 	return cmd
 }
 
@@ -119,6 +123,19 @@ func runExport(app *App, output string) error {
 			version = insts[0].Version
 		}
 		set.Add(name, version)
+	}
+	// Record the named registries these skills came from so `sync` on another
+	// machine can auto-configure them. Default-registry installs contribute
+	// nothing (every CLI already has the default).
+	if p, err := profile.Load(app.Config.ProfilePath); err == nil && p != nil {
+		for _, inst := range m.Installations {
+			if inst.RegistryName == "" || inst.RegistryName == "default" {
+				continue
+			}
+			if r, ok := p.FindRegistry(inst.RegistryName); ok {
+				set.AddRegistry(r.Name, r.URL)
+			}
+		}
 	}
 	set.Sort()
 
@@ -171,7 +188,10 @@ func newSyncCmd(app *App) *cobra.Command {
 }
 
 func runSync(app *App, path string, f installFlags, prune bool) error {
-	set, err := skillset.LoadFrom(path)
+	// Send the default stored token (if any) on remote skillset fetches so a
+	// skillset can live in the same private repo as its registry.
+	defaultTok, _ := secrets.GetRegistryTokenFor("")
+	set, err := skillset.LoadFrom(path, defaultTok)
 	if err != nil {
 		return err
 	}
@@ -180,13 +200,32 @@ func runSync(app *App, path string, f installFlags, prune bool) error {
 		return nil
 	}
 
+	// Configure any registries the skillset names before loading them: add
+	// missing ones to the profile and walk the user through a token for
+	// private ones. Non-fatal — unreadable registries surface as per-skill
+	// "not found" warnings below.
+	bootstrapSkillsetRegistries(app, set)
+
 	adapterList, err := app.Adapters()
 	if err != nil {
 		return fmt.Errorf("load adapters: %w", err)
 	}
-	reg, _, err := app.registryFetcher().Load()
-	if err != nil {
-		return fmt.Errorf("load registry: %w", err)
+	loaded := app.loadRegistries()
+	anyLoaded := false
+	for _, rs := range loaded {
+		if rs.Err == nil {
+			anyLoaded = true
+		} else if !app.Config.JSON {
+			app.UI.Warn("registry %q unavailable: %v", rs.Name, rs.Err)
+		}
+	}
+	if !anyLoaded {
+		for _, rs := range loaded {
+			if rs.Err != nil {
+				return fmt.Errorf("load registry %q: %w", rs.Name, rs.Err)
+			}
+		}
+		return fmt.Errorf("no registries configured")
 	}
 	p, err := profile.Load(app.Config.ProfilePath)
 	if err != nil {
@@ -205,14 +244,36 @@ func runSync(app *App, path string, f installFlags, prune bool) error {
 		return fmt.Errorf("no platforms selected — run 'humblskills doctor' to see what's detected")
 	}
 
-	engine := app.installEngine()
+	// When a skill exists in several registries, prefer the skillset's own
+	// registry order — the file's author knows where their skills live.
+	regOrder := map[string]int{}
+	for i, r := range set.Registries {
+		regOrder[r.Name] = i + 1
+	}
+
 	var aggregate install.Result
 	var missing []string
 
 	names := set.Names()
 	sort.Strings(names)
 	for _, name := range names {
-		plan, planErr := install.Plan(reg, name)
+		matches := allRegistriesForSkill(loaded, name)
+		if len(matches) == 0 {
+			missing = append(missing, name)
+			app.UI.Warn("skipping %q: not found in any configured registry", name)
+			continue
+		}
+		target := matches[0]
+		if len(matches) > 1 {
+			best := int(^uint(0) >> 1)
+			for _, m := range matches {
+				if o, ok := regOrder[m.Name]; ok && o < best {
+					best = o
+					target = m
+				}
+			}
+		}
+		plan, planErr := install.Plan(target.Reg, name)
 		if planErr != nil {
 			// A skill in the skillset that the registry doesn't know about is a
 			// warning, not a hard failure — sync the rest.
@@ -220,12 +281,13 @@ func runSync(app *App, path string, f installFlags, prune bool) error {
 			app.UI.Warn("skipping %q: %v", name, planErr)
 			continue
 		}
-		res, execErr := engine.Execute(reg, plan, install.ExecuteOpts{
-			Adapters:  adapterList,
-			Platforms: selected,
-			Scope:     scope,
-			Force:     f.force,
-			Global:    global,
+		res, execErr := app.installEngineForToken(target.Token).Execute(target.Reg, plan, install.ExecuteOpts{
+			Adapters:     adapterList,
+			Platforms:    selected,
+			Scope:        scope,
+			Force:        f.force,
+			Global:       global,
+			RegistryName: target.Name,
 		})
 		if execErr != nil {
 			return fmt.Errorf("%s: %w", name, execErr)
@@ -243,12 +305,15 @@ func runSync(app *App, path string, f installFlags, prune bool) error {
 	}
 
 	if app.Config.JSON {
+		zips := maybeDesktopExport(app, aggregate)
 		return app.UI.JSON(struct {
 			install.Result
-			Pruned []install.TargetResult `json:"pruned,omitempty"`
-		}{aggregate, pruned})
+			Pruned      []install.TargetResult `json:"pruned,omitempty"`
+			DesktopZips []desktopZipInfo       `json:"desktop_zips,omitempty"`
+		}{aggregate, pruned, zips})
 	}
 	printInstall(app, aggregate)
+	maybeDesktopExport(app, aggregate)
 	for _, t := range pruned {
 		app.UI.Success("pruned %s [%s/%s]", t.Skill, t.Platform, t.Scope)
 	}
@@ -257,6 +322,111 @@ func runSync(app *App, path string, f installFlags, prune bool) error {
 			len(missing), textutil.Plural(len(missing)), path, missing)
 	}
 	return nil
+}
+
+// bootstrapSkillsetRegistries makes sure every registry the skillset names is
+// configured (adding missing ones to the profile) and readable — walking the
+// user through creating and storing a token for private ones. Everything here
+// is non-fatal: sync continues, and skills from a registry that stays
+// unreadable surface as per-skill warnings.
+func bootstrapSkillsetRegistries(app *App, set *skillset.Set) {
+	if len(set.Registries) == 0 {
+		return
+	}
+	p, err := profile.Load(app.Config.ProfilePath)
+	if err != nil {
+		app.UI.Warn("skillset registries: %v", err)
+		return
+	}
+	for _, r := range set.Registries {
+		if existing, ok := p.FindRegistry(r.Name); ok {
+			if existing.URL != normalizeRegistryURL(strings.TrimSpace(r.URL)) {
+				app.UI.Detail("registry %q already configured (%s) — keeping your URL over the skillset's", r.Name, existing.URL)
+			}
+			ensureRegistryReadable(app, r.Name)
+			continue
+		}
+		name, url, err := addRegistry(app, r.Name, r.URL)
+		if err != nil {
+			app.UI.Warn("skillset registry %q: %v", r.Name, err)
+			continue
+		}
+		app.UI.Success("added registry %s → %s", name, url)
+		ensureRegistryReadable(app, name)
+	}
+}
+
+// ensureRegistryReadable checks a configured registry loads; when it doesn't
+// and no token of its own is stored, prints the token guide and (on a TTY)
+// prompts for one, storing + verifying it via the same path as
+// `registry login`.
+func ensureRegistryReadable(app *App, name string) {
+	var target *resolvedRegistry
+	for _, r := range app.resolvedRegistries() {
+		if r.Name == name {
+			rr := r
+			target = &rr
+			break
+		}
+	}
+	if target == nil {
+		return
+	}
+	if _, _, err := app.fetcherForRegistry(*target).Load(); err == nil {
+		return
+	}
+	if own := secrets.OwnRegistryTokenSource(name); own != secrets.SourceAbsent {
+		app.UI.Warn("registry %q is not readable with its stored token — re-run 'humblskills registry login --name %s'", name, name)
+		return
+	}
+	printTokenGuide(app, name, target.URL)
+	if !app.Prompt.Interactive {
+		app.UI.Warn("no token stored for %q — its skills will be skipped this run; add one with 'humblskills registry login --name %s' and re-run sync", name, name)
+		return
+	}
+	tok, err := app.Prompt.Secret("Paste the token for " + name + " (input hidden)")
+	if err != nil || strings.TrimSpace(tok) == "" {
+		app.UI.Warn("no token provided — skills from %q will be skipped this run", name)
+		return
+	}
+	msg, ok := storeAndVerifyToken(app, name, strings.TrimSpace(tok))
+	if ok {
+		app.UI.Success("%s", msg)
+	} else {
+		app.UI.Warn("%s", msg)
+	}
+}
+
+// printTokenGuide prints the shortest path to a working GitHub token for a
+// private registry, with the repo name filled in when the URL reveals it.
+func printTokenGuide(app *App, name, rawURL string) {
+	repoLabel := "the registry's GitHub repository"
+	if owner, repo := ownerRepoFromRegistryURL(rawURL); owner != "" {
+		repoLabel = owner + "/" + repo
+	}
+	app.UI.Info("registry %q looks private — a GitHub token is needed to read it", name)
+	app.UI.Info("  1. ask the repo owner to give your GitHub account read access to %s", repoLabel)
+	app.UI.Info("  2. open https://github.com/settings/personal-access-tokens → Generate new token (fine-grained)")
+	app.UI.Info("  3. Repository access: 'Only select repositories' → %s", repoLabel)
+	app.UI.Info("  4. Permissions → Repository permissions → Contents: Read-only → Generate, then copy the token")
+	app.UI.Info("  5. paste it at the prompt below (or later: humblskills registry login --name %s)", name)
+}
+
+// ownerRepoFromRegistryURL extracts owner/repo from a github.com or
+// raw.githubusercontent.com registry URL; empty strings when it can't.
+func ownerRepoFromRegistryURL(raw string) (string, string) {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "", ""
+	}
+	if u.Host != "raw.githubusercontent.com" && u.Host != "github.com" {
+		return "", ""
+	}
+	parts := strings.Split(strings.Trim(u.Path, "/"), "/")
+	if len(parts) < 2 {
+		return "", ""
+	}
+	return parts[0], parts[1]
 }
 
 // pruneToSkillset uninstalls every skill that's installed locally but absent

--- a/cli/cmd/humblskills/skillset_test.go
+++ b/cli/cmd/humblskills/skillset_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/jjfantini/humblSKILLS/cli/internal/manifest"
+	"github.com/jjfantini/humblSKILLS/cli/internal/profile"
 	"github.com/jjfantini/humblSKILLS/cli/internal/skillset"
 	"github.com/jjfantini/humblSKILLS/cli/internal/testutil"
 )
@@ -347,5 +348,151 @@ func TestSync_MissingFile_Errors(t *testing.T) {
 	)
 	if res.RunErr == nil {
 		t.Fatal("expected error when skillset file is missing")
+	}
+}
+
+func TestSync_AutoConfiguresRegistryFromSkillset(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	enableClaudeCode(t, s)
+
+	regURL := seedTestRegistry(t, s, []testutil.SkillFixture{
+		{
+			Name: "foo", Version: "1.0.0",
+			Platforms: []string{"claude-code"},
+			Files:     testutil.SkillTree{"SKILL.md": sampleSkillMD},
+		},
+	})
+
+	setPath := filepath.Join(s.Root, "humblskills.json")
+	body := `{"schema_version":1,"registries":[{"name":"work","url":"` + regURL + `"}],"skills":[{"name":"foo"}]}`
+	if err := os.WriteFile(setPath, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	res := runCLIWithStdoutCapture(t,
+		"sync", setPath,
+		"--cache-dir", s.CacheDir,
+		"--manifest", s.ManifestPath,
+		"--profile", s.ProfilePath,
+		"--platform", "claude-code",
+		"--scope", "user",
+		"--yes",
+	)
+	if res.RunErr != nil {
+		t.Fatalf("sync: %v\n%s", res.RunErr, res.Err)
+	}
+
+	// The registry from the skillset must now be configured…
+	p, err := profile.Load(s.ProfilePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r, ok := p.FindRegistry("work"); !ok || r.URL == "" {
+		t.Fatalf("registry not auto-configured; profile registries: %+v", p.Registries)
+	}
+	// …and the skill installed from it, attributed to it.
+	m, err := manifest.Load(s.ManifestPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	insts := m.FindAll("foo")
+	if len(insts) == 0 {
+		t.Fatalf("foo not installed; manifest: %+v", m.Installations)
+	}
+	if insts[0].RegistryName != "work" {
+		t.Errorf("RegistryName = %q, want work", insts[0].RegistryName)
+	}
+}
+
+func TestSync_UnreachableRegistry_NonInteractive_GuidesAndContinues(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	enableClaudeCode(t, s)
+
+	goodURL := seedTestRegistry(t, s, []testutil.SkillFixture{
+		{
+			Name: "foo", Version: "1.0.0",
+			Platforms: []string{"claude-code"},
+			Files:     testutil.SkillTree{"SKILL.md": sampleSkillMD},
+		},
+	})
+
+	setPath := filepath.Join(s.Root, "humblskills.json")
+	body := `{"schema_version":1,"registries":[` +
+		`{"name":"good","url":"` + goodURL + `"},` +
+		`{"name":"private","url":"https://raw.githubusercontent.com/acme/private-skills/main/registry.json"}` +
+		`],"skills":[{"name":"foo"},{"name":"secret-skill"}]}`
+	if err := os.WriteFile(setPath, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	res := runCLIWithStdoutCapture(t,
+		"sync", setPath,
+		"--cache-dir", s.CacheDir,
+		"--manifest", s.ManifestPath,
+		"--profile", s.ProfilePath,
+		"--platform", "claude-code",
+		"--scope", "user",
+		"--yes",
+	)
+	if res.RunErr != nil {
+		t.Fatalf("sync should continue past an unreadable registry: %v\n%s", res.RunErr, res.Err)
+	}
+	// The good registry's skill installed…
+	m, err := manifest.Load(s.ManifestPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(m.FindAll("foo")) == 0 {
+		t.Errorf("foo not installed; manifest: %+v", m.Installations)
+	}
+	// …the private one's skill was skipped, and the token guide printed.
+	if len(m.FindAll("secret-skill")) != 0 {
+		t.Error("secret-skill should not have installed")
+	}
+	combined := res.Out + res.Err
+	assertContains(t, combined, "personal-access-tokens")
+	assertContains(t, combined, "acme/private-skills")
+	assertContains(t, combined, "registry login --name private")
+}
+
+func TestExport_EmitsRegistries(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	enableClaudeCode(t, s)
+
+	regURL := seedTestRegistry(t, s, []testutil.SkillFixture{
+		{
+			Name: "foo", Version: "1.0.0",
+			Platforms: []string{"claude-code"},
+			Files:     testutil.SkillTree{"SKILL.md": sampleSkillMD},
+		},
+	})
+	setPath := filepath.Join(s.Root, "humblskills.json")
+	body := `{"schema_version":1,"registries":[{"name":"work","url":"` + regURL + `"}],"skills":[{"name":"foo"}]}`
+	if err := os.WriteFile(setPath, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if res := runCLIWithStdoutCapture(t,
+		"sync", setPath,
+		"--cache-dir", s.CacheDir, "--manifest", s.ManifestPath, "--profile", s.ProfilePath,
+		"--platform", "claude-code", "--scope", "user", "--yes",
+	); res.RunErr != nil {
+		t.Fatalf("sync: %v\n%s", res.RunErr, res.Err)
+	}
+
+	outPath := filepath.Join(s.Root, "exported.json")
+	if res := runCLIWithStdoutCapture(t,
+		"export",
+		"--manifest", s.ManifestPath, "--profile", s.ProfilePath,
+		"--output", outPath, "--yes",
+	); res.RunErr != nil {
+		t.Fatalf("export: %v\n%s", res.RunErr, res.Err)
+	}
+
+	exported, err := skillset.Load(outPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(exported.Registries) != 1 || exported.Registries[0].Name != "work" {
+		t.Errorf("exported registries = %+v, want [work]", exported.Registries)
 	}
 }

--- a/cli/cmd/humblskills/update.go
+++ b/cli/cmd/humblskills/update.go
@@ -219,7 +219,8 @@ func runUpdate(app *App, only []string, f updateFlags) error {
 			return err
 		}
 		// Feedback already lives in the progress model's blocking done/summary
-		// screen — see runInstall for why we don't also print to stdout here.
+		// screen — see runInstall for why the desktop-zip lines still print.
+		maybeDesktopExport(app, aggregate)
 		return nil
 	}
 	if err := run(nil); err != nil {
@@ -227,9 +228,14 @@ func runUpdate(app *App, only []string, f updateFlags) error {
 	}
 
 	if app.Config.JSON {
-		return app.UI.JSON(aggregate)
+		zips := maybeDesktopExport(app, aggregate)
+		return app.UI.JSON(struct {
+			install.Result
+			DesktopZips []desktopZipInfo `json:"desktop_zips,omitempty"`
+		}{aggregate, zips})
 	}
 	printInstall(app, aggregate)
+	maybeDesktopExport(app, aggregate)
 	return nil
 }
 

--- a/cli/internal/profile/profile.go
+++ b/cli/internal/profile/profile.go
@@ -59,6 +59,13 @@ type Profile struct {
 	// positive value is the number of seconds to wait. Only success
 	// screens auto-return - a failed run always waits for the user.
 	StatusAutoReturnSeconds *int `json:"status_auto_return_seconds,omitempty"`
+
+	// DesktopExports, when true, regenerates a claude.ai / Claude Desktop
+	// upload zip (see `humblskills export desktop`) for every skill that an
+	// install or update touches, under ~/.humblskills/desktop. Off by
+	// default — Desktop uploads are manual either way; this just keeps the
+	// zips fresh.
+	DesktopExports bool `json:"desktop_exports,omitempty"`
 }
 
 // NamedRegistry is one entry in the multi-registry set (Profile.Registries).

--- a/cli/internal/skillset/skillset.go
+++ b/cli/internal/skillset/skillset.go
@@ -41,10 +41,23 @@ type Skill struct {
 	Version string `json:"version,omitempty"`
 }
 
+// Registry is a named registry the skillset's skills come from. `sync`
+// auto-configures any it doesn't have yet (and walks the user through storing
+// a token for private ones). Tokens themselves NEVER belong in a skillset —
+// it's a shared file.
+type Registry struct {
+	Name string `json:"name"`
+	URL  string `json:"url"`
+}
+
 // Set is the full skillset document.
 type Set struct {
 	SchemaVersion int     `json:"schema_version"`
 	Skills        []Skill `json:"skills"`
+	// Registries, when present, lists the named registries needed to resolve
+	// Skills. Additive: older CLIs ignore it and hand-written files may omit
+	// it entirely.
+	Registries []Registry `json:"registries,omitempty"`
 }
 
 // New returns an empty, current-schema Set. Skills is a non-nil empty slice so
@@ -70,9 +83,10 @@ func (s *Set) Add(name, version string) {
 	s.Skills = append(s.Skills, Skill{Name: name, Version: version})
 }
 
-// Sort orders skills by name for stable, diff-friendly output.
+// Sort orders skills and registries by name for stable, diff-friendly output.
 func (s *Set) Sort() {
 	sort.Slice(s.Skills, func(i, j int) bool { return s.Skills[i].Name < s.Skills[j].Name })
+	sort.Slice(s.Registries, func(i, j int) bool { return s.Registries[i].Name < s.Registries[j].Name })
 }
 
 // Names returns the skill names in file order.
@@ -99,17 +113,48 @@ func (s *Set) Validate() error {
 		}
 		seen[sk.Name] = true
 	}
+	seenReg := map[string]bool{}
+	for _, r := range s.Registries {
+		if strings.TrimSpace(r.Name) == "" {
+			return fmt.Errorf("skillset contains a registry with an empty name")
+		}
+		if strings.TrimSpace(r.URL) == "" {
+			return fmt.Errorf("skillset registry %q has an empty url", r.Name)
+		}
+		if seenReg[r.Name] {
+			return fmt.Errorf("skillset lists registry %q more than once", r.Name)
+		}
+		seenReg[r.Name] = true
+	}
 	return nil
+}
+
+// AddRegistry records a named registry, de-duplicating by name (last URL
+// wins). Blank names are ignored.
+func (s *Set) AddRegistry(name, url string) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return
+	}
+	for i := range s.Registries {
+		if s.Registries[i].Name == name {
+			s.Registries[i].URL = url
+			return
+		}
+	}
+	s.Registries = append(s.Registries, Registry{Name: name, URL: url})
 }
 
 // LoadFrom loads a skillset from any supported source: a local filesystem
 // path, a file:// URL, or an http(s):// URL. This is the entry point `sync`
 // uses so a team can host one canonical skillset and everyone runs
-// `humblskills sync https://example.com/humblskills.json`.
-func LoadFrom(source string) (*Set, error) {
+// `humblskills sync https://example.com/humblskills.json`. token, when
+// non-empty, is sent as a Bearer token on http(s) fetches so a skillset can
+// live in the same private repo as its registry.
+func LoadFrom(source, token string) (*Set, error) {
 	switch {
 	case isRemote(source):
-		return loadRemote(source)
+		return loadRemote(source, token)
 	case strings.HasPrefix(source, "file://"):
 		return Load(fileURLPath(source))
 	default:
@@ -133,8 +178,15 @@ func isRemote(source string) bool {
 
 // loadRemote fetches a skillset over HTTP(S) and validates it. It never touches
 // any cache - a skillset is small and the caller asked for a fresh copy.
-func loadRemote(rawURL string) (*Set, error) {
-	resp, err := httpClient.Get(rawURL)
+func loadRemote(rawURL, token string) (*Set, error) {
+	req, err := http.NewRequest(http.MethodGet, rawURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("fetch skillset %s: %w", rawURL, err)
+	}
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("fetch skillset %s: %w", rawURL, err)
 	}

--- a/cli/internal/skillset/skillset_test.go
+++ b/cli/internal/skillset/skillset_test.go
@@ -140,7 +140,7 @@ func TestLoadFrom_LocalPath(t *testing.T) {
 	if err := os.WriteFile(path, []byte(`{"skills":[{"name":"foo"}]}`), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	got, err := LoadFrom(path)
+	got, err := LoadFrom(path, "")
 	if err != nil {
 		t.Fatalf("LoadFrom(local): %v", err)
 	}
@@ -155,7 +155,7 @@ func TestLoadFrom_FileURL(t *testing.T) {
 	if err := os.WriteFile(path, []byte(`{"skills":[{"name":"bar"}]}`), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	got, err := LoadFrom("file://" + path)
+	got, err := LoadFrom("file://"+path, "")
 	if err != nil {
 		t.Fatalf("LoadFrom(file url): %v", err)
 	}
@@ -170,7 +170,7 @@ func TestLoadFrom_RemoteHTTP(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	got, err := LoadFrom(srv.URL + "/humblskills.json")
+	got, err := LoadFrom(srv.URL+"/humblskills.json", "")
 	if err != nil {
 		t.Fatalf("LoadFrom(http): %v", err)
 	}
@@ -185,7 +185,7 @@ func TestLoadFrom_RemoteNon200(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	if _, err := LoadFrom(srv.URL + "/missing.json"); err == nil {
+	if _, err := LoadFrom(srv.URL+"/missing.json", ""); err == nil {
 		t.Fatal("expected error for HTTP 404")
 	}
 }
@@ -196,7 +196,7 @@ func TestLoadFrom_RemoteBadJSON(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	if _, err := LoadFrom(srv.URL + "/bad.json"); err == nil {
+	if _, err := LoadFrom(srv.URL+"/bad.json", ""); err == nil {
 		t.Fatal("expected parse error for invalid JSON")
 	}
 }
@@ -207,7 +207,49 @@ func TestLoadFrom_RemoteValidatesSchema(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	if _, err := LoadFrom(srv.URL + "/s.json"); err == nil {
+	if _, err := LoadFrom(srv.URL+"/s.json", ""); err == nil {
 		t.Fatal("expected validation error for bad schema_version")
+	}
+}
+
+func TestRegistries_RoundTripAndSorted(t *testing.T) {
+	dir := t.TempDir()
+	path := dir + "/humblskills.json"
+	s := New()
+	s.Add("a-skill", "1.0.0")
+	s.AddRegistry("zeta", "https://example.com/z/registry.json")
+	s.AddRegistry("alpha", "https://example.com/a/registry.json")
+	s.AddRegistry("zeta", "https://example.com/z2/registry.json") // last URL wins
+	if err := Save(path, s); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	got, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(got.Registries) != 2 {
+		t.Fatalf("registries = %+v, want 2", got.Registries)
+	}
+	if got.Registries[0].Name != "alpha" || got.Registries[1].Name != "zeta" {
+		t.Errorf("not sorted: %+v", got.Registries)
+	}
+	if got.Registries[1].URL != "https://example.com/z2/registry.json" {
+		t.Errorf("dedupe last-wins failed: %+v", got.Registries[1])
+	}
+}
+
+func TestValidate_RegistryErrors(t *testing.T) {
+	cases := []struct {
+		name string
+		set  Set
+	}{
+		{"empty name", Set{SchemaVersion: SchemaVersion, Registries: []Registry{{Name: " ", URL: "https://x"}}}},
+		{"empty url", Set{SchemaVersion: SchemaVersion, Registries: []Registry{{Name: "a", URL: ""}}}},
+		{"duplicate", Set{SchemaVersion: SchemaVersion, Registries: []Registry{{Name: "a", URL: "https://x"}, {Name: "a", URL: "https://y"}}}},
+	}
+	for _, tc := range cases {
+		if err := tc.set.Validate(); err == nil {
+			t.Errorf("%s: expected validation error", tc.name)
+		}
 	}
 }

--- a/cli/internal/tui/profile.go
+++ b/cli/internal/tui/profile.go
@@ -233,6 +233,11 @@ func (m profileModel) toggleCurrent() profileModel {
 			m.profile.StatusAutoReturnSeconds = autoReturnSettingOpts[m.valueIdx].value
 			m.changed = true
 		}
+	case 3: // desktop zips
+		if m.valueIdx >= 0 && m.valueIdx < len(desktopExportSettingOpts) {
+			m.profile.DesktopExports = desktopExportSettingOpts[m.valueIdx].value
+			m.changed = true
+		}
 	}
 	return m
 }
@@ -266,6 +271,24 @@ var autoReturnSettingOpts = []struct {
 
 func intPtr(n int) *int { return &n }
 
+// desktopExportSettingOpts is the picker for Profile.DesktopExports: whether
+// install/update also regenerates claude.ai / Claude Desktop upload zips.
+var desktopExportSettingOpts = []struct {
+	label string
+	value bool
+}{
+	{"off (default)", false},
+	{"on — write upload zips on every install/update", true},
+}
+
+// desktopExportCurrent maps the profile value onto a picker index.
+func desktopExportCurrent(on bool) int {
+	if on {
+		return 1
+	}
+	return 0
+}
+
 // currentSelectionIndex returns the index in the right-pane options list that
 // represents the profile's current value for the focused setting. Used to
 // place the cursor on the already-selected option when the user drills in.
@@ -287,6 +310,8 @@ func (m profileModel) currentSelectionIndex() int {
 				return i
 			}
 		}
+	case 3:
+		return desktopExportCurrent(m.profile.DesktopExports)
 	}
 	return 0
 }
@@ -309,6 +334,8 @@ func (m profileModel) valueCount() int {
 		return len(scopeSettingOpts)
 	case 2:
 		return len(autoReturnSettingOpts)
+	case 3:
+		return len(desktopExportSettingOpts)
 	}
 	return 0
 }
@@ -332,6 +359,7 @@ var profileSettings = []profileSetting{
 	{key: "platforms", label: "default platforms", kind: settingMulti},
 	{key: "scope", label: "default scope", kind: settingRadio},
 	{key: "status_auto_return", label: "status auto-return", kind: settingRadio},
+	{key: "desktop_exports", label: "desktop zips", kind: settingRadio},
 }
 
 func (m profileModel) View() string {
@@ -460,6 +488,8 @@ func (m profileModel) renderRight(width int) string {
 		body = append(body, m.renderScopeOptions(bar, width)...)
 	case 2:
 		body = append(body, m.renderAutoReturnOptions(bar, width)...)
+	case 3:
+		body = append(body, m.renderDesktopExportOptions(bar, width)...)
 	}
 	return strings.Join(body, "\n")
 }
@@ -586,6 +616,44 @@ func (m profileModel) renderAutoReturnOptions(bar string, width int) []string {
 	return rows
 }
 
+// renderDesktopExportOptions renders the Profile.DesktopExports picker:
+// whether install/update regenerates claude.ai / Claude Desktop upload zips.
+func (m profileModel) renderDesktopExportOptions(bar string, width int) []string {
+	th := m.theme
+	rows := make([]string, 0, len(desktopExportSettingOpts)+4)
+	rows = append(rows, bar+" "+th.Detail.Render(
+		"Claude Desktop and claude.ai take skills as zip uploads. When on, "+
+			"every install/update also writes an upload-ready zip per skill to "+
+			"~/.humblskills/desktop (same as 'humblskills export desktop')."))
+	rows = append(rows, bar)
+	rows = append(rows, bar+" "+th.SectionTitle.Render("OPTIONS"))
+	current := desktopExportCurrent(m.profile.DesktopExports)
+	for i, opt := range desktopExportSettingOpts {
+		cursorHere := i == m.valueIdx && m.focus == focusValue
+		isCurrent := i == current
+		marker := "( )"
+		if isCurrent {
+			marker = "(●)"
+		}
+		var styled string
+		switch {
+		case cursorHere:
+			styled = th.RowSelected.Render(marker + "  " + opt.label)
+		case isCurrent:
+			styled = th.Success.Render(marker) + "  " + th.RowUnselected.Render(opt.label)
+		default:
+			styled = th.RowDim.Render(marker) + "  " + th.RowUnselected.Render(opt.label)
+		}
+		prefix := bar + "   "
+		if cursorHere {
+			prefix = bar + " " + th.Bullet.Render("▸") + " "
+		}
+		rows = append(rows, prefix+styled)
+	}
+	_ = width
+	return rows
+}
+
 func (m profileModel) layoutRow(label, badge string, width int) string {
 	lw := lipgloss.Width(label)
 	bw := lipgloss.Width(badge)
@@ -618,6 +686,11 @@ func (m profileModel) settingBadge(key string) string {
 		}
 	case "status_auto_return":
 		return formatAutoReturnBadge(m.profile.StatusAutoReturnSeconds)
+	case "desktop_exports":
+		if m.profile.DesktopExports {
+			return "on"
+		}
+		return "off (default)"
 	}
 	return ""
 }

--- a/registry.json
+++ b/registry.json
@@ -1,10 +1,10 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-07-28T17:57:30Z",
+  "generated_at": "2026-07-28T20:22:39Z",
   "source": {
     "repo": "github.com/jjfantini/humblSKILLS",
-    "ref": "main",
-    "sha": "6331df5e83eb97ff1241a94578e2e48eaba7cb66"
+    "ref": "feat/sync-bootstrap-and-desktop-export",
+    "sha": "ae94f4ebfa8d1adfe4f6a41b9cd7374519c906a8"
   },
   "skills": [
     {


### PR DESCRIPTION
## Feature A — one-command team onboarding

- `humblskills.json` skillsets gain a `registries` section (additive, old CLIs/files unaffected). `export` records the named registries its skills came from.
- `sync` auto-configures missing registries from the file, and for private ones prints a **step-by-step fine-grained-PAT guide** and prompts (masked, TTY only) for a token — stored + verified via the same path as `registry login`. Non-interactive runs print the guide and skip that registry's skills non-fatally.
- `sync` is now truly **multi-registry** (it previously read only the single default registry): per-skill registry resolution honoring the skillset's registry order, per-registry tokens, `RegistryName` attribution in the manifest.
- Remote skillset fetches send the default stored token, so a skillset can live in the same private repo as its registry.

## Feature B — Claude Desktop bridge

- `humblskills export desktop [skill...]` writes upload-ready zips (skill folder at zip root, from the canonical store — never the symlinked platform paths) to `~/.humblskills/desktop` (or `-o`), with upload instructions (claude.ai → Settings → Capabilities → Skills).
- New profile setting **`desktop_exports`** (CLI `profile set` + TUI picker row): when on, every install/update/sync regenerates the zips automatically, printed on the text path and included as `desktop_zips` in `--json` envelopes. Zip failures warn, never fail the install.

## Verified

- Full `-race` suite + vet green; new tests: registries round-trip/validation, sync auto-configure (profile gains the registry, install attributed to it), unreachable-private-registry non-interactive path (guide printed, other skills still install), export emits registries, desktop zip layout (folder-at-root, all store files), no-arg all-skills JSON, auto-export on/off.
- E2E on a real machine: a skillset naming the private happySKILLS registry bootstrapped it and installed `deal-positioning-framework` in one command (keychain token reused, no prompt); `export desktop` produced a 19-file zip with correct layout, verified with `unzip -l`.

Merge with an empty squash body ([skip ci] registry-bot trap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)