### PR TITLE
feat(cli): group skills TUI by category with collapsible sections

### DIFF
--- a/cli/cmd/humblskills/browse_skills.go
+++ b/cli/cmd/humblskills/browse_skills.go
@@ -8,11 +8,14 @@ import (
 	"github.com/charmbracelet/lipgloss"
 
 	"github.com/jjfantini/humblSKILLS/cli/internal/manifest"
+	"github.com/jjfantini/humblSKILLS/cli/internal/profile"
 	"github.com/jjfantini/humblSKILLS/cli/internal/registry"
 	"github.com/jjfantini/humblSKILLS/cli/internal/textutil"
 	"github.com/jjfantini/humblSKILLS/cli/internal/tui"
 	"github.com/jjfantini/humblSKILLS/cli/internal/ui"
 )
+
+const uncategorizedLabel = "uncategorized"
 
 // skillsBrowseMode determines the verb shown in the footer and the result
 // action returned when the user presses enter.
@@ -35,9 +38,10 @@ const (
 // (source of truth) plus every platform it's symlinked to, instead of
 // whichever platform happened to be inserted into the manifest first.
 type skillItem struct {
-	s        registry.Skill
-	installs []manifest.Installation // empty if not installed on this machine
-	outdated bool                    // any installed entry's version != registry version
+	s          registry.Skill
+	installs   []manifest.Installation // empty if not installed on this machine
+	outdated   bool                    // any installed entry's version != registry version
+	parentKeys []string                // collapse keys of ancestor category/role headers
 }
 
 // primary returns the first installed entry, or nil if none. Used where a
@@ -53,6 +57,7 @@ func (s skillItem) Key() string { return s.s.Name }
 func (s skillItem) FilterValue() string {
 	return strings.ToLower(s.s.Name + " " + s.s.Category + " " + s.s.Role + " " + strings.Join(s.s.Tags, " ") + " " + s.s.Description)
 }
+func (s skillItem) ParentCollapseKeys() []string { return s.parentKeys }
 
 // NaturalWidth reports the row's display width: dot + space + name + 2-gap
 // + version. Status is encoded entirely in the leading dot colour
@@ -87,45 +92,53 @@ func (s skillItem) Row(th *ui.Theme, width int, selected bool) string {
 }
 
 func (s skillItem) Detail(th *ui.Theme, width int) string {
+	if width < 20 {
+		width = 20
+	}
 	var sb strings.Builder
 	primary := s.primary()
 	sub := "v" + s.s.Version
 	if primary != nil && primary.Version != s.s.Version {
 		sub = "v" + primary.Version + " → v" + s.s.Version
 	}
-	sb.WriteString(th.DetailTitle.Render(s.s.Name) + "  " +
-		th.DetailSub.Render(sub) + "\n\n")
+	title := th.DetailTitle.Render(s.s.Name) + "  " + th.DetailSub.Render(sub)
+	sb.WriteString(ansiWrap(title, width) + "\n\n")
 
 	if s.s.Description != "" {
 		desc := th.Desc.Width(width).Render(s.s.Description)
-		sb.WriteString(desc + "\n\n")
+		// Hard-wrap any leftover long tokens lipgloss left intact.
+		var descOut []string
+		for _, line := range strings.Split(desc, "\n") {
+			descOut = append(descOut, strings.Split(ansiWrap(line, width), "\n")...)
+		}
+		sb.WriteString(strings.Join(descOut, "\n") + "\n\n")
 	}
 
 	if s.s.Registry != "" {
-		sb.WriteString(kvRow(th, "registry", th.KVValue.Render(s.s.Registry)))
+		sb.WriteString(kvRowWidth(th, "registry", th.KVValue.Render(s.s.Registry), width))
 	}
 	if s.s.Category != "" {
-		sb.WriteString(kvRow(th, "category", th.Category.Render(s.s.Category)))
+		sb.WriteString(kvRowWidth(th, "category", th.Category.Render(s.s.Category), width))
 	}
 	if s.s.Role != "" {
-		sb.WriteString(kvRow(th, "role", th.Platform.Render(s.s.Role)))
+		sb.WriteString(kvRowWidth(th, "role", th.Platform.Render(s.s.Role), width))
 	}
 	if len(s.s.Tags) > 0 {
 		chips := make([]string, 0, len(s.s.Tags))
 		for _, t := range s.s.Tags {
 			chips = append(chips, th.Tag.Render("#"+t))
 		}
-		sb.WriteString(kvRow(th, "tags", strings.Join(chips, "  ")))
+		sb.WriteString(kvRowWidth(th, "tags", strings.Join(chips, "  "), width))
 	}
 	if len(s.s.Platforms) > 0 {
 		plats := make([]string, 0, len(s.s.Platforms))
 		for _, p := range s.s.Platforms {
 			plats = append(plats, th.Platform.Render(p))
 		}
-		sb.WriteString(kvRow(th, "target", strings.Join(plats, "  ")))
+		sb.WriteString(kvRowWidth(th, "target", strings.Join(plats, "  "), width))
 	}
 	if len(s.s.Requires) > 0 {
-		sb.WriteString(kvRow(th, "deps", th.KVValue.Render(strings.Join(s.s.Requires, ", "))))
+		sb.WriteString(kvRowWidth(th, "deps", th.KVValue.Render(strings.Join(s.s.Requires, ", ")), width))
 	}
 
 	if len(s.installs) > 0 {
@@ -150,7 +163,7 @@ func (s skillItem) installedSection(th *ui.Theme, width int) string {
 		}
 	}
 	if store != "" {
-		sb.WriteString(kvRow(th, "store", th.KVValue.Render(store)))
+		sb.WriteString(kvRowWidth(th, "store", th.KVValue.Render(store), width))
 	}
 
 	sb.WriteString("\n" + th.SectionTitle.Render("SYMLINKED PLATFORMS") + "\n")
@@ -162,12 +175,12 @@ func (s skillItem) installedSection(th *ui.Theme, width int) string {
 		if inst.Version != s.s.Version {
 			ver = "v" + inst.Version + " → v" + s.s.Version
 		}
-		sb.WriteString(kvRow(th, "platform", th.Platform.Render(inst.Platform)+"  "+th.KVValue.Render(ver)))
-		sb.WriteString(kvRow(th, "scope", th.KVValue.Render(inst.Scope)))
-		sb.WriteString(kvRow(th, "path", th.KVValue.Render(inst.Path)))
+		sb.WriteString(kvRowWidth(th, "platform", th.Platform.Render(inst.Platform)+"  "+th.KVValue.Render(ver), width))
+		sb.WriteString(kvRowWidth(th, "scope", th.KVValue.Render(inst.Scope), width))
+		sb.WriteString(kvRowWidth(th, "path", th.KVValue.Render(inst.Path), width))
 		if !inst.InstalledAt.IsZero() {
-			sb.WriteString(kvRow(th, "at", th.KVValue.Render(
-				inst.InstalledAt.Format("2006-01-02 15:04"))))
+			sb.WriteString(kvRowWidth(th, "at", th.KVValue.Render(
+				inst.InstalledAt.Format("2006-01-02 15:04")), width))
 		}
 	}
 	return sb.String()
@@ -176,7 +189,8 @@ func (s skillItem) installedSection(th *ui.Theme, width int) string {
 // buildSkillItems joins a registry listing with the install manifest so the
 // returned items know every (platform, scope) they're installed onto, and
 // whether any of those have drifted from the registry version.
-func buildSkillItems(skills []registry.Skill, m *manifest.Manifest) []skillItem {
+// groupByCategory controls sort order (must match aggregateSkills / buildSkillTree).
+func buildSkillItems(skills []registry.Skill, m *manifest.Manifest, groupByCategory bool) []skillItem {
 	installed := map[string][]manifest.Installation{}
 	if m != nil {
 		for _, inst := range m.Installations {
@@ -207,56 +221,225 @@ func buildSkillItems(skills []registry.Skill, m *manifest.Manifest) []skillItem 
 		items = append(items, it)
 	}
 	sort.SliceStable(items, func(i, j int) bool {
-		// Group by source registry (empty registry — single-registry views —
-		// all collapse into one group), then by role within a registry
-		// (role-less skills first, directly under the registry header),
-		// then by skill name. Must stay in step with aggregateSkills.
-		if items[i].s.Registry != items[j].s.Registry {
-			return items[i].s.Registry < items[j].s.Registry
-		}
-		if items[i].s.Role != items[j].s.Role {
-			return items[i].s.Role < items[j].s.Role
-		}
-		return items[i].s.Name < items[j].s.Name
+		return lessSkill(items[i].s, items[j].s, groupByCategory)
 	})
 	return items
 }
 
-// registryHeaderItem is a non-selectable section-header row rendered above
-// each registry's skills when more than one registry is shown, and — with
-// sub set — as the lighter role sub-header within a registry's block. One
-// type for both levels so the list's header handling (nav skipping, filter
-// hiding, countSkills) needs no second case.
-type registryHeaderItem struct {
-	name     string
-	registry string // owning registry, part of Key so same-named role headers don't collide
-	sub      bool   // true = role sub-header
-}
-
-func (h registryHeaderItem) IsHeader() bool      { return true }
-func (h registryHeaderItem) Key() string         { return "__header__:" + h.registry + ":" + h.name }
-func (h registryHeaderItem) FilterValue() string { return "" }
-func (h registryHeaderItem) NaturalWidth(th *ui.Theme) int {
-	return lipgloss.Width(h.render(th))
-}
-func (h registryHeaderItem) render(th *ui.Theme) string {
-	if h.sub {
-		return th.Meta.Render("· " + h.name + " ·")
+// lessSkill orders skills for the TUI tree. With groupByCategory:
+// registry → category → role → name. Without: registry → role → name.
+func lessSkill(a, b registry.Skill, groupByCategory bool) bool {
+	if a.Registry != b.Registry {
+		return a.Registry < b.Registry
 	}
-	return th.SectionTitle.Render("── " + h.name + " ──")
+	if groupByCategory {
+		ca, cb := skillCategory(a), skillCategory(b)
+		if ca != cb {
+			return ca < cb
+		}
+	}
+	if a.Role != b.Role {
+		return a.Role < b.Role
+	}
+	return a.Name < b.Name
 }
-func (h registryHeaderItem) Row(th *ui.Theme, width int, _ bool) string {
-	return h.render(th)
-}
-func (h registryHeaderItem) Detail(th *ui.Theme, width int) string { return "" }
 
-// interleaveRegistryHeaders turns a (registry, role, name)-sorted item list
-// into a tui.Item slice with a "── <registry> ──" header before each
-// registry's block (only when grouped, i.e. >1 registry) and a lighter
-// "· <role> ·" sub-header before each role's block. Role sub-headers appear
-// whenever any skill carries a role — independent of registry grouping.
-// Role-less skills sort first within their registry and get no sub-header.
-func interleaveRegistryHeaders(skills []skillItem, grouped bool) []tui.Item {
+func skillCategory(s registry.Skill) string {
+	if strings.TrimSpace(s.Category) == "" {
+		return uncategorizedLabel
+	}
+	return s.Category
+}
+
+// sectionKind distinguishes registry dividers from collapsible category/role
+// headers in the skills list.
+type sectionKind int
+
+const (
+	sectionRegistry sectionKind = iota
+	sectionCategory
+	sectionRole
+)
+
+// sectionHeaderItem is a list section row. Registry headers are non-focusable
+// full-width dividers (HeaderItem). Category and role headers are focusable
+// CollapsibleItems toggled with Enter.
+type sectionHeaderItem struct {
+	kind       sectionKind
+	name       string
+	registry   string
+	category   string   // set for role headers (owning category)
+	parentKeys []string // ancestor collapse keys
+}
+
+func (h sectionHeaderItem) FilterValue() string { return "" }
+
+func (h sectionHeaderItem) Key() string {
+	switch h.kind {
+	case sectionRegistry:
+		return "__header__:reg:" + h.registry
+	case sectionCategory:
+		return "__header__:cat:" + h.registry + ":" + h.name
+	case sectionRole:
+		return "__header__:role:" + h.registry + ":" + h.category + ":" + h.name
+	}
+	return "__header__:" + h.name
+}
+
+func (h sectionHeaderItem) IsHeader() bool { return h.kind == sectionRegistry }
+
+func (h sectionHeaderItem) IsCollapsible() bool {
+	return h.kind == sectionCategory || h.kind == sectionRole
+}
+
+func (h sectionHeaderItem) CollapseKey() string {
+	return h.Key()
+}
+
+func (h sectionHeaderItem) ParentCollapseKeys() []string { return h.parentKeys }
+
+func (h sectionHeaderItem) NaturalWidth(th *ui.Theme) int {
+	return lipgloss.Width(h.renderLabel(th, false))
+}
+
+func (h sectionHeaderItem) renderLabel(th *ui.Theme, collapsed bool) string {
+	switch h.kind {
+	case sectionRegistry:
+		return th.SectionTitle.Render("── " + h.name + " ")
+	case sectionCategory:
+		caret := "▾"
+		if collapsed {
+			caret = "▸"
+		}
+		return th.SectionTitle.Render(caret + " " + h.name)
+	case sectionRole:
+		caret := "▾"
+		if collapsed {
+			caret = "▸"
+		}
+		return th.Meta.Render("  " + caret + " " + h.name)
+	}
+	return h.name
+}
+
+func (h sectionHeaderItem) Row(th *ui.Theme, width int, selected bool) string {
+	return h.RowCollapsed(th, width, selected, false)
+}
+
+func (h sectionHeaderItem) RowCollapsed(th *ui.Theme, width int, selected, collapsed bool) string {
+	if h.kind == sectionRegistry {
+		// Full-width registry bar: "── name ────────"
+		base := "── " + h.name + " "
+		pad := width - lipgloss.Width(base)
+		if pad < 2 {
+			pad = 2
+		}
+		return th.SectionTitle.Render(base + strings.Repeat("─", pad))
+	}
+	label := h.renderLabel(th, collapsed)
+	if selected {
+		// Keep caret + name; selection bar is drawn by the list model.
+		_ = selected
+	}
+	rw := lipgloss.Width(label)
+	if rw >= width {
+		return label
+	}
+	return label + strings.Repeat(" ", width-rw)
+}
+
+func (h sectionHeaderItem) Detail(th *ui.Theme, width int) string {
+	if width < 20 {
+		width = 20
+	}
+	var sb strings.Builder
+	switch h.kind {
+	case sectionRegistry:
+		sb.WriteString(th.DetailTitle.Render(h.name) + "\n\n")
+		sb.WriteString(th.Desc.Width(width).Render("Registry section. Skills below are grouped from this source.") + "\n")
+	case sectionCategory:
+		sb.WriteString(th.DetailTitle.Render(h.name) + "\n\n")
+		sb.WriteString(th.Desc.Width(width).Render("Category group. Press enter to expand or collapse skills in this category.") + "\n")
+		sb.WriteString(kvRowWidth(th, "registry", th.KVValue.Render(registryDisplayName(h.registry)), width))
+	case sectionRole:
+		sb.WriteString(th.DetailTitle.Render(h.name) + "\n\n")
+		sb.WriteString(th.Desc.Width(width).Render("Role group. Press enter to expand or collapse skills for this role.") + "\n")
+		sb.WriteString(kvRowWidth(th, "registry", th.KVValue.Render(registryDisplayName(h.registry)), width))
+		sb.WriteString(kvRowWidth(th, "category", th.Category.Render(h.category), width))
+	}
+	return sb.String()
+}
+
+// buildSkillTree turns a sorted skillItem list into tui.Items with section
+// headers. When groupByCategory is true: Registry → Category → Role → Skills.
+// When false (legacy): Registry → Role → Skills.
+// Registry headers appear only when multiRegistry is true.
+func buildSkillTree(skills []skillItem, multiRegistry, groupByCategory bool) []tui.Item {
+	if groupByCategory {
+		return buildSkillTreeByCategory(skills, multiRegistry)
+	}
+	return buildSkillTreeByRole(skills, multiRegistry)
+}
+
+func buildSkillTreeByCategory(skills []skillItem, multiRegistry bool) []tui.Item {
+	items := make([]tui.Item, 0, len(skills)+8)
+	prevReg, prevCat, prevRole := "", "", ""
+	started := false
+	for _, s := range skills {
+		reg := s.s.Registry
+		cat := skillCategory(s.s)
+		role := s.s.Role
+		regChanged := !started || reg != prevReg
+		catChanged := regChanged || cat != prevCat
+		roleChanged := catChanged || role != prevRole
+
+		if multiRegistry && regChanged {
+			items = append(items, sectionHeaderItem{
+				kind:     sectionRegistry,
+				name:     registryDisplayName(reg),
+				registry: reg,
+			})
+		}
+		var catKey string
+		if catChanged {
+			catHeader := sectionHeaderItem{
+				kind:     sectionCategory,
+				name:     cat,
+				registry: reg,
+			}
+			catKey = catHeader.CollapseKey()
+			items = append(items, catHeader)
+		} else {
+			catKey = sectionHeaderItem{kind: sectionCategory, name: cat, registry: reg}.CollapseKey()
+		}
+
+		parentKeys := []string{catKey}
+		if role != "" && roleChanged {
+			roleHeader := sectionHeaderItem{
+				kind:       sectionRole,
+				name:       role,
+				registry:   reg,
+				category:   cat,
+				parentKeys: []string{catKey},
+			}
+			items = append(items, roleHeader)
+			parentKeys = append(parentKeys, roleHeader.CollapseKey())
+		} else if role != "" {
+			roleKey := sectionHeaderItem{
+				kind: sectionRole, name: role, registry: reg, category: cat,
+			}.CollapseKey()
+			parentKeys = append(parentKeys, roleKey)
+		}
+
+		s.parentKeys = parentKeys
+		items = append(items, s)
+		prevReg, prevCat, prevRole, started = reg, cat, role, true
+	}
+	return items
+}
+
+// buildSkillTreeByRole is the legacy layout: Registry → Role → Skills.
+func buildSkillTreeByRole(skills []skillItem, multiRegistry bool) []tui.Item {
 	hasRoles := false
 	for _, s := range skills {
 		if s.s.Role != "" {
@@ -269,16 +452,40 @@ func interleaveRegistryHeaders(skills []skillItem, grouped bool) []tui.Item {
 	started := false
 	for _, s := range skills {
 		regChanged := !started || s.s.Registry != prevReg
-		if grouped && regChanged {
-			items = append(items, registryHeaderItem{name: registryDisplayName(s.s.Registry), registry: s.s.Registry})
+		if multiRegistry && regChanged {
+			items = append(items, sectionHeaderItem{
+				kind:     sectionRegistry,
+				name:     registryDisplayName(s.s.Registry),
+				registry: s.s.Registry,
+			})
 		}
+		var parentKeys []string
 		if hasRoles && s.s.Role != "" && (regChanged || s.s.Role != prevRole) {
-			items = append(items, registryHeaderItem{name: s.s.Role, registry: s.s.Registry, sub: true})
+			roleHeader := sectionHeaderItem{
+				kind:     sectionRole,
+				name:     s.s.Role,
+				registry: s.s.Registry,
+				category: "",
+			}
+			items = append(items, roleHeader)
+			parentKeys = []string{roleHeader.CollapseKey()}
+		} else if hasRoles && s.s.Role != "" {
+			roleKey := sectionHeaderItem{
+				kind: sectionRole, name: s.s.Role, registry: s.s.Registry,
+			}.CollapseKey()
+			parentKeys = []string{roleKey}
 		}
-		prevReg, prevRole, started = s.s.Registry, s.s.Role, true
+		s.parentKeys = parentKeys
 		items = append(items, s)
+		prevReg, prevRole, started = s.s.Registry, s.s.Role, true
 	}
 	return items
+}
+
+// interleaveRegistryHeaders is kept as a thin alias for tests / callers that
+// still use the legacy name. It builds the category tree (default-on behaviour).
+func interleaveRegistryHeaders(skills []skillItem, grouped bool) []tui.Item {
+	return buildSkillTree(skills, grouped, true)
 }
 
 func registryDisplayName(name string) string {
@@ -288,14 +495,14 @@ func registryDisplayName(name string) string {
 	return name
 }
 
-// countSkills counts the non-header items (real skills) in a tui.Item list.
+// countSkills counts the real skill rows in a tui.Item list (skips headers
+// and collapsible section rows).
 func countSkills(items []tui.Item) int {
 	n := 0
 	for _, it := range items {
-		if h, ok := it.(tui.HeaderItem); ok && h.IsHeader() {
-			continue
+		if _, ok := it.(skillItem); ok {
+			n++
 		}
-		n++
 	}
 	return n
 }
@@ -320,7 +527,6 @@ func runSkillBrowser(app *App, section string, skills []skillItem, mode skillsBr
 		app.UI.Info(emptyMsg)
 		return "", "", nil
 	}
-	items := interleaveRegistryHeaders(skills, distinctRegistries(skills) > 1)
 
 	var actions []tui.ActionSpec
 	switch mode {
@@ -375,6 +581,15 @@ func runSkillBrowser(app *App, section string, skills []skillItem, mode skillsBr
 	}
 
 	for {
+		groupBy := app.resolvedGroupByCategory()
+		// Re-sort + rebuild tree each loop so a profile toggle takes effect
+		// immediately after the inline profile editor returns.
+		sorted := append([]skillItem(nil), skills...)
+		sort.SliceStable(sorted, func(i, j int) bool {
+			return lessSkill(sorted[i].s, sorted[j].s, groupBy)
+		})
+		items := buildSkillTree(sorted, distinctRegistries(sorted) > 1, groupBy)
+
 		cfg := tui.Config{
 			Theme:      app.UI.Theme(),
 			Version:    resolveVersion().Version,
@@ -409,4 +624,14 @@ func runSkillBrowser(app *App, section string, skills []skillItem, mode skillsBr
 		}
 		return it.s.Name, res.Action, nil
 	}
+}
+
+// resolvedGroupByCategory loads the profile toggle; defaults to on when the
+// profile is missing or unreadable so the TUI still groups by category.
+func (app *App) resolvedGroupByCategory() bool {
+	p, err := profile.Load(app.Config.ProfilePath)
+	if err != nil || p == nil {
+		return true
+	}
+	return p.ResolvedGroupByCategory()
 }

--- a/cli/cmd/humblskills/browse_skills_test.go
+++ b/cli/cmd/humblskills/browse_skills_test.go
@@ -5,6 +5,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
+
 	"github.com/jjfantini/humblSKILLS/cli/internal/manifest"
 	"github.com/jjfantini/humblSKILLS/cli/internal/registry"
 	"github.com/jjfantini/humblSKILLS/cli/internal/ui"
@@ -25,7 +28,7 @@ func TestBuildSkillItems_CarriesEveryInstallationForASkill(t *testing.T) {
 		Path: "/home/u/.agents/skills/foo", StorePath: "/home/u/.humblskills/skills/foo",
 	})
 
-	items := buildSkillItems([]registry.Skill{{Name: "foo", Version: "1.0.0"}}, m)
+	items := buildSkillItems([]registry.Skill{{Name: "foo", Version: "1.0.0"}}, m, true)
 	if len(items) != 1 {
 		t.Fatalf("items = %d, want 1", len(items))
 	}
@@ -58,7 +61,7 @@ func TestBuildSkillItems_OutdatedWhenAnyInstallDrifts(t *testing.T) {
 		Path: "/home/u/.cursor/skills/foo", StorePath: "/home/u/.humblskills/skills/foo",
 	})
 
-	items := buildSkillItems([]registry.Skill{{Name: "foo", Version: "1.0.0"}}, m)
+	items := buildSkillItems([]registry.Skill{{Name: "foo", Version: "1.0.0"}}, m, true)
 	if !items[0].outdated {
 		t.Error("expected outdated=true when one install lags the registry version")
 	}
@@ -100,13 +103,44 @@ func TestSkillItem_Detail_NotInstalled_NoInstalledSection(t *testing.T) {
 	}
 }
 
-func TestBuildSkillItems_RolelessFirstThenByRoleWithinRegistry(t *testing.T) {
+func TestSkillItem_Detail_LinesFitWidth(t *testing.T) {
+	const width = 40
+	longPath := "/Users/jenningsfantini/.humblskills/skills/deal-positioning-framework"
+	it := skillItem{
+		s: registry.Skill{
+			Name:        "deal-positioning-framework",
+			Version:     "0.1.0",
+			Description: "Build an exec-ready HappyRobot Point of View (POV) that frames the customer's problem, our unique approach, and the commercial ask in one tight narrative for sellers.",
+			Category:    "writing",
+			Role:        "sdr",
+			Tags:        []string{"sales", "pov", "positioning", "executive", "narrative"},
+			Platforms:   []string{"claude-code", "cursor", "codex"},
+			Registry:    "happyrobot",
+		},
+		installs: []manifest.Installation{
+			{
+				Skill: "deal-positioning-framework", Version: "0.1.0",
+				Platform: "claude-code", Scope: "user",
+				Path: longPath, StorePath: longPath,
+			},
+		},
+	}
+	detail := it.Detail(ui.DefaultTheme(), width)
+	for i, line := range strings.Split(detail, "\n") {
+		plain := ansi.Strip(line)
+		if w := lipgloss.Width(plain); w > width {
+			t.Errorf("line %d width %d > %d: %q", i, w, width, plain)
+		}
+	}
+}
+
+func TestBuildSkillItems_RolelessFirstThenByRoleWithinRegistry_Legacy(t *testing.T) {
 	items := buildSkillItems([]registry.Skill{
 		{Name: "zeta", Version: "1.0.0", Registry: "work", Role: "sdr"},
 		{Name: "alpha", Version: "1.0.0", Registry: "work", Role: "fde"},
 		{Name: "misc", Version: "1.0.0", Registry: "work"},
 		{Name: "other", Version: "1.0.0", Registry: "personal"},
-	}, nil)
+	}, nil, false)
 	got := make([]string, 0, len(items))
 	for _, it := range items {
 		got = append(got, it.s.Registry+"/"+it.s.Role+"/"+it.s.Name)
@@ -119,24 +153,92 @@ func TestBuildSkillItems_RolelessFirstThenByRoleWithinRegistry(t *testing.T) {
 	}
 }
 
-func TestInterleaveHeaders_RoleSubHeaders(t *testing.T) {
+func TestBuildSkillItems_SortsByCategoryWhenGrouped(t *testing.T) {
+	items := buildSkillItems([]registry.Skill{
+		{Name: "zeta", Version: "1.0.0", Registry: "work", Category: "writing", Role: "sdr"},
+		{Name: "alpha", Version: "1.0.0", Registry: "work", Category: "design"},
+		{Name: "misc", Version: "1.0.0", Registry: "work", Category: "writing"},
+		{Name: "other", Version: "1.0.0", Registry: "personal", Category: "meta"},
+	}, nil, true)
+	got := make([]string, 0, len(items))
+	for _, it := range items {
+		got = append(got, it.s.Registry+"/"+skillCategory(it.s)+"/"+it.s.Role+"/"+it.s.Name)
+	}
+	want := []string{
+		"personal/meta//other",
+		"work/design//alpha",
+		"work/writing//misc",
+		"work/writing/sdr/zeta",
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("order = %v, want %v", got, want)
+		}
+	}
+}
+
+func TestBuildSkillTree_CategoryThenRole(t *testing.T) {
+	skills := buildSkillItems([]registry.Skill{
+		{Name: "misc", Version: "1.0.0", Registry: "work", Category: "writing"},
+		{Name: "alpha", Version: "1.0.0", Registry: "work", Category: "writing", Role: "fde"},
+		{Name: "beta", Version: "1.0.0", Registry: "work", Category: "writing", Role: "fde"},
+		{Name: "zeta", Version: "1.0.0", Registry: "work", Category: "design"},
+		{Name: "other", Version: "1.0.0", Registry: "personal", Category: "meta"},
+	}, nil, true)
+	items := buildSkillTree(skills, true, true)
+
+	got := make([]string, 0, len(items))
+	for _, it := range items {
+		switch v := it.(type) {
+		case sectionHeaderItem:
+			switch v.kind {
+			case sectionRegistry:
+				got = append(got, "reg:"+v.name)
+			case sectionCategory:
+				got = append(got, "cat:"+v.name)
+			case sectionRole:
+				got = append(got, "role:"+v.name)
+			}
+		case skillItem:
+			got = append(got, v.s.Name)
+		}
+	}
+	want := []string{
+		"reg:personal", "cat:meta", "other",
+		"reg:work", "cat:design", "zeta",
+		"cat:writing", "misc", "role:fde", "alpha", "beta",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("items = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("items = %v, want %v", got, want)
+		}
+	}
+}
+
+func TestBuildSkillTree_LegacyRoleSubHeaders(t *testing.T) {
 	skills := buildSkillItems([]registry.Skill{
 		{Name: "misc", Version: "1.0.0", Registry: "work"},
 		{Name: "alpha", Version: "1.0.0", Registry: "work", Role: "fde"},
 		{Name: "beta", Version: "1.0.0", Registry: "work", Role: "fde"},
 		{Name: "zeta", Version: "1.0.0", Registry: "work", Role: "sdr"},
 		{Name: "other", Version: "1.0.0", Registry: "personal"},
-	}, nil)
-	items := interleaveRegistryHeaders(skills, true)
+	}, nil, false)
+	items := buildSkillTree(skills, true, false)
 
 	got := make([]string, 0, len(items))
 	for _, it := range items {
 		switch v := it.(type) {
-		case registryHeaderItem:
-			if v.sub {
-				got = append(got, "role:"+v.name)
-			} else {
+		case sectionHeaderItem:
+			switch v.kind {
+			case sectionRegistry:
 				got = append(got, "reg:"+v.name)
+			case sectionRole:
+				got = append(got, "role:"+v.name)
+			default:
+				got = append(got, "other:"+v.name)
 			}
 		case skillItem:
 			got = append(got, v.s.Name)
@@ -153,32 +255,31 @@ func TestInterleaveHeaders_RoleSubHeaders(t *testing.T) {
 	}
 }
 
-func TestInterleaveHeaders_RoleSubHeadersWithoutRegistryGrouping(t *testing.T) {
-	// Single registry (grouped=false): role sub-headers still appear.
+func TestBuildSkillTree_LegacyRoleWithoutRegistryGrouping(t *testing.T) {
 	skills := buildSkillItems([]registry.Skill{
 		{Name: "misc", Version: "1.0.0"},
 		{Name: "alpha", Version: "1.0.0", Role: "fde"},
-	}, nil)
-	items := interleaveRegistryHeaders(skills, false)
+	}, nil, false)
+	items := buildSkillTree(skills, false, false)
 
 	if len(items) != 3 {
-		t.Fatalf("items = %d, want 3 (skill, sub-header, skill)", len(items))
+		t.Fatalf("items = %d, want 3 (skill, role header, skill)", len(items))
 	}
-	h, ok := items[1].(registryHeaderItem)
-	if !ok || !h.sub || h.name != "fde" {
-		t.Fatalf("items[1] = %#v, want fde sub-header", items[1])
+	h, ok := items[1].(sectionHeaderItem)
+	if !ok || h.kind != sectionRole || h.name != "fde" {
+		t.Fatalf("items[1] = %#v, want fde role header", items[1])
 	}
 }
 
-func TestInterleaveHeaders_NoRoleSubHeadersWhenNoRoles(t *testing.T) {
+func TestBuildSkillTree_NoRoleHeadersWhenNoRoles(t *testing.T) {
 	skills := buildSkillItems([]registry.Skill{
-		{Name: "a", Version: "1.0.0", Registry: "work"},
-		{Name: "b", Version: "1.0.0", Registry: "personal"},
-	}, nil)
-	items := interleaveRegistryHeaders(skills, true)
+		{Name: "a", Version: "1.0.0", Registry: "work", Category: "design"},
+		{Name: "b", Version: "1.0.0", Registry: "personal", Category: "meta"},
+	}, nil, true)
+	items := buildSkillTree(skills, true, true)
 	for _, it := range items {
-		if h, ok := it.(registryHeaderItem); ok && h.sub {
-			t.Fatalf("unexpected role sub-header %q", h.name)
+		if h, ok := it.(sectionHeaderItem); ok && h.kind == sectionRole {
+			t.Fatalf("unexpected role header %q", h.name)
 		}
 	}
 }
@@ -191,5 +292,39 @@ func TestSkillItem_RoleInDetailAndFilterValue(t *testing.T) {
 	}
 	if !strings.Contains(it.FilterValue(), "fde") {
 		t.Error("FilterValue missing role")
+	}
+}
+
+func TestSectionHeader_CollapsibleAndParentKeys(t *testing.T) {
+	skills := buildSkillItems([]registry.Skill{
+		{Name: "alpha", Version: "1.0.0", Registry: "work", Category: "writing", Role: "sdr"},
+	}, nil, true)
+	items := buildSkillTree(skills, false, true)
+	var cat, role sectionHeaderItem
+	var skill skillItem
+	for _, it := range items {
+		switch v := it.(type) {
+		case sectionHeaderItem:
+			if v.kind == sectionCategory {
+				cat = v
+			}
+			if v.kind == sectionRole {
+				role = v
+			}
+		case skillItem:
+			skill = v
+		}
+	}
+	if !cat.IsCollapsible() || cat.IsHeader() {
+		t.Fatalf("category should be collapsible, not a nav-skip header: %#v", cat)
+	}
+	if !role.IsCollapsible() {
+		t.Fatal("role should be collapsible")
+	}
+	if len(role.ParentCollapseKeys()) != 1 || role.ParentCollapseKeys()[0] != cat.CollapseKey() {
+		t.Fatalf("role parentKeys = %v, want [%s]", role.ParentCollapseKeys(), cat.CollapseKey())
+	}
+	if len(skill.ParentCollapseKeys()) != 2 {
+		t.Fatalf("skill parentKeys = %v, want category+role", skill.ParentCollapseKeys())
 	}
 }

--- a/cli/cmd/humblskills/doctor_view.go
+++ b/cli/cmd/humblskills/doctor_view.go
@@ -7,12 +7,22 @@ import (
 	"time"
 
 	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
 
 	"github.com/jjfantini/humblSKILLS/cli/internal/eval/workspace"
 	"github.com/jjfantini/humblSKILLS/cli/internal/textutil"
 	"github.com/jjfantini/humblSKILLS/cli/internal/tui"
 	"github.com/jjfantini/humblSKILLS/cli/internal/ui"
 )
+
+// ansiWrap wraps s to limit cells, breaking mid-token when needed (paths,
+// long tags). Empty breakpoints forces hard wrap via charmbracelet/x/ansi.
+func ansiWrap(s string, limit int) string {
+	if limit < 1 {
+		return s
+	}
+	return ansi.Wrap(s, limit, "")
+}
 
 // This file is the doctor presentation layer: the listdetail Item adapters
 // used by the TUI plus the non-TTY static renderer. The report data model and
@@ -308,15 +318,42 @@ func rowWithTrailingBadge(label, badge string, width int) string {
 	return label + strings.Repeat(" ", gap) + badge
 }
 
+// kvLabelCol is the display width reserved for the key column in kvRow.
+const kvLabelCol = 11
+
 // kvRow formats one key/value pair as `  label    value` with the label padded
-// to 11 cells (matching the design's 110px label column, in mono-font terms).
+// to kvLabelCol cells. Prefer kvRowWidth when the pane width is known so long
+// values wrap instead of clipping.
 func kvRow(th *ui.Theme, key, value string) string {
+	return kvRowWidth(th, key, value, 0)
+}
+
+// kvRowWidth is kvRow with soft/hard wrapping of the value to fit `width`
+// display cells. width <= 0 disables wrapping (legacy single-line behaviour).
+func kvRowWidth(th *ui.Theme, key, value string, width int) string {
 	label := th.KVKey.Render(key)
-	pad := 11 - lipgloss.Width(label)
+	pad := kvLabelCol - lipgloss.Width(label)
 	if pad < 1 {
 		pad = 1
 	}
-	return "  " + label + strings.Repeat(" ", pad) + value + "\n"
+	indent := "  " + label + strings.Repeat(" ", pad)
+	indentW := lipgloss.Width(indent)
+	if width <= 0 || width <= indentW+4 {
+		return indent + value + "\n"
+	}
+	valueW := width - indentW
+	wrapped := ansiWrap(value, valueW)
+	lines := strings.Split(wrapped, "\n")
+	var sb strings.Builder
+	cont := strings.Repeat(" ", indentW)
+	for i, line := range lines {
+		if i == 0 {
+			sb.WriteString(indent + line + "\n")
+		} else {
+			sb.WriteString(cont + line + "\n")
+		}
+	}
+	return sb.String()
 }
 
 // rwLegend explains the pills rendered by pathRow so users don't have to guess

--- a/cli/cmd/humblskills/install.go
+++ b/cli/cmd/humblskills/install.go
@@ -407,7 +407,7 @@ func pickSkill(app *App, reg *registry.Registry, fromDashboard bool) (string, er
 		}
 		return m, nil
 	})
-	items := buildSkillItems(skills, m)
+	items := buildSkillItems(skills, m, app.resolvedGroupByCategory())
 
 	skill, action, err := runSkillBrowser(app, "Install", items, modeSearch, "registry is empty", fromDashboard)
 	if err != nil {

--- a/cli/cmd/humblskills/list.go
+++ b/cli/cmd/humblskills/list.go
@@ -227,7 +227,7 @@ func runListTUI(app *App, m *manifest.Manifest, fromDashboard bool) error {
 		skills = append(skills, sk)
 	}
 
-	items := buildSkillItems(skills, m)
+	items := buildSkillItems(skills, m, app.resolvedGroupByCategory())
 
 	skill, action, err := runSkillBrowser(app, "Installed", items, modeInstalledOnly, "no skills installed", fromDashboard)
 	if err != nil {

--- a/cli/cmd/humblskills/profile.go
+++ b/cli/cmd/humblskills/profile.go
@@ -47,7 +47,8 @@ func newProfileSetCmd(app *App) *cobra.Command {
 	return &cobra.Command{
 		Use: "set <key> <value>",
 		Short: "Set a profile value. Keys: platforms (csv), scope (global|user|project|adapter-default), " +
-			"registry (URL/file:// path, or \"\" to clear), status_auto_return_seconds (seconds, or default|off).",
+			"registry (URL/file:// path, or \"\" to clear), status_auto_return_seconds (seconds, or default|off), " +
+			"group_by_category (on|off|default).",
 		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runProfileSet(app, args[0], args[1])
@@ -146,6 +147,8 @@ func runProfileShow(app *App) error {
 		th.KVValue.Render(formatRegistry(p.Registry)))
 	fmt.Fprintln(app.UI.Out(), "  "+th.KVKey.Render("auto-return")+"  "+
 		th.KVValue.Render(formatAutoReturn(p.StatusAutoReturnSeconds)))
+	fmt.Fprintln(app.UI.Out(), "  "+th.KVKey.Render("group-by")+"     "+
+		th.KVValue.Render(formatGroupByCategory(p.GroupByCategory)))
 	fmt.Fprintln(app.UI.Out(), "  "+th.KVKey.Render("path")+"         "+
 		th.KVValue.Render(app.Config.ProfilePath))
 
@@ -200,8 +203,14 @@ func runProfileSet(app *App, key, value string) error {
 			return err
 		}
 		p.StatusAutoReturnSeconds = seconds
+	case "group_by_category":
+		flag, err := parseGroupByCategory(value)
+		if err != nil {
+			return err
+		}
+		p.GroupByCategory = flag
 	default:
-		return fmt.Errorf("unknown key %q — valid keys: platforms, scope, registry, status_auto_return_seconds", key)
+		return fmt.Errorf("unknown key %q — valid keys: platforms, scope, registry, status_auto_return_seconds, group_by_category", key)
 	}
 
 	if err := profile.Save(app.Config.ProfilePath, p); err != nil {
@@ -298,6 +307,34 @@ func formatAutoReturn(seconds *int) string {
 		return "disabled — wait for enter/q"
 	default:
 		return fmt.Sprintf("%ds", *seconds)
+	}
+}
+
+// parseGroupByCategory parses `profile set group_by_category`:
+// "default"/"" resets to unset (on), "on"/"true"/"1" enables, "off"/"false"/"0" disables.
+func parseGroupByCategory(value string) (*bool, error) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "default", "":
+		return nil, nil
+	case "on", "true", "1", "yes":
+		v := true
+		return &v, nil
+	case "off", "false", "0", "no":
+		v := false
+		return &v, nil
+	}
+	return nil, fmt.Errorf("invalid group_by_category %q — expected on, off, or default", value)
+}
+
+// formatGroupByCategory renders GroupByCategory for `profile show`.
+func formatGroupByCategory(flag *bool) string {
+	switch {
+	case flag == nil:
+		return "on (default)"
+	case *flag:
+		return "on"
+	default:
+		return "off"
 	}
 }
 

--- a/cli/cmd/humblskills/profile_test.go
+++ b/cli/cmd/humblskills/profile_test.go
@@ -228,6 +228,46 @@ func TestProfileSet_StatusAutoReturnSeconds_Invalid(t *testing.T) {
 	}
 }
 
+func TestProfileSet_GroupByCategory(t *testing.T) {
+	s := testutil.NewSandbox(t)
+
+	res := runCLIWithStdoutCapture(t,
+		"profile", "set", "group_by_category", "off",
+		"--profile", s.ProfilePath, "--json",
+	)
+	if res.RunErr != nil {
+		t.Fatalf("run: %v", res.RunErr)
+	}
+	p, err := profile.Load(s.ProfilePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.GroupByCategory == nil || *p.GroupByCategory {
+		t.Errorf("GroupByCategory = %v, want false", p.GroupByCategory)
+	}
+	if p.ResolvedGroupByCategory() {
+		t.Error("ResolvedGroupByCategory() should be false after off")
+	}
+
+	res = runCLIWithStdoutCapture(t,
+		"profile", "set", "group_by_category", "default",
+		"--profile", s.ProfilePath, "--json",
+	)
+	if res.RunErr != nil {
+		t.Fatalf("reset: %v", res.RunErr)
+	}
+	p, err = profile.Load(s.ProfilePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.GroupByCategory != nil {
+		t.Errorf("GroupByCategory = %v, want nil after default", p.GroupByCategory)
+	}
+	if !p.ResolvedGroupByCategory() {
+		t.Error("ResolvedGroupByCategory() should be true after default")
+	}
+}
+
 func TestProfileReset_RemovesFile(t *testing.T) {
 	s := testutil.NewSandbox(t)
 

--- a/cli/cmd/humblskills/registries.go
+++ b/cli/cmd/humblskills/registries.go
@@ -170,7 +170,8 @@ func (a *App) loadRegistries() []registrySkills {
 // (Source left empty — it's for listing/picking only, not fetching), sorted by
 // (registry, name) so a picker renders grouped.
 func mergedRegistry(loaded []registrySkills) *registry.Registry {
-	skills, _ := aggregateSkills(loaded)
+	// Default-on category sort matches the TUI when the profile is unset.
+	skills, _ := aggregateSkills(loaded, true)
 	return &registry.Registry{SchemaVersion: registry.SchemaVersion, Skills: skills}
 }
 
@@ -371,10 +372,11 @@ func (a *App) installEngineForToken(token string) *install.Engine {
 	return e
 }
 
-// aggregateSkills flattens loaded registries into a single slice sorted by
-// (registry name, skill name), so a stable grouped order can be rendered. It
-// also returns the per-registry load errors (name -> err) for reporting.
-func aggregateSkills(loaded []registrySkills) ([]registry.Skill, map[string]error) {
+// aggregateSkills flattens loaded registries into a single slice sorted to
+// match the skills TUI tree (see lessSkill). groupByCategory selects
+// registry→category→role→name vs legacy registry→role→name. It also returns
+// the per-registry load errors (name -> err) for reporting.
+func aggregateSkills(loaded []registrySkills, groupByCategory bool) ([]registry.Skill, map[string]error) {
 	var all []registry.Skill
 	errs := map[string]error{}
 	for _, rs := range loaded {
@@ -385,15 +387,7 @@ func aggregateSkills(loaded []registrySkills) ([]registry.Skill, map[string]erro
 		all = append(all, rs.Skills...)
 	}
 	sort.SliceStable(all, func(i, j int) bool {
-		if all[i].Registry != all[j].Registry {
-			return all[i].Registry < all[j].Registry
-		}
-		// Role-less skills ("") sort first, directly under the registry
-		// header; role-tagged skills follow, block per role.
-		if all[i].Role != all[j].Role {
-			return all[i].Role < all[j].Role
-		}
-		return all[i].Name < all[j].Name
+		return lessSkill(all[i], all[j], groupByCategory)
 	})
 	return all, errs
 }

--- a/cli/cmd/humblskills/search.go
+++ b/cli/cmd/humblskills/search.go
@@ -47,7 +47,7 @@ func newSearchCmd(app *App) *cobra.Command {
 			loaded, _ := tui.RunWithLoadingIf(willBrowse, app.UI.Theme(), "loading registries…", func() ([]registrySkills, error) {
 				return app.loadRegistries(), nil
 			})
-			all, loadErrs := aggregateSkills(loaded)
+			all, loadErrs := aggregateSkills(loaded, app.resolvedGroupByCategory())
 			// A failed registry is reported but doesn't abort the others; only
 			// error out if every registry failed and nothing loaded.
 			if len(all) == 0 && len(loadErrs) > 0 {
@@ -130,7 +130,7 @@ func runSearchTUI(app *App, hits []registry.Skill, fromDashboard bool) error {
 	if err != nil {
 		m = &manifest.Manifest{}
 	}
-	items := buildSkillItems(hits, m)
+	items := buildSkillItems(hits, m, app.resolvedGroupByCategory())
 
 	skill, action, err := runSkillBrowser(app, "Search", items, modeSearch, "no skills match", fromDashboard)
 	if err != nil {

--- a/cli/cmd/humblskills/start.go
+++ b/cli/cmd/humblskills/start.go
@@ -164,7 +164,7 @@ func dispatchDashboardCommand(app *App, cmd string) error {
 		return runUpgrade(app, upgradeFlags{})
 	case "search":
 		hits, err := tui.RunWithLoading(app.UI.Theme(), "loading registries…", func() ([]registry.Skill, error) {
-			all, _ := aggregateSkills(app.loadRegistries())
+			all, _ := aggregateSkills(app.loadRegistries(), app.resolvedGroupByCategory())
 			return all, nil
 		})
 		if err != nil {

--- a/cli/cmd/humblskills/uninstall.go
+++ b/cli/cmd/humblskills/uninstall.go
@@ -59,7 +59,7 @@ func runUninstallPicker(app *App, fromDashboard bool) error {
 		}
 		skills = append(skills, registry.Skill{Name: name, Version: inst[0].Version})
 	}
-	items := buildSkillItems(skills, m)
+	items := buildSkillItems(skills, m, app.resolvedGroupByCategory())
 
 	skill, action, err := runSkillBrowser(app, "Uninstall", items, modeInstalledOnly, "no skills installed", fromDashboard)
 	if err != nil {

--- a/cli/internal/profile/profile.go
+++ b/cli/internal/profile/profile.go
@@ -59,6 +59,12 @@ type Profile struct {
 	// positive value is the number of seconds to wait. Only success
 	// screens auto-return - a failed run always waits for the user.
 	StatusAutoReturnSeconds *int `json:"status_auto_return_seconds,omitempty"`
+
+	// GroupByCategory controls whether the skills TUI nests skills under
+	// category (and role) section headers. nil (unset) means on — the
+	// recommended default. Explicit false restores the legacy flat
+	// registry→role→skills layout.
+	GroupByCategory *bool `json:"group_by_category,omitempty"`
 }
 
 // NamedRegistry is one entry in the multi-registry set (Profile.Registries).
@@ -289,4 +295,13 @@ func (p *Profile) StatusAutoReturnDuration() time.Duration {
 		return 0
 	}
 	return time.Duration(*p.StatusAutoReturnSeconds) * time.Second
+}
+
+// ResolvedGroupByCategory returns whether the skills TUI should nest by
+// category. nil/unset defaults to true (on).
+func (p *Profile) ResolvedGroupByCategory() bool {
+	if p == nil || p.GroupByCategory == nil {
+		return true
+	}
+	return *p.GroupByCategory
 }

--- a/cli/internal/profile/profile_test.go
+++ b/cli/internal/profile/profile_test.go
@@ -355,6 +355,25 @@ func TestStatusAutoReturnDuration(t *testing.T) {
 	}
 }
 
+func TestResolvedGroupByCategory(t *testing.T) {
+	ptr := func(b bool) *bool { return &b }
+	cases := []struct {
+		name string
+		p    *profile.Profile
+		want bool
+	}{
+		{"nil profile defaults to on", nil, true},
+		{"unset defaults to on", &profile.Profile{}, true},
+		{"explicit on", &profile.Profile{GroupByCategory: ptr(true)}, true},
+		{"explicit off", &profile.Profile{GroupByCategory: ptr(false)}, false},
+	}
+	for _, c := range cases {
+		if got := c.p.ResolvedGroupByCategory(); got != c.want {
+			t.Errorf("%s: ResolvedGroupByCategory() = %v, want %v", c.name, got, c.want)
+		}
+	}
+}
+
 func TestResolvedScope(t *testing.T) {
 	cases := []struct {
 		name string

--- a/cli/internal/tui/listdetail.go
+++ b/cli/internal/tui/listdetail.go
@@ -56,9 +56,48 @@ type HeaderItem interface {
 	IsHeader() bool
 }
 
+// CollapsibleItem marks a focusable section header (category/role) that can
+// hide its descendants when collapsed. Unlike HeaderItem, these rows ARE
+// navigable; Enter toggles collapse instead of firing the first Action.
+type CollapsibleItem interface {
+	Item
+	IsCollapsible() bool
+	CollapseKey() string
+	// RowCollapsed is like Row but includes expand/collapse caret state.
+	RowCollapsed(theme *ui.Theme, width int, selected, collapsed bool) string
+}
+
+// NestedItem reports ancestor collapse keys. When any key is collapsed in the
+// model's map, the item is hidden from the visible list.
+type NestedItem interface {
+	Item
+	ParentCollapseKeys() []string
+}
+
 func isHeader(it Item) bool {
 	h, ok := it.(HeaderItem)
 	return ok && h.IsHeader()
+}
+
+func isCollapsible(it Item) bool {
+	c, ok := it.(CollapsibleItem)
+	return ok && c.IsCollapsible()
+}
+
+// isNavSkip reports whether ↑/↓ should skip this row. Collapsible headers are
+// focusable; plain HeaderItem dividers are not.
+func isNavSkip(it Item) bool {
+	if isCollapsible(it) {
+		return false
+	}
+	return isHeader(it)
+}
+
+func parentCollapseKeys(it Item) []string {
+	if n, ok := it.(NestedItem); ok {
+		return n.ParentCollapseKeys()
+	}
+	return nil
 }
 
 // ActionSpec binds a key to a caller-named action. Pressing Key while an item
@@ -105,19 +144,20 @@ type Result struct {
 
 // Model is the shared two-pane bubbletea model.
 type Model struct {
-	cfg     Config
-	items   []Item // filtered view (equal to cfg.Items when filter is empty)
-	cursor  int
-	width   int
-	height  int
-	preview viewport.Model
-	filter  textinput.Model
-	filtOn  bool
-	helpOn  bool // ? overlay: full-body keybinding cheatsheet
-	result  Result
-	keys    Keys
-	actions map[string]ActionSpec // keyed by ActionSpec.Key
-	done    bool
+	cfg       Config
+	items     []Item // visible view (filter + collapse applied)
+	cursor    int
+	width     int
+	height    int
+	preview   viewport.Model
+	filter    textinput.Model
+	filtOn    bool
+	helpOn    bool // ? overlay: full-body keybinding cheatsheet
+	result    Result
+	keys      Keys
+	actions   map[string]ActionSpec // keyed by ActionSpec.Key
+	done      bool
+	collapsed map[string]bool // CollapseKey → collapsed; missing = expanded
 }
 
 // NewListDetail builds a Model ready for Run.
@@ -145,32 +185,33 @@ func NewListDetail(cfg Config) Model {
 	}
 
 	m := Model{
-		cfg:     cfg,
-		items:   append([]Item(nil), cfg.Items...),
-		preview: vp,
-		filter:  filt,
-		keys:    DefaultKeys(),
-		actions: acts,
+		cfg:       cfg,
+		preview:   vp,
+		filter:    filt,
+		keys:      DefaultKeys(),
+		actions:   acts,
+		collapsed: map[string]bool{},
 	}
+	m.rebuildVisible()
 	m.cursor = m.firstSelectable()
 	return m
 }
 
-// firstSelectable returns the index of the first non-header item, or 0.
+// firstSelectable returns the index of the first navigable item, or 0.
 func (m Model) firstSelectable() int {
 	for i := range m.items {
-		if !isHeader(m.items[i]) {
+		if !isNavSkip(m.items[i]) {
 			return i
 		}
 	}
 	return 0
 }
 
-// nextSelectable / prevSelectable return the next non-header index in the given
+// nextSelectable / prevSelectable return the next navigable index in the given
 // direction, or -1 if there is none.
 func (m Model) nextSelectable(from int) int {
 	for i := from + 1; i < len(m.items); i++ {
-		if !isHeader(m.items[i]) {
+		if !isNavSkip(m.items[i]) {
 			return i
 		}
 	}
@@ -179,7 +220,7 @@ func (m Model) nextSelectable(from int) int {
 
 func (m Model) prevSelectable(from int) int {
 	for i := from - 1; i >= 0; i-- {
-		if !isHeader(m.items[i]) {
+		if !isNavSkip(m.items[i]) {
 			return i
 		}
 	}
@@ -319,6 +360,17 @@ func (m Model) updateNav(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 	k := msg.String()
 	if k == "enter" {
+		// Collapsible section headers absorb enter to toggle expand/collapse.
+		if len(m.items) > 0 && m.cursor < len(m.items) && isCollapsible(m.items[m.cursor]) {
+			c := m.items[m.cursor].(CollapsibleItem)
+			key := c.CollapseKey()
+			m.collapsed[key] = !m.collapsed[key]
+			focusKey := key
+			m.rebuildVisible()
+			m.cursor = m.indexOfCollapseKey(focusKey)
+			m.refreshPreview()
+			return m, nil
+		}
 		// First enabled action absorbs enter so users don't need to learn a
 		// verb-key for the common case (install, update, apply…).
 		for _, a := range m.cfg.Actions {
@@ -342,12 +394,24 @@ func (m Model) exitWith(action string) (tea.Model, tea.Cmd) {
 	if len(m.items) > 0 && m.cursor < len(m.items) {
 		it = m.items[m.cursor]
 	}
-	if isHeader(it) { // never surface a header row as a selection
+	// Never surface a header or collapsible section row as a selection.
+	if isHeader(it) || isCollapsible(it) {
 		it = nil
 	}
 	m.result = Result{Action: action, Item: it}
 	m.done = true
 	return m, tea.Quit
+}
+
+// indexOfCollapseKey finds a collapsible header by CollapseKey in the visible
+// list, or falls back to firstSelectable.
+func (m Model) indexOfCollapseKey(key string) int {
+	for i, it := range m.items {
+		if c, ok := it.(CollapsibleItem); ok && c.IsCollapsible() && c.CollapseKey() == key {
+			return i
+		}
+	}
+	return m.firstSelectable()
 }
 
 func (m *Model) resize() {
@@ -431,15 +495,24 @@ func (m Model) measureLeftWidth() int {
 }
 
 func (m *Model) applyFilter() {
+	m.rebuildVisible()
+	// Keep the cursor in range and off non-navigable rows.
+	if len(m.items) == 0 {
+		m.cursor = 0
+	} else if m.cursor >= len(m.items) || isNavSkip(m.items[m.cursor]) {
+		m.cursor = m.firstSelectable()
+	}
+}
+
+// rebuildVisible rebuilds m.items from cfg.Items applying the active filter
+// and collapse state. While filtering, all headers (including collapsible
+// section headers) are hidden so the list is a flat match view.
+func (m *Model) rebuildVisible() {
 	q := strings.ToLower(strings.TrimSpace(m.filter.Value()))
-	if q == "" {
-		m.items = append([]Item(nil), m.cfg.Items...)
-	} else {
+	if q != "" {
 		out := make([]Item, 0, len(m.cfg.Items))
 		for _, it := range m.cfg.Items {
-			// Headers are group dividers, not matches — hide them while
-			// filtering so the list collapses to a flat matched view.
-			if isHeader(it) {
+			if isHeader(it) || isCollapsible(it) {
 				continue
 			}
 			if strings.Contains(strings.ToLower(it.FilterValue()), q) {
@@ -447,13 +520,28 @@ func (m *Model) applyFilter() {
 			}
 		}
 		m.items = out
+		return
 	}
-	// Keep the cursor in range and off any header row.
-	if len(m.items) == 0 {
-		m.cursor = 0
-	} else if m.cursor >= len(m.items) || isHeader(m.items[m.cursor]) {
-		m.cursor = m.firstSelectable()
+	if m.collapsed == nil {
+		m.collapsed = map[string]bool{}
 	}
+	out := make([]Item, 0, len(m.cfg.Items))
+	for _, it := range m.cfg.Items {
+		if hiddenByCollapse(it, m.collapsed) {
+			continue
+		}
+		out = append(out, it)
+	}
+	m.items = out
+}
+
+func hiddenByCollapse(it Item, collapsed map[string]bool) bool {
+	for _, k := range parentCollapseKeys(it) {
+		if collapsed[k] {
+			return true
+		}
+	}
+	return false
 }
 
 func (m *Model) refreshPreview() {
@@ -556,7 +644,12 @@ func (m Model) renderLeft(width int) string {
 	sb.WriteString("\n\n")
 	for i, it := range m.items {
 		selected := i == m.cursor
-		row := it.Row(th, width-2, selected)
+		var row string
+		if c, ok := it.(CollapsibleItem); ok && c.IsCollapsible() {
+			row = c.RowCollapsed(th, width-2, selected, m.collapsed[c.CollapseKey()])
+		} else {
+			row = it.Row(th, width-2, selected)
+		}
 		// Pad the row body (minus the leading bar/gutter) to width-2.
 		rowW := lipgloss.Width(row)
 		if rowW < width-2 {
@@ -661,12 +754,21 @@ func (m Model) hints() []KeyHint {
 		hints = append(hints, KeyHint{Keys: "/", Label: "filter"})
 	}
 	hints = append(hints, KeyHint{Keys: "⇞⇟", Label: "scroll"})
+
+	onSection := len(m.items) > 0 && m.cursor < len(m.items) && isCollapsible(m.items[m.cursor])
+	if onSection {
+		hints = append(hints, KeyHint{Keys: "enter", Label: "toggle"})
+	}
+
 	// Deduplicate enter when it's absorbed by the first action.
 	seen := map[string]bool{}
+	if onSection {
+		seen["enter"] = true // enter already claimed by section toggle
+	}
 	for _, a := range m.cfg.Actions {
 		label := a.Label
 		keyStr := a.Key
-		if keyStr == "enter" || (len(m.cfg.Actions) > 0 && !seen["enter"] && a.Key == m.cfg.Actions[0].Key) {
+		if !onSection && (keyStr == "enter" || (len(m.cfg.Actions) > 0 && !seen["enter"] && a.Key == m.cfg.Actions[0].Key)) {
 			// First action also triggers on enter.
 			keyStr = a.Key + "/enter"
 			if a.Key == "enter" {
@@ -705,6 +807,7 @@ func (m Model) renderHelp() string {
 	nav := helpGroup{title: "NAVIGATE", rows: []helpRow{
 		{"↑ / k", "move up"},
 		{"↓ / j", "move down"},
+		{"enter", "toggle section (on category/role headers)"},
 	}}
 	if m.cfg.Items != nil {
 		nav.rows = append(nav.rows, helpRow{"/", "filter list"})

--- a/cli/internal/tui/listdetail_collapse_test.go
+++ b/cli/internal/tui/listdetail_collapse_test.go
@@ -1,0 +1,133 @@
+package tui
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/jjfantini/humblSKILLS/cli/internal/ui"
+)
+
+type testCollapse struct {
+	k       string
+	parents []string
+}
+
+func (c testCollapse) Key() string                     { return c.k }
+func (c testCollapse) Row(*ui.Theme, int, bool) string { return c.k }
+func (c testCollapse) Detail(*ui.Theme, int) string    { return c.k }
+func (c testCollapse) FilterValue() string             { return "" }
+func (c testCollapse) IsCollapsible() bool             { return true }
+func (c testCollapse) CollapseKey() string             { return c.k }
+func (c testCollapse) ParentCollapseKeys() []string    { return c.parents }
+func (c testCollapse) RowCollapsed(th *ui.Theme, width int, selected, collapsed bool) string {
+	_ = th
+	_ = width
+	_ = selected
+	if collapsed {
+		return "▸ " + c.k
+	}
+	return "▾ " + c.k
+}
+
+type testNestedRow struct {
+	k       string
+	parents []string
+}
+
+func (r testNestedRow) Key() string                     { return r.k }
+func (r testNestedRow) Row(*ui.Theme, int, bool) string { return r.k }
+func (r testNestedRow) Detail(*ui.Theme, int) string    { return "" }
+func (r testNestedRow) FilterValue() string             { return r.k }
+func (r testNestedRow) ParentCollapseKeys() []string    { return r.parents }
+
+func TestListDetail_CollapsibleNavAndToggle(t *testing.T) {
+	m := NewListDetail(Config{Items: []Item{
+		testHeader{"reg"},
+		testCollapse{k: "cat"},
+		testNestedRow{k: "a", parents: []string{"cat"}},
+		testCollapse{k: "role", parents: []string{"cat"}},
+		testNestedRow{k: "b", parents: []string{"cat", "role"}},
+	}})
+
+	// Registry header skipped; land on category.
+	if m.cursor != 1 || m.items[m.cursor].Key() != "cat" {
+		t.Fatalf("cursor=%d key=%q, want category", m.cursor, m.items[m.cursor].Key())
+	}
+	// Category is navigable (not skipped).
+	if got := m.nextSelectable(1); got != 2 {
+		t.Fatalf("next from cat = %d, want 2 (skill a)", got)
+	}
+
+	// Collapse category → hide a, role, b.
+	m.cursor = 1
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(Model)
+	keys := visibleKeys(m)
+	want := []string{"reg", "cat"}
+	if len(keys) != len(want) {
+		t.Fatalf("after collapse visible = %v, want %v", keys, want)
+	}
+	for i := range want {
+		if keys[i] != want[i] {
+			t.Fatalf("after collapse visible = %v, want %v", keys, want)
+		}
+	}
+	if m.cursor != 1 || m.items[m.cursor].Key() != "cat" {
+		t.Fatalf("cursor should stay on category, got %d %q", m.cursor, m.items[m.cursor].Key())
+	}
+
+	// Expand again.
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(Model)
+	keys = visibleKeys(m)
+	want = []string{"reg", "cat", "a", "role", "b"}
+	if len(keys) != len(want) {
+		t.Fatalf("after expand visible = %v, want %v", keys, want)
+	}
+}
+
+func TestListDetail_CollapseRoleOnly(t *testing.T) {
+	m := NewListDetail(Config{Items: []Item{
+		testCollapse{k: "cat"},
+		testNestedRow{k: "a", parents: []string{"cat"}},
+		testCollapse{k: "role", parents: []string{"cat"}},
+		testNestedRow{k: "b", parents: []string{"cat", "role"}},
+	}})
+	// Move to role header.
+	m.cursor = 2
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(Model)
+	keys := visibleKeys(m)
+	want := []string{"cat", "a", "role"}
+	if len(keys) != len(want) {
+		t.Fatalf("visible = %v, want %v", keys, want)
+	}
+	for i := range want {
+		if keys[i] != want[i] {
+			t.Fatalf("visible = %v, want %v", keys, want)
+		}
+	}
+}
+
+func TestListDetail_FilterHidesCollapsibleHeaders(t *testing.T) {
+	m := NewListDetail(Config{Items: []Item{
+		testCollapse{k: "cat"},
+		testNestedRow{k: "alpha", parents: []string{"cat"}},
+		testNestedRow{k: "beta", parents: []string{"cat"}},
+	}})
+	m.filter.SetValue("alp")
+	m.rebuildVisible()
+	keys := visibleKeys(m)
+	if len(keys) != 1 || keys[0] != "alpha" {
+		t.Fatalf("filter visible = %v, want [alpha]", keys)
+	}
+}
+
+func visibleKeys(m Model) []string {
+	out := make([]string, 0, len(m.items))
+	for _, it := range m.items {
+		out = append(out, it.Key())
+	}
+	return out
+}

--- a/cli/internal/tui/profile.go
+++ b/cli/internal/tui/profile.go
@@ -201,8 +201,8 @@ func (m profileModel) updateValue(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 }
 
 func (m profileModel) toggleCurrent() profileModel {
-	switch m.settingIdx {
-	case 0: // platforms
+	switch profileSettings[m.settingIdx].key {
+	case "platforms":
 		if m.valueIdx >= len(m.adapters) {
 			return m
 		}
@@ -223,14 +223,19 @@ func (m profileModel) toggleCurrent() profileModel {
 			m.profile.DefaultPlatforms = append(m.profile.DefaultPlatforms, name)
 		}
 		m.changed = true
-	case 1: // scope
+	case "scope":
 		if m.valueIdx >= 0 && m.valueIdx < len(scopeSettingOpts) {
 			m.profile.DefaultScope = scopeSettingOpts[m.valueIdx].value
 			m.changed = true
 		}
-	case 2: // status auto-return
+	case "status_auto_return":
 		if m.valueIdx >= 0 && m.valueIdx < len(autoReturnSettingOpts) {
 			m.profile.StatusAutoReturnSeconds = autoReturnSettingOpts[m.valueIdx].value
+			m.changed = true
+		}
+	case "group_by_category":
+		if m.valueIdx >= 0 && m.valueIdx < len(groupByCategoryOpts) {
+			m.profile.GroupByCategory = groupByCategoryOpts[m.valueIdx].value
 			m.changed = true
 		}
 	}
@@ -264,7 +269,18 @@ var autoReturnSettingOpts = []struct {
 	{"disabled — wait for enter/q", intPtr(0)},
 }
 
-func intPtr(n int) *int { return &n }
+// groupByCategoryOpts is the picker for GroupByCategory. Selecting "on"
+// clears the field (nil → resolved default on); "off" stores explicit false.
+var groupByCategoryOpts = []struct {
+	label string
+	value *bool
+}{
+	{"on (default)", nil},
+	{"off", boolPtr(false)},
+}
+
+func intPtr(n int) *int    { return &n }
+func boolPtr(b bool) *bool { return &b }
 
 // detailLines wraps a setting description to the value pane's width and
 // prefixes each wrapped line with the divider bar, so long descriptions
@@ -282,28 +298,32 @@ func detailLines(th *ui.Theme, bar, text string, width int) []string {
 	return out
 }
 
-
 // currentSelectionIndex returns the index in the right-pane options list that
 // represents the profile's current value for the focused setting. Used to
 // place the cursor on the already-selected option when the user drills in.
 func (m profileModel) currentSelectionIndex() int {
-	switch m.settingIdx {
-	case 0:
+	switch profileSettings[m.settingIdx].key {
+	case "platforms":
 		return 0
-	case 1:
+	case "scope":
 		resolved := m.profile.ResolvedScope()
 		for i, opt := range scopeSettingOpts {
 			if opt.value == resolved {
 				return i
 			}
 		}
-	case 2:
+	case "status_auto_return":
 		cur := m.profile.StatusAutoReturnSeconds
 		for i, opt := range autoReturnSettingOpts {
 			if autoReturnValueEqual(cur, opt.value) {
 				return i
 			}
 		}
+	case "group_by_category":
+		if m.profile.ResolvedGroupByCategory() {
+			return 0
+		}
+		return 1
 	}
 	return 0
 }
@@ -319,13 +339,15 @@ func autoReturnValueEqual(a, b *int) bool {
 }
 
 func (m profileModel) valueCount() int {
-	switch m.settingIdx {
-	case 0:
+	switch profileSettings[m.settingIdx].key {
+	case "platforms":
 		return len(m.adapters)
-	case 1:
+	case "scope":
 		return len(scopeSettingOpts)
-	case 2:
+	case "status_auto_return":
 		return len(autoReturnSettingOpts)
+	case "group_by_category":
+		return len(groupByCategoryOpts)
 	}
 	return 0
 }
@@ -349,6 +371,7 @@ var profileSettings = []profileSetting{
 	{key: "platforms", label: "default platforms", kind: settingMulti},
 	{key: "scope", label: "default scope", kind: settingRadio},
 	{key: "status_auto_return", label: "status auto-return", kind: settingRadio},
+	{key: "group_by_category", label: "group by category", kind: settingRadio},
 }
 
 func (m profileModel) View() string {
@@ -470,13 +493,15 @@ func (m profileModel) renderRight(width int) string {
 	body = append(body, bar+" "+th.DetailSub.Render(hint))
 	body = append(body, bar)
 
-	switch m.settingIdx {
-	case 0:
+	switch setting.key {
+	case "platforms":
 		body = append(body, m.renderPlatformOptions(bar, width)...)
-	case 1:
+	case "scope":
 		body = append(body, m.renderScopeOptions(bar, width)...)
-	case 2:
+	case "status_auto_return":
 		body = append(body, m.renderAutoReturnOptions(bar, width)...)
+	case "group_by_category":
+		body = append(body, m.renderGroupByCategoryOptions(bar, width)...)
 	}
 	return strings.Join(body, "\n")
 }
@@ -600,6 +625,41 @@ func (m profileModel) renderAutoReturnOptions(bar string, width int) []string {
 	return rows
 }
 
+func (m profileModel) renderGroupByCategoryOptions(bar string, width int) []string {
+	th := m.theme
+	rows := make([]string, 0, len(groupByCategoryOpts)+4)
+	rows = append(rows, detailLines(th, bar,
+		"Nest skills under category headers in the skills browser (Registry → "+
+			"Category → Role → Skills). Role headers appear only when skills carry a "+
+			"role. Off restores the legacy Registry → Role → Skills layout.", width)...)
+	rows = append(rows, bar)
+	rows = append(rows, bar+" "+th.SectionTitle.Render("OPTIONS"))
+	for i, opt := range groupByCategoryOpts {
+		cursorHere := i == m.valueIdx && m.focus == focusValue
+		resolvedOn := m.profile.ResolvedGroupByCategory()
+		isCurrent := (i == 0 && resolvedOn) || (i == 1 && !resolvedOn)
+		marker := "( )"
+		if isCurrent {
+			marker = "(●)"
+		}
+		var styled string
+		switch {
+		case cursorHere:
+			styled = th.RowSelected.Render(marker + "  " + opt.label)
+		case isCurrent:
+			styled = th.Success.Render(marker) + "  " + th.RowUnselected.Render(opt.label)
+		default:
+			styled = th.RowDim.Render(marker) + "  " + th.RowUnselected.Render(opt.label)
+		}
+		prefix := bar + "   "
+		if cursorHere {
+			prefix = bar + " " + th.Bullet.Render("▸") + " "
+		}
+		rows = append(rows, prefix+styled)
+	}
+	return rows
+}
+
 func (m profileModel) layoutRow(label, badge string, width int) string {
 	lw := lipgloss.Width(label)
 	bw := lipgloss.Width(badge)
@@ -632,8 +692,21 @@ func (m profileModel) settingBadge(key string) string {
 		}
 	case "status_auto_return":
 		return formatAutoReturnBadge(m.profile.StatusAutoReturnSeconds)
+	case "group_by_category":
+		return formatGroupByCategoryBadge(m.profile.GroupByCategory)
 	}
 	return ""
+}
+
+func formatGroupByCategoryBadge(flag *bool) string {
+	switch {
+	case flag == nil:
+		return "on (default)"
+	case *flag:
+		return "on"
+	default:
+		return "off"
+	}
 }
 
 // formatAutoReturnBadge renders StatusAutoReturnSeconds for the left-pane

--- a/cli/internal/tui/profile_test.go
+++ b/cli/internal/tui/profile_test.go
@@ -246,3 +246,33 @@ func TestProfileModel_Radio_EnterTogglesAndReturns(t *testing.T) {
 		t.Errorf("enter should return focus to the settings pane, got %v", updated.focus)
 	}
 }
+
+func TestProfileModel_GroupByCategory_DefaultsOn(t *testing.T) {
+	m := newTestProfileModel(profile.Profile{})
+	m.settingIdx = 3 // group_by_category
+	if got := m.currentSelectionIndex(); got != 0 {
+		t.Errorf("unset group_by_category should select on (default), got %d", got)
+	}
+	if got := m.settingBadge("group_by_category"); got != "on (default)" {
+		t.Errorf("badge = %q, want on (default)", got)
+	}
+	if m.valueCount() != 2 {
+		t.Errorf("valueCount = %d, want 2", m.valueCount())
+	}
+}
+
+func TestProfileModel_GroupByCategory_ToggleOff(t *testing.T) {
+	m := newTestProfileModel(profile.Profile{})
+	m.settingIdx = 3
+	m.focus = focusValue
+	m.valueIdx = 1 // off
+
+	out, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updated := out.(profileModel)
+	if updated.profile.GroupByCategory == nil || *updated.profile.GroupByCategory {
+		t.Errorf("GroupByCategory = %v, want false", updated.profile.GroupByCategory)
+	}
+	if updated.profile.ResolvedGroupByCategory() {
+		t.Error("expected ResolvedGroupByCategory false after off")
+	}
+}

--- a/registry.json
+++ b/registry.json
@@ -1,10 +1,10 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-07-29T19:15:42Z",
+  "generated_at": "2026-07-29T20:23:11Z",
   "source": {
     "repo": "github.com/jjfantini/humblSKILLS",
-    "ref": "feat/better-interface",
-    "sha": "a4a27accb4f5f959556e55f5cd2c939e2afea13c"
+    "ref": "feat/tui-category-grouping",
+    "sha": "1d6ae0d1c4ade97ea71d1a1ba3666345a71e4772"
   },
   "skills": [
     {


### PR DESCRIPTION
## Summary
- Nest skills under category (and role when present) in the skills TUI; profile toggle `group_by_category` defaults on
- Category/role headers are focusable and collapse/expand with Enter; registry bars stay full-width separators
- Fix DETAIL pane wrapping for descriptions, tags, and long install paths

## Test plan
- [x] `go test ./internal/profile/ ./internal/tui/ ./cmd/humblskills/`
- [ ] After merge, release-please opens/updates release PR → tag → goreleaser → brew formula bump
- [ ] `brew upgrade humblskills` installs the new version
- [ ] Skills browser shows category groups; Enter toggles; Detail text wraps


Made with [Cursor](https://cursor.com)