### PR TITLE
feat(cli): claude-desktop as a first-class platform (zip transform)

### DIFF
--- a/cli/cmd/humblskills/desktop.go
+++ b/cli/cmd/humblskills/desktop.go
@@ -1,28 +1,25 @@
 package main
 
 import (
-	"archive/zip"
 	"fmt"
-	"io/fs"
 	"os"
 	"path/filepath"
-	"sort"
 
 	"github.com/spf13/cobra"
 
 	"github.com/jjfantini/humblSKILLS/cli/internal/install"
 	"github.com/jjfantini/humblSKILLS/cli/internal/manifest"
-	"github.com/jjfantini/humblSKILLS/cli/internal/profile"
 	"github.com/jjfantini/humblSKILLS/cli/internal/textutil"
 )
 
-// Claude Desktop and claude.ai can't read filesystem skills — they take an
-// account-level zip upload (skill folder at the zip root, SKILL.md inside).
-// This file is the bridge: `export desktop` writes upload-ready zips from the
-// canonical store, and the profile's desktop_exports setting regenerates them
-// automatically after install/update.
+// Claude Desktop and claude.ai can't read skills from the filesystem — they
+// take an account-level zip upload (skill folder at the zip root). The
+// claude-desktop ADAPTER is the primary path: select it like any platform and
+// install/update keep ~/.humblskills/desktop stocked with current zips. This
+// command is the manual complement: regenerate zips on demand without
+// reinstalling anything.
 
-const desktopUploadHint = "upload at claude.ai (or the Claude desktop app): Settings → Capabilities → Skills → upload the zip. Uploads don't auto-update — re-export after 'humblskills update'."
+const desktopUploadHint = "upload at claude.ai (or the Claude desktop app): Settings → Capabilities → Skills → upload the zip. Uploads don't auto-update — re-upload after 'humblskills update'."
 
 // desktopZipInfo is one written zip, for JSON envelopes and printing.
 type desktopZipInfo struct {
@@ -40,8 +37,9 @@ func newExportDesktopCmd(app *App) *cobra.Command {
 			"they take a zip upload (the skill folder at the zip root). " +
 			"'export desktop' writes one upload-ready zip per installed skill " +
 			"(or just the ones you name) from the canonical humblskills store. " +
-			"Set 'humblskills profile set desktop_exports on' to regenerate the " +
-			"zips automatically on every install/update.",
+			"Tip: select claude-desktop as a platform (install --platform " +
+			"claude-desktop, or in your profile's default platforms) and " +
+			"install/update keep the zips current automatically.",
 		Args: cobra.ArbitraryArgs,
 		RunE: func(_ *cobra.Command, args []string) error {
 			return runExportDesktop(app, args, outDir)
@@ -77,8 +75,8 @@ func runExportDesktop(app *App, names []string, outDir string) error {
 		if inst == nil {
 			return fmt.Errorf("%q has no canonical store recorded — is it installed? (older installs: reinstall once with the current CLI)", name)
 		}
-		zipPath := filepath.Join(outDir, name+"-"+inst.Version+".zip")
-		if err := writeDesktopZip(inst.StorePath, name, zipPath); err != nil {
+		zipPath := filepath.Join(outDir, name+".zip")
+		if err := install.WriteSkillZip(inst.StorePath, name, zipPath); err != nil {
 			return fmt.Errorf("zip %s: %w", name, err)
 		}
 		infos = append(infos, desktopZipInfo{Skill: name, Version: inst.Version, Zip: zipPath})
@@ -108,113 +106,12 @@ func installWithStorePath(m *manifest.Manifest, skill string) *manifest.Installa
 	return nil
 }
 
-// defaultDesktopDir is where auto-exports and no-flag runs put the zips:
-// ~/.humblskills/desktop, next to the canonical global store.
+// defaultDesktopDir is where the zips land: ~/.humblskills/desktop — the same
+// place the claude-desktop adapter targets.
 func defaultDesktopDir() (string, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", fmt.Errorf("resolve home: %w", err)
 	}
 	return filepath.Join(home, ".humblskills", "desktop"), nil
-}
-
-// writeDesktopZip zips the skill's store directory in claude.ai's required
-// layout: every file under a single "<skillName>/…" folder at the zip root.
-// Regular files only (symlinks skipped), sorted walk for deterministic output.
-func writeDesktopZip(storePath, skillName, outPath string) error {
-	var files []string
-	err := filepath.WalkDir(storePath, func(p string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		if d.Type().IsRegular() {
-			files = append(files, p)
-		}
-		return nil
-	})
-	if err != nil {
-		return fmt.Errorf("walk %s: %w", storePath, err)
-	}
-	if len(files) == 0 {
-		return fmt.Errorf("store %s has no files", storePath)
-	}
-	sort.Strings(files)
-
-	f, err := os.Create(outPath)
-	if err != nil {
-		return err
-	}
-	zw := zip.NewWriter(f)
-	for _, p := range files {
-		rel, err := filepath.Rel(storePath, p)
-		if err != nil {
-			zw.Close()
-			f.Close()
-			return err
-		}
-		w, err := zw.Create(skillName + "/" + filepath.ToSlash(rel))
-		if err != nil {
-			zw.Close()
-			f.Close()
-			return err
-		}
-		data, err := os.ReadFile(p)
-		if err != nil {
-			zw.Close()
-			f.Close()
-			return err
-		}
-		if _, err := w.Write(data); err != nil {
-			zw.Close()
-			f.Close()
-			return err
-		}
-	}
-	if err := zw.Close(); err != nil {
-		f.Close()
-		return err
-	}
-	return f.Close()
-}
-
-// maybeDesktopExport regenerates upload zips for the run's changed skills
-// when the profile's desktop_exports setting is on. Returns the zip info for
-// JSON envelopes; prints success lines + the upload hint on the text path.
-// Never fails the install — zip problems are warnings.
-func maybeDesktopExport(app *App, res install.Result) []desktopZipInfo {
-	p, err := profile.Load(app.Config.ProfilePath)
-	if err != nil || p == nil || !p.DesktopExports {
-		return nil
-	}
-	outDir, err := defaultDesktopDir()
-	if err != nil {
-		app.UI.Warn("desktop zips: %v", err)
-		return nil
-	}
-	if err := os.MkdirAll(outDir, 0o755); err != nil {
-		app.UI.Warn("desktop zips: %v", err)
-		return nil
-	}
-
-	seen := map[string]bool{}
-	var infos []desktopZipInfo
-	for _, t := range res.Results {
-		if seen[t.Skill] || t.StorePath == "" || t.Outcome == install.OutcomeSkipped {
-			continue
-		}
-		seen[t.Skill] = true
-		zipPath := filepath.Join(outDir, t.Skill+"-"+t.Version+".zip")
-		if err := writeDesktopZip(t.StorePath, t.Skill, zipPath); err != nil {
-			app.UI.Warn("desktop zip for %s: %v", t.Skill, err)
-			continue
-		}
-		infos = append(infos, desktopZipInfo{Skill: t.Skill, Version: t.Version, Zip: zipPath})
-	}
-	if len(infos) > 0 && !app.Config.JSON {
-		for _, z := range infos {
-			app.UI.Success("desktop zip → %s", z.Zip)
-		}
-		app.UI.Info("%s", desktopUploadHint)
-	}
-	return infos
 }

--- a/cli/cmd/humblskills/desktop_test.go
+++ b/cli/cmd/humblskills/desktop_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/jjfantini/humblSKILLS/cli/internal/install"
+	"github.com/jjfantini/humblSKILLS/cli/internal/manifest"
 	"github.com/jjfantini/humblSKILLS/cli/internal/testutil"
 )
 
@@ -69,7 +71,7 @@ func TestExportDesktop_WritesUploadReadyZip(t *testing.T) {
 		t.Fatalf("export desktop: %v\n%s", res.RunErr, res.Err)
 	}
 
-	zipPath := filepath.Join(outDir, "foo-1.0.0.zip")
+	zipPath := filepath.Join(outDir, "foo.zip")
 	names := zipNames(t, zipPath)
 	want := map[string]bool{"foo/SKILL.md": false, "foo/references/notes.md": false}
 	for _, n := range names {
@@ -135,21 +137,14 @@ func TestExportDesktop_NotInstalled_Errors(t *testing.T) {
 	}
 }
 
-func TestInstall_DesktopExportsSetting_WritesZip(t *testing.T) {
+func TestInstall_ClaudeDesktopPlatform_WritesZip(t *testing.T) {
 	s := testutil.NewSandbox(t)
 	enableClaudeCode(t, s)
-
-	if err := os.MkdirAll(filepath.Dir(s.ProfilePath), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(s.ProfilePath, []byte(`{"schema_version":1,"desktop_exports":true}`), 0o644); err != nil {
-		t.Fatal(err)
-	}
 
 	regURL := seedTestRegistry(t, s, []testutil.SkillFixture{
 		{
 			Name: "foo", Version: "1.0.0",
-			Platforms: []string{"claude-code"},
+			Platforms: []string{"claude-code", "claude-desktop"},
 			Files:     testutil.SkillTree{"SKILL.md": sampleSkillMD},
 		},
 	})
@@ -159,42 +154,58 @@ func TestInstall_DesktopExportsSetting_WritesZip(t *testing.T) {
 		"--cache-dir", s.CacheDir,
 		"--manifest", s.ManifestPath,
 		"--profile", s.ProfilePath,
-		"--platform", "claude-code",
+		"--platform", "claude-code,claude-desktop",
 		"--scope", "user",
-		"--json", "--yes",
+		"--yes",
 	)
 	if res.RunErr != nil {
 		t.Fatalf("install: %v\n%s", res.RunErr, res.Err)
 	}
-	idx := strings.Index(res.Out, "{")
-	var out struct {
-		DesktopZips []struct {
-			Zip string `json:"zip"`
-		} `json:"desktop_zips"`
+
+	m, err := manifest.Load(s.ManifestPath)
+	if err != nil {
+		t.Fatal(err)
 	}
-	if err := json.Unmarshal([]byte(res.Out[idx:]), &out); err != nil {
-		t.Fatalf("parse: %v\n%s", err, res.Out)
+	desktop := m.FindOne("foo", "claude-desktop", "user")
+	if desktop == nil {
+		t.Fatalf("no claude-desktop manifest entry; manifest: %+v", m.Installations)
 	}
-	if len(out.DesktopZips) != 1 {
-		t.Fatalf("desktop_zips = %+v, want 1 entry", out.DesktopZips)
+	if desktop.InstallMode != install.InstallModeZip {
+		t.Errorf("InstallMode = %q, want zip", desktop.InstallMode)
 	}
-	if _, err := os.Stat(out.DesktopZips[0].Zip); err != nil {
-		t.Errorf("auto-exported zip not on disk: %v", err)
+	if !strings.HasSuffix(desktop.Path, "foo.zip") {
+		t.Errorf("Path = %q, want …/foo.zip", desktop.Path)
 	}
-	names := zipNames(t, out.DesktopZips[0].Zip)
+	names := zipNames(t, desktop.Path)
 	if len(names) == 0 || !strings.HasPrefix(names[0], "foo/") {
 		t.Errorf("zip layout wrong: %v", names)
 	}
-}
+	assertContains(t, res.Out+res.Err, "upload at claude.ai")
 
-func TestInstall_DesktopExportsOff_NoZip(t *testing.T) {
-	s := testutil.NewSandbox(t)
-	enableClaudeCode(t, s)
-	installFixtureSkill(t, s, "foo")
+	// Second install is idempotent for the zip target too.
+	res = runCLIWithStdoutCapture(t,
+		"install", "foo",
+		"--registry", regURL,
+		"--cache-dir", s.CacheDir,
+		"--manifest", s.ManifestPath,
+		"--profile", s.ProfilePath,
+		"--platform", "claude-desktop",
+		"--scope", "user",
+		"--json", "--yes",
+	)
+	if res.RunErr != nil {
+		t.Fatalf("reinstall: %v\n%s", res.RunErr, res.Err)
+	}
+	assertContains(t, res.Out, "\"outcome\": \"skipped\"")
 
-	home, _ := os.UserHomeDir()
-	dir := filepath.Join(home, ".humblskills", "desktop")
-	if entries, err := os.ReadDir(dir); err == nil && len(entries) > 0 {
-		t.Errorf("desktop dir should be empty with the setting off; got %v", entries)
+	// Uninstall removes the zip.
+	if res := runCLIWithStdoutCapture(t,
+		"uninstall", "foo",
+		"--manifest", s.ManifestPath, "--profile", s.ProfilePath, "--yes",
+	); res.RunErr != nil {
+		t.Fatalf("uninstall: %v\n%s", res.RunErr, res.Err)
+	}
+	if _, err := os.Stat(desktop.Path); !os.IsNotExist(err) {
+		t.Errorf("zip still on disk after uninstall: %v", err)
 	}
 }

--- a/cli/cmd/humblskills/install.go
+++ b/cli/cmd/humblskills/install.go
@@ -220,10 +220,8 @@ func runInstall(app *App, skill string, f installFlags, fromDashboard bool) erro
 			return err
 		}
 		// Feedback already lives in the progress model's blocking done/summary
-		// screen; the desktop-zip lines below are the exception (they don't
-		// exist in the progress model) — the dashboard loop captures them
-		// onto its status screen, one-shot runs print them normally.
-		maybeDesktopExport(app, res)
+		// screen — printing to the normal buffer here would just get hidden
+		// the instant the dashboard loop re-enters the alt-screen.
 		return nil
 	}
 	if err := run(nil); err != nil {
@@ -231,15 +229,10 @@ func runInstall(app *App, skill string, f installFlags, fromDashboard bool) erro
 	}
 
 	if app.Config.JSON {
-		zips := maybeDesktopExport(app, res)
-		return app.UI.JSON(struct {
-			install.Result
-			DesktopZips []desktopZipInfo `json:"desktop_zips,omitempty"`
-		}{res, zips})
+		return app.UI.JSON(res)
 	}
 
 	printInstall(app, res)
-	maybeDesktopExport(app, res)
 	return nil
 }
 
@@ -349,6 +342,12 @@ func printInstall(app *App, r install.Result) {
 	}
 	if len(installed)+len(replaced)+len(forced) == 0 {
 		app.UI.Info("%d target%s already up-to-date (use --force to reinstall)", len(skipped), textutil.Plural(len(skipped)))
+	}
+	for _, t := range r.Results {
+		if t.Platform == "claude-desktop" && t.Outcome != install.OutcomeSkipped {
+			app.UI.Info("%s", desktopUploadHint)
+			break
+		}
 	}
 }
 

--- a/cli/cmd/humblskills/profile.go
+++ b/cli/cmd/humblskills/profile.go
@@ -47,8 +47,7 @@ func newProfileSetCmd(app *App) *cobra.Command {
 	return &cobra.Command{
 		Use: "set <key> <value>",
 		Short: "Set a profile value. Keys: platforms (csv), scope (global|user|project|adapter-default), " +
-			"registry (URL/file:// path, or \"\" to clear), status_auto_return_seconds (seconds, or default|off), " +
-			"desktop_exports (on|off — write claude.ai upload zips on every install/update).",
+			"registry (URL/file:// path, or \"\" to clear), status_auto_return_seconds (seconds, or default|off).",
 		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runProfileSet(app, args[0], args[1])
@@ -147,8 +146,6 @@ func runProfileShow(app *App) error {
 		th.KVValue.Render(formatRegistry(p.Registry)))
 	fmt.Fprintln(app.UI.Out(), "  "+th.KVKey.Render("auto-return")+"  "+
 		th.KVValue.Render(formatAutoReturn(p.StatusAutoReturnSeconds)))
-	fmt.Fprintln(app.UI.Out(), "  "+th.KVKey.Render("desktop-zips")+" "+
-		th.KVValue.Render(formatOnOff(p.DesktopExports)))
 	fmt.Fprintln(app.UI.Out(), "  "+th.KVKey.Render("path")+"         "+
 		th.KVValue.Render(app.Config.ProfilePath))
 
@@ -203,14 +200,8 @@ func runProfileSet(app *App, key, value string) error {
 			return err
 		}
 		p.StatusAutoReturnSeconds = seconds
-	case "desktop_exports":
-		on, err := parseOnOff(value)
-		if err != nil {
-			return fmt.Errorf("invalid desktop_exports %q — expected on or off", value)
-		}
-		p.DesktopExports = on
 	default:
-		return fmt.Errorf("unknown key %q — valid keys: platforms, scope, registry, status_auto_return_seconds, desktop_exports", key)
+		return fmt.Errorf("unknown key %q — valid keys: platforms, scope, registry, status_auto_return_seconds", key)
 	}
 
 	if err := profile.Save(app.Config.ProfilePath, p); err != nil {
@@ -308,25 +299,6 @@ func formatAutoReturn(seconds *int) string {
 	default:
 		return fmt.Sprintf("%ds", *seconds)
 	}
-}
-
-// parseOnOff parses a boolean profile value.
-func parseOnOff(value string) (bool, error) {
-	switch strings.ToLower(strings.TrimSpace(value)) {
-	case "on", "true", "1":
-		return true, nil
-	case "off", "false", "0", "":
-		return false, nil
-	}
-	return false, fmt.Errorf("expected on or off")
-}
-
-// formatOnOff renders a boolean profile value for `profile show`.
-func formatOnOff(on bool) string {
-	if on {
-		return "on"
-	}
-	return "off (default)"
 }
 
 // formatRegistry renders Profile.Registry for `profile show`.

--- a/cli/cmd/humblskills/skillset.go
+++ b/cli/cmd/humblskills/skillset.go
@@ -305,15 +305,12 @@ func runSync(app *App, path string, f installFlags, prune bool) error {
 	}
 
 	if app.Config.JSON {
-		zips := maybeDesktopExport(app, aggregate)
 		return app.UI.JSON(struct {
 			install.Result
-			Pruned      []install.TargetResult `json:"pruned,omitempty"`
-			DesktopZips []desktopZipInfo       `json:"desktop_zips,omitempty"`
-		}{aggregate, pruned, zips})
+			Pruned []install.TargetResult `json:"pruned,omitempty"`
+		}{aggregate, pruned})
 	}
 	printInstall(app, aggregate)
-	maybeDesktopExport(app, aggregate)
 	for _, t := range pruned {
 		app.UI.Success("pruned %s [%s/%s]", t.Skill, t.Platform, t.Scope)
 	}

--- a/cli/cmd/humblskills/update.go
+++ b/cli/cmd/humblskills/update.go
@@ -219,8 +219,7 @@ func runUpdate(app *App, only []string, f updateFlags) error {
 			return err
 		}
 		// Feedback already lives in the progress model's blocking done/summary
-		// screen — see runInstall for why the desktop-zip lines still print.
-		maybeDesktopExport(app, aggregate)
+		// screen — see runInstall for why we don't also print to stdout here.
 		return nil
 	}
 	if err := run(nil); err != nil {
@@ -228,14 +227,9 @@ func runUpdate(app *App, only []string, f updateFlags) error {
 	}
 
 	if app.Config.JSON {
-		zips := maybeDesktopExport(app, aggregate)
-		return app.UI.JSON(struct {
-			install.Result
-			DesktopZips []desktopZipInfo `json:"desktop_zips,omitempty"`
-		}{aggregate, zips})
+		return app.UI.JSON(aggregate)
 	}
 	printInstall(app, aggregate)
-	maybeDesktopExport(app, aggregate)
 	return nil
 }
 

--- a/cli/internal/adapters/adapters.go
+++ b/cli/internal/adapters/adapters.go
@@ -14,6 +14,11 @@ type Adapter struct {
 	Transform      string            `yaml:"transform"`
 }
 
+// TransformZip is the adapter transform that writes an upload-ready zip
+// (skill folder at the zip root) instead of symlinking the store — used by
+// claude-desktop, which only accepts account-level zip uploads.
+const TransformZip = "zip"
+
 // DetectRules describes how to decide whether this platform is present on the
 // user's machine. Only one of AnyOf / AllOf should be set.
 type DetectRules struct {

--- a/cli/internal/adapters/claude-desktop.yaml
+++ b/cli/internal/adapters/claude-desktop.yaml
@@ -1,0 +1,18 @@
+name: claude-desktop
+# Claude Desktop / claude.ai can't read skills from the filesystem — they
+# take an account-level zip upload. This adapter's transform writes an
+# upload-ready zip (skill folder at the zip root) instead of symlinking, so
+# selecting the platform keeps ~/.humblskills/desktop stocked with current
+# zips to upload at claude.ai → Settings → Capabilities → Skills.
+# Detection probes the app's per-user data dir (created on first run) rather
+# than the app bundle: home-relative paths keep detection correct per user
+# and hermetic under test sandboxes that re-home $HOME.
+detect:
+  any_of:
+    - path_exists: ~/Library/Application Support/Claude
+    - path_exists: ~/AppData/Roaming/Claude
+    - path_exists: ~/.config/Claude
+install_targets:
+  user: ~/.humblskills/desktop
+default_scope: user
+transform: zip

--- a/cli/internal/install/engine.go
+++ b/cli/internal/install/engine.go
@@ -238,7 +238,11 @@ func (e *Engine) installOne(
 		}
 		adapter := adapterIndex[p]
 		scope := opts.Scope
-		if opts.Global {
+		if adapter.Transform == adapters.TransformZip {
+			// Zip targets (claude-desktop) have one machine-wide output dir;
+			// project/global scope distinctions don't apply to an upload zip.
+			scope = adapter.DefaultScope
+		} else if opts.Global {
 			scope = "user"
 		} else if scope == "" {
 			scope = adapter.DefaultScope
@@ -247,17 +251,31 @@ func (e *Engine) installOne(
 		if err != nil {
 			return nil, err
 		}
+		final := filepath.Join(t.Path, skill.Name)
+		if adapter.Transform == adapters.TransformZip {
+			final = filepath.Join(t.Path, skill.Name+".zip")
+		}
 		pendings = append(pendings, installPending{
 			adapter: adapter,
 			target:  t,
-			final:   filepath.Join(t.Path, skill.Name),
+			final:   final,
 		})
 	}
 	if len(pendings) == 0 {
 		return nil, nil
 	}
 
-	storePath, err := CanonicalSkillPath(skill.Name, pendings[0].target.Scope, opts.Global)
+	// The canonical store's scope follows the first real (non-zip) target;
+	// zip targets are derived artifacts and shouldn't decide where the store
+	// lives when mixed with filesystem platforms.
+	storeScope := pendings[0].target.Scope
+	for _, pg := range pendings {
+		if pg.adapter.Transform != adapters.TransformZip {
+			storeScope = pg.target.Scope
+			break
+		}
+	}
+	storePath, err := CanonicalSkillPath(skill.Name, storeScope, opts.Global)
 	if err != nil {
 		return nil, err
 	}
@@ -273,13 +291,23 @@ func (e *Engine) installOne(
 			orphan = existing.Path
 		}
 
+		targetMode := mode
+		if pg.adapter.Transform == adapters.TransformZip {
+			targetMode = InstallModeZip
+		}
 		upToDate := existing != nil &&
 			existing.Version == skill.Version &&
 			existing.RegistryRef == skill.DirSHA &&
 			existing.Path == pg.final &&
 			existing.StorePath == storePath &&
-			existing.InstallMode == mode
-		if !targetLinksToStore(pg.final, storePath) {
+			existing.InstallMode == targetMode
+		if pg.adapter.Transform == adapters.TransformZip {
+			// A zip is current when the manifest matches and the file exists —
+			// it's a derived artifact, not a link back to the store.
+			if _, err := os.Stat(pg.final); err != nil {
+				upToDate = false
+			}
+		} else if !targetLinksToStore(pg.final, storePath) {
 			upToDate = false
 		}
 		if _, err := os.Stat(filepath.Join(storePath, "SKILL.md")); err != nil {
@@ -391,7 +419,13 @@ func (e *Engine) installOne(
 				return nil, fmt.Errorf("clean old install %s: %w", pt.orphan, err)
 			}
 		}
-		if err := linkStore(storePath, pt.pending.final); err != nil {
+		targetMode := mode
+		if pt.pending.adapter.Transform == adapters.TransformZip {
+			targetMode = InstallModeZip
+			if err := WriteSkillZip(storePath, skill.Name, pt.pending.final); err != nil {
+				return nil, fmt.Errorf("zip %s -> %s: %w", storePath, pt.pending.final, err)
+			}
+		} else if err := linkStore(storePath, pt.pending.final); err != nil {
 			return nil, fmt.Errorf("link %s -> %s: %w", pt.pending.final, storePath, err)
 		}
 		m.Upsert(manifest.Installation{
@@ -401,7 +435,7 @@ func (e *Engine) installOne(
 			Scope:        pt.pending.target.Scope,
 			Path:         pt.pending.final,
 			StorePath:    storePath,
-			InstallMode:  mode,
+			InstallMode:  targetMode,
 			InstalledAt:  e.Now().UTC(),
 			SourceSHA:    reg.Source.SHA,
 			RegistryRef:  skill.DirSHA,

--- a/cli/internal/install/store.go
+++ b/cli/internal/install/store.go
@@ -11,6 +11,9 @@ import (
 const (
 	InstallModeLinked = "linked"
 	InstallModeGlobal = "global"
+	// InstallModeZip marks a claude-desktop upload zip target: a derived
+	// artifact regenerated from the store, not a link back to it.
+	InstallModeZip = "zip"
 )
 
 // CanonicalSkillPath returns the humblskills-owned source directory for a

--- a/cli/internal/install/zip.go
+++ b/cli/internal/install/zip.go
@@ -1,0 +1,69 @@
+package install
+
+import (
+	"archive/zip"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+// WriteSkillZip zips a skill's store directory in claude.ai's required upload
+// layout: every file under a single "<skillName>/…" folder at the zip root.
+// Regular files only (symlinks skipped), sorted walk for deterministic
+// output. Used by the claude-desktop adapter's zip transform and the
+// `export desktop` command.
+func WriteSkillZip(storePath, skillName, outPath string) error {
+	var files []string
+	err := filepath.WalkDir(storePath, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.Type().IsRegular() {
+			files = append(files, p)
+		}
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("walk %s: %w", storePath, err)
+	}
+	if len(files) == 0 {
+		return fmt.Errorf("store %s has no files", storePath)
+	}
+	sort.Strings(files)
+
+	if err := os.MkdirAll(filepath.Dir(outPath), 0o755); err != nil {
+		return err
+	}
+	f, err := os.Create(outPath)
+	if err != nil {
+		return err
+	}
+	zw := zip.NewWriter(f)
+	write := func() error {
+		for _, p := range files {
+			rel, err := filepath.Rel(storePath, p)
+			if err != nil {
+				return err
+			}
+			w, err := zw.Create(skillName + "/" + filepath.ToSlash(rel))
+			if err != nil {
+				return err
+			}
+			data, err := os.ReadFile(p)
+			if err != nil {
+				return err
+			}
+			if _, err := w.Write(data); err != nil {
+				return err
+			}
+		}
+		return zw.Close()
+	}
+	if err := write(); err != nil {
+		f.Close()
+		return err
+	}
+	return f.Close()
+}

--- a/cli/internal/profile/profile.go
+++ b/cli/internal/profile/profile.go
@@ -59,13 +59,6 @@ type Profile struct {
 	// positive value is the number of seconds to wait. Only success
 	// screens auto-return - a failed run always waits for the user.
 	StatusAutoReturnSeconds *int `json:"status_auto_return_seconds,omitempty"`
-
-	// DesktopExports, when true, regenerates a claude.ai / Claude Desktop
-	// upload zip (see `humblskills export desktop`) for every skill that an
-	// install or update touches, under ~/.humblskills/desktop. Off by
-	// default — Desktop uploads are manual either way; this just keeps the
-	// zips fresh.
-	DesktopExports bool `json:"desktop_exports,omitempty"`
 }
 
 // NamedRegistry is one entry in the multi-registry set (Profile.Registries).

--- a/cli/internal/tui/profile.go
+++ b/cli/internal/tui/profile.go
@@ -233,11 +233,6 @@ func (m profileModel) toggleCurrent() profileModel {
 			m.profile.StatusAutoReturnSeconds = autoReturnSettingOpts[m.valueIdx].value
 			m.changed = true
 		}
-	case 3: // desktop zips
-		if m.valueIdx >= 0 && m.valueIdx < len(desktopExportSettingOpts) {
-			m.profile.DesktopExports = desktopExportSettingOpts[m.valueIdx].value
-			m.changed = true
-		}
 	}
 	return m
 }
@@ -271,23 +266,22 @@ var autoReturnSettingOpts = []struct {
 
 func intPtr(n int) *int { return &n }
 
-// desktopExportSettingOpts is the picker for Profile.DesktopExports: whether
-// install/update also regenerates claude.ai / Claude Desktop upload zips.
-var desktopExportSettingOpts = []struct {
-	label string
-	value bool
-}{
-	{"off (default)", false},
-	{"on — write upload zips on every install/update", true},
+// detailLines wraps a setting description to the value pane's width and
+// prefixes each wrapped line with the divider bar, so long descriptions
+// flow instead of getting clipped at the pane edge on narrow terminals.
+func detailLines(th *ui.Theme, bar, text string, width int) []string {
+	w := width - 4
+	if w < 16 {
+		w = 16
+	}
+	wrapped := th.Detail.Width(w).Render(text)
+	var out []string
+	for _, line := range strings.Split(wrapped, "\n") {
+		out = append(out, bar+" "+line)
+	}
+	return out
 }
 
-// desktopExportCurrent maps the profile value onto a picker index.
-func desktopExportCurrent(on bool) int {
-	if on {
-		return 1
-	}
-	return 0
-}
 
 // currentSelectionIndex returns the index in the right-pane options list that
 // represents the profile's current value for the focused setting. Used to
@@ -310,8 +304,6 @@ func (m profileModel) currentSelectionIndex() int {
 				return i
 			}
 		}
-	case 3:
-		return desktopExportCurrent(m.profile.DesktopExports)
 	}
 	return 0
 }
@@ -334,8 +326,6 @@ func (m profileModel) valueCount() int {
 		return len(scopeSettingOpts)
 	case 2:
 		return len(autoReturnSettingOpts)
-	case 3:
-		return len(desktopExportSettingOpts)
 	}
 	return 0
 }
@@ -359,7 +349,6 @@ var profileSettings = []profileSetting{
 	{key: "platforms", label: "default platforms", kind: settingMulti},
 	{key: "scope", label: "default scope", kind: settingRadio},
 	{key: "status_auto_return", label: "status auto-return", kind: settingRadio},
-	{key: "desktop_exports", label: "desktop zips", kind: settingRadio},
 }
 
 func (m profileModel) View() string {
@@ -488,8 +477,6 @@ func (m profileModel) renderRight(width int) string {
 		body = append(body, m.renderScopeOptions(bar, width)...)
 	case 2:
 		body = append(body, m.renderAutoReturnOptions(bar, width)...)
-	case 3:
-		body = append(body, m.renderDesktopExportOptions(bar, width)...)
 	}
 	return strings.Join(body, "\n")
 }
@@ -502,8 +489,8 @@ func (m profileModel) renderPlatformOptions(bar string, width int) []string {
 	}
 	rows := make([]string, 0, len(m.adapters)+2)
 	if len(m.profile.DefaultPlatforms) == 0 {
-		rows = append(rows, bar+" "+th.Detail.Render(
-			"No defaults set — installs target every detected platform."))
+		rows = append(rows, detailLines(th, bar,
+			"No defaults set — installs target every detected platform.", width)...)
 		rows = append(rows, bar)
 	}
 	rows = append(rows, bar+" "+th.SectionTitle.Render("PLATFORMS"))
@@ -529,7 +516,6 @@ func (m profileModel) renderPlatformOptions(bar string, width int) []string {
 		}
 		rows = append(rows, prefix+styled)
 	}
-	_ = width
 	return rows
 }
 
@@ -537,10 +523,10 @@ func (m profileModel) renderScopeOptions(bar string, width int) []string {
 	th := m.theme
 	resolved := m.profile.ResolvedScope()
 	rows := make([]string, 0, len(scopeSettingOpts)+4)
-	rows = append(rows, bar+" "+th.Detail.Render(
+	rows = append(rows, detailLines(th, bar,
 		"Which scope installs default to. Global humblskills installs one canonical "+
 			"copy and symlinks it to every selected platform — recommended for most "+
-			"setups. User/project pin a concrete platform-native location instead."))
+			"setups. User/project pin a concrete platform-native location instead.", width)...)
 	rows = append(rows, bar)
 	rows = append(rows, bar+" "+th.SectionTitle.Render("OPTIONS"))
 	for i, opt := range scopeSettingOpts {
@@ -567,13 +553,12 @@ func (m profileModel) renderScopeOptions(bar string, width int) []string {
 	}
 	if resolved == profile.ScopeAdapterDefault {
 		rows = append(rows, bar)
-		rows = append(rows, bar+" "+th.Detail.Render(
+		rows = append(rows, detailLines(th, bar,
 			"Note: adapter default can't show a concrete location up front — "+
 				"every platform here happens to default to \"user\" today, but the "+
 				"install screen will still ask you to pick a scope since it can't "+
-				"display one for this setting."))
+				"display one for this setting.", width)...)
 	}
-	_ = width
 	return rows
 }
 
@@ -584,10 +569,10 @@ func (m profileModel) renderAutoReturnOptions(bar string, width int) []string {
 	th := m.theme
 	cur := m.profile.StatusAutoReturnSeconds
 	rows := make([]string, 0, len(autoReturnSettingOpts)+4)
-	rows = append(rows, bar+" "+th.Detail.Render(
+	rows = append(rows, detailLines(th, bar,
 		"How long a completed status screen (registry refresh, install, update) "+
 			"stays up before automatically returning to the dashboard. A failed run "+
-			"always waits for enter/q — this only applies to successful runs."))
+			"always waits for enter/q — this only applies to successful runs.", width)...)
 	rows = append(rows, bar)
 	rows = append(rows, bar+" "+th.SectionTitle.Render("OPTIONS"))
 	for i, opt := range autoReturnSettingOpts {
@@ -612,45 +597,6 @@ func (m profileModel) renderAutoReturnOptions(bar string, width int) []string {
 		}
 		rows = append(rows, prefix+styled)
 	}
-	_ = width
-	return rows
-}
-
-// renderDesktopExportOptions renders the Profile.DesktopExports picker:
-// whether install/update regenerates claude.ai / Claude Desktop upload zips.
-func (m profileModel) renderDesktopExportOptions(bar string, width int) []string {
-	th := m.theme
-	rows := make([]string, 0, len(desktopExportSettingOpts)+4)
-	rows = append(rows, bar+" "+th.Detail.Render(
-		"Claude Desktop and claude.ai take skills as zip uploads. When on, "+
-			"every install/update also writes an upload-ready zip per skill to "+
-			"~/.humblskills/desktop (same as 'humblskills export desktop')."))
-	rows = append(rows, bar)
-	rows = append(rows, bar+" "+th.SectionTitle.Render("OPTIONS"))
-	current := desktopExportCurrent(m.profile.DesktopExports)
-	for i, opt := range desktopExportSettingOpts {
-		cursorHere := i == m.valueIdx && m.focus == focusValue
-		isCurrent := i == current
-		marker := "( )"
-		if isCurrent {
-			marker = "(●)"
-		}
-		var styled string
-		switch {
-		case cursorHere:
-			styled = th.RowSelected.Render(marker + "  " + opt.label)
-		case isCurrent:
-			styled = th.Success.Render(marker) + "  " + th.RowUnselected.Render(opt.label)
-		default:
-			styled = th.RowDim.Render(marker) + "  " + th.RowUnselected.Render(opt.label)
-		}
-		prefix := bar + "   "
-		if cursorHere {
-			prefix = bar + " " + th.Bullet.Render("▸") + " "
-		}
-		rows = append(rows, prefix+styled)
-	}
-	_ = width
 	return rows
 }
 
@@ -686,11 +632,6 @@ func (m profileModel) settingBadge(key string) string {
 		}
 	case "status_auto_return":
 		return formatAutoReturnBadge(m.profile.StatusAutoReturnSeconds)
-	case "desktop_exports":
-		if m.profile.DesktopExports {
-			return "on"
-		}
-		return "off (default)"
 	}
 	return ""
 }

--- a/registry.json
+++ b/registry.json
@@ -1,10 +1,10 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-07-28T20:23:30Z",
+  "generated_at": "2026-07-28T21:11:45Z",
   "source": {
     "repo": "github.com/jjfantini/humblSKILLS",
-    "ref": "main",
-    "sha": "f58d5810af2b9652be9e941814e3e6e9df39399c"
+    "ref": "feat/claude-desktop-platform",
+    "sha": "85ca28b4281ad8242e70a0fa0632bf3853a43eee"
   },
   "skills": [
     {


### PR DESCRIPTION
## What (per user feedback on v2.38.0)

Rolls the Claude Desktop zip export into the **platform model** instead of a separate profile toggle:

- New **claude-desktop adapter** (`cli/internal/adapters/claude-desktop.yaml`) — detected via the app's per-user data dir (`~/Library/Application Support/Claude` on macOS, `~/AppData/Roaming/Claude` on Windows, `~/.config/Claude` on Linux; home-relative so detection is per-user and test-hermetic). Its `transform: zip` activates a new engine path that writes an upload-ready zip (`~/.humblskills/desktop/<skill>.zip`, folder-at-root layout) instead of symlinking.
- Wired through the **install engine**: manifest entries with `InstallMode: zip`, idempotent up-to-date checks (manifest match + zip exists), scope pinned to the adapter default (an upload zip has no project/global distinction), store scope decided by the first real filesystem target when mixed, uninstall removes the zip. Every surface that enumerates platforms — install picker, `--platform`, profile default platforms, global fanout over detected platforms — now includes claude-desktop with zero extra UI.
- `printInstall` reminds where to upload (claude.ai → Settings → Capabilities → Skills) whenever a zip was written.
- **Removes the `desktop_exports` profile setting** (shipped for one day in v2.38.0): profile field, CLI key, TUI picker row. Stale keys in profiles are ignored on load. `export desktop` stays as the on-demand regenerator, now writing stable `<skill>.zip` names matching the adapter target.
- **Fixes the profile editor clipping**: long setting descriptions in the value pane now wrap to the pane width (`detailLines` helper applied to every picker) instead of being cut off on narrow terminals.

## Verified

- Full `-race` suite + vet green. New/updated tests: install with `--platform claude-code,claude-desktop` → manifest zip entry, folder-at-root layout, upload hint printed, second install skipped (idempotent), uninstall removes the zip; `export desktop` layout/no-arg/JSON tests updated to the new naming.
- Detection initially probed `/Applications/Claude.app` — an absolute path that leaked the host machine into every test sandbox; switched to home-relative data dirs and the whole suite is hermetic again.

Merge with an empty squash body ([skip ci] registry-bot trap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)