### PR TITLE
fix(install): carry preserved user data across a skill rename

### DIFF
--- a/cli/cmd/build-registry/main.go
+++ b/cli/cmd/build-registry/main.go
@@ -104,18 +104,19 @@ func run(skillsDir, outFile, repo, ref, sha string, check bool) error {
 			return fmt.Errorf("dir_sha for %s: %w", p.fm.Name, err)
 		}
 		skills = append(skills, registry.Skill{
-			Name:        p.fm.Name,
-			Version:     p.fm.Version(),
-			Description: p.fm.Description,
-			Category:    p.fm.Category(),
-			Role:        p.fm.Role(),
-			Tags:        p.fm.Tags(),
-			Platforms:   p.fm.Platforms(),
-			Requires:    p.fm.Requires(),
-			Preserve:    p.fm.Preserve(),
-			Upstream:    p.fm.Upstream,
-			Path:        filepath.ToSlash(filepath.Join(filepath.Base(skillsDir), p.dirName)),
-			DirSHA:      dirSha,
+			Name:          p.fm.Name,
+			Version:       p.fm.Version(),
+			Description:   p.fm.Description,
+			Category:      p.fm.Category(),
+			Role:          p.fm.Role(),
+			Tags:          p.fm.Tags(),
+			Platforms:     p.fm.Platforms(),
+			Requires:      p.fm.Requires(),
+			Preserve:      p.fm.Preserve(),
+			PreviousNames: p.fm.PreviousNames(),
+			Upstream:      p.fm.Upstream,
+			Path:          filepath.ToSlash(filepath.Join(filepath.Base(skillsDir), p.dirName)),
+			DirSHA:        dirSha,
 		})
 	}
 	sort.Slice(skills, func(i, j int) bool { return skills[i].Name < skills[j].Name })

--- a/cli/internal/frontmatter/frontmatter.go
+++ b/cli/internal/frontmatter/frontmatter.go
@@ -48,6 +48,11 @@ type Metadata struct {
 	Platforms []string `yaml:"platforms,omitempty"`
 	Tags      []string `yaml:"tags,omitempty"`
 	Preserve  []string `yaml:"preserve,omitempty"`
+	// PreviousNames lists names this skill was published under before being
+	// renamed. Without it a rename reads as "a brand new skill installed next
+	// to an unrelated old one", and the user's preserved brain data is stranded
+	// in a directory nothing points at. See install.Engine for how it is used.
+	PreviousNames []string `yaml:"previous_names,omitempty"`
 }
 
 // Upstream declares that a skill is a mirror of a skill published elsewhere.
@@ -170,6 +175,13 @@ func (f Frontmatter) Preserve() []string {
 		return f.Metadata.Preserve
 	}
 	return f.legacyPreserve
+}
+
+// PreviousNames returns the names this skill was published under before a
+// rename. There is no deprecated top-level fallback - the key postdates the
+// legacy-field migration window.
+func (f Frontmatter) PreviousNames() []string {
+	return f.Metadata.PreviousNames
 }
 
 // DeprecationWarnings returns a list of human-readable strings describing

--- a/cli/internal/install/engine.go
+++ b/cli/internal/install/engine.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/jjfantini/humblSKILLS/cli/internal/adapters"
@@ -284,6 +285,7 @@ func (e *Engine) installOne(
 	var toWrite []installPlanTarget
 	var skipped []TargetResult
 	preserveSource := ""
+	renamedFrom := ""
 	for _, pg := range pendings {
 		existing := m.FindOne(skill.Name, pg.adapter.Name, pg.target.Scope)
 		orphan := ""
@@ -324,6 +326,20 @@ func (e *Engine) installOne(
 			}
 		} else if preserveSource == "" && realDirExists(pg.final) {
 			preserveSource = pg.final
+		}
+		// A renamed skill has no installation under its new name, so the
+		// lookups above find nothing and every preserved path would be written
+		// fresh - silently discarding the user's log/decisions/patterns. Fall
+		// back to whatever this skill used to be called.
+		if preserveSource == "" && existing == nil {
+			if prev := m.FindPrevious(skill.PreviousNames, pg.adapter.Name, pg.target.Scope); prev != nil {
+				if prev.StorePath != "" {
+					preserveSource = prev.StorePath
+				} else {
+					preserveSource = prev.Path
+				}
+				renamedFrom = prev.Skill
+			}
 		}
 		switch {
 		case upToDate && !opts.Force:
@@ -401,6 +417,13 @@ func (e *Engine) installOne(
 				}
 			}
 			writeSrc = perStore
+			if renamedFrom != "" {
+				opts.OnEvent.emit(Event{
+					Phase: PhaseWarn, Skill: skill.Name,
+					Msg: fmt.Sprintf("renamed from %s — carried over preserved data (%s)",
+						renamedFrom, strings.Join(preserveList, ", ")),
+				})
+			}
 		}
 	}
 
@@ -456,7 +479,48 @@ func (e *Engine) installOne(
 			Outcome: pt.out, Path: pt.pending.final, Version: skill.Version, StorePath: storePath,
 		})
 	}
+
+	// The superseded installation is only retired once the new one is fully
+	// written and its data carried over. Leaving it would double-register the
+	// skill with every agent runtime; removing it earlier would risk losing the
+	// only copy of the user's brain data if anything above failed.
+	if renamedFrom != "" {
+		removed, err := e.retireRenamed(m, renamedFrom, storePath)
+		if err != nil {
+			return nil, err
+		}
+		results = append(results, removed...)
+	}
 	return results, nil
+}
+
+// retireRenamed removes installations published under a superseded name after
+// the renamed skill has been installed and its preserved data carried forward.
+// The canonical store is only deleted when nothing else references it.
+func (e *Engine) retireRenamed(m *manifest.Manifest, oldName, newStorePath string) ([]TargetResult, error) {
+	var out []TargetResult
+	stores := map[string]struct{}{}
+	for _, inst := range m.FindAll(oldName) {
+		if inst.StorePath != "" && inst.StorePath != newStorePath {
+			stores[inst.StorePath] = struct{}{}
+		}
+		if err := os.RemoveAll(inst.Path); err != nil {
+			return out, fmt.Errorf("retire renamed %s: %w", inst.Path, err)
+		}
+		out = append(out, TargetResult{
+			Skill: inst.Skill, Platform: inst.Platform, Scope: inst.Scope,
+			Path: inst.Path, Outcome: "removed",
+		})
+	}
+	m.Remove(oldName)
+	for store := range stores {
+		if !manifestReferencesStore(m, store) {
+			if err := os.RemoveAll(store); err != nil {
+				return out, fmt.Errorf("retire renamed store %s: %w", store, err)
+			}
+		}
+	}
+	return out, nil
 }
 
 func (e *Engine) preserveListForStore(

--- a/cli/internal/install/engine_test.go
+++ b/cli/internal/install/engine_test.go
@@ -1478,3 +1478,134 @@ func TestEngine_DirSHAMismatchFails(t *testing.T) {
 		t.Fatal("expected dir_sha mismatch error")
 	}
 }
+
+// TestRename_CarriesPreservedDataToNewName is the regression test for the
+// data-loss hole a rename opens: `preserve` is looked up by skill name, so a
+// renamed skill matches no existing installation and every preserved path is
+// written fresh from the tarball -- silently discarding the user's log,
+// decisions, and patterns. `previous_names` closes it.
+func TestRename_CarriesPreservedDataToNewName(t *testing.T) {
+	root := t.TempDir()
+	cacheDir := filepath.Join(root, "cache")
+	installRoot := filepath.Join(root, "home", ".claude", "skills")
+	manifestPath := filepath.Join(root, "manifest.json")
+
+	oldBody := skillMD("use-foo", "0.1.0", []string{"log.md"})
+	oldFiles := map[string]string{
+		"skills/use-foo/SKILL.md": oldBody,
+		"skills/use-foo/log.md":   "shipped\n",
+	}
+	oldSHA := expectedDirSHA(t, map[string]string{"SKILL.md": oldBody, "log.md": "shipped\n"})
+	src1 := "sharename1aaa"
+	seedTarball(t, cacheDir, "ex", "r", src1, "ex-r-abc", oldFiles)
+
+	newBody := skillMD("foo", "0.2.0", []string{"log.md"})
+	newFiles := map[string]string{
+		"skills/foo/SKILL.md": newBody,
+		"skills/foo/log.md":   "shipped-v2\n",
+	}
+	newSHA := expectedDirSHA(t, map[string]string{"SKILL.md": newBody, "log.md": "shipped-v2\n"})
+	src2 := "sharename2bbb"
+	seedTarball(t, cacheDir, "ex", "r", src2, "ex-r-def", newFiles)
+
+	adapter := adapters.Adapter{
+		Name:           "test",
+		InstallTargets: map[string]string{"user": installRoot},
+		DefaultScope:   "user",
+	}
+	engine := NewEngine(cacheDir, manifestPath)
+	engine.Now = func() time.Time { return time.Unix(1700000000, 0).UTC() }
+
+	reg1 := &registry.Registry{
+		SchemaVersion: registry.SchemaVersion,
+		Source:        registry.Source{Repo: "github.com/ex/r", SHA: src1},
+		Skills: []registry.Skill{{
+			Name: "use-foo", Version: "0.1.0", Path: "skills/use-foo",
+			Platforms: []string{"test"}, DirSHA: oldSHA, Preserve: []string{"log.md"},
+		}},
+	}
+	plan1, _ := Plan(reg1, "use-foo")
+	if _, err := engine.Execute(reg1, plan1, ExecuteOpts{
+		Adapters: []adapters.Adapter{adapter}, Platforms: []string{"test"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// The user accumulates brain data under the OLD name.
+	userLog := "shipped\n[SESSION] real work the user cannot get back\n"
+	if err := os.WriteFile(filepath.Join(installRoot, "use-foo", "log.md"), []byte(userLog), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Upstream renames use-foo -> foo.
+	reg2 := &registry.Registry{
+		SchemaVersion: registry.SchemaVersion,
+		Source:        registry.Source{Repo: "github.com/ex/r", SHA: src2},
+		Skills: []registry.Skill{{
+			Name: "foo", Version: "0.2.0", Path: "skills/foo",
+			Platforms: []string{"test"}, DirSHA: newSHA, Preserve: []string{"log.md"},
+			PreviousNames: []string{"use-foo"},
+		}},
+	}
+	plan2, _ := Plan(reg2, "foo")
+	r, err := engine.Execute(reg2, plan2, ExecuteOpts{
+		Adapters: []adapters.Adapter{adapter}, Platforms: []string{"test"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(installRoot, "foo", "log.md"))
+	if err != nil {
+		t.Fatalf("renamed skill not installed: %v", err)
+	}
+	if string(got) != userLog {
+		t.Errorf("user brain data lost across rename\n got: %q\nwant: %q", got, userLog)
+	}
+
+	// The superseded install is retired, so the skill is not double-registered.
+	if _, err := os.Stat(filepath.Join(installRoot, "use-foo")); !os.IsNotExist(err) {
+		t.Error("old install directory should be removed after a successful rename")
+	}
+	m, err := manifest.Load(manifestPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m.Find("use-foo") != nil {
+		t.Error("manifest should no longer track the old name")
+	}
+	if m.Find("foo") == nil {
+		t.Error("manifest should track the new name")
+	}
+
+	// The carry-over is reported, not silent.
+	var announced bool
+	for _, w := range r.Warnings {
+		if strings.Contains(w.Msg, "renamed from use-foo") {
+			announced = true
+		}
+	}
+	if !announced {
+		t.Errorf("rename carry-over should be surfaced to the user, got %+v", r.Warnings)
+	}
+}
+
+// TestRename_WithoutPreviousNamesLeavesOldAlone guards the blast radius: a
+// skill that merely shares a prefix must never trigger retirement.
+func TestRename_WithoutPreviousNamesLeavesOldAlone(t *testing.T) {
+	m := &manifest.Manifest{Installations: []manifest.Installation{
+		{Skill: "use-foo", Platform: "test", Scope: "user"},
+	}}
+	if got := m.FindPrevious(nil, "test", "user"); got != nil {
+		t.Error("no previous_names must match nothing")
+	}
+	if got := m.FindPrevious([]string{"", "unrelated"}, "test", "user"); got != nil {
+		t.Error("unrelated names must not match")
+	}
+	if got := m.FindPrevious([]string{"use-foo"}, "test", "user"); got == nil {
+		t.Error("declared previous name should match")
+	}
+	if got := m.FindPrevious([]string{"use-foo"}, "other", "user"); got != nil {
+		t.Error("must not cross platform boundaries")
+	}
+}

--- a/cli/internal/manifest/manifest.go
+++ b/cli/internal/manifest/manifest.go
@@ -184,3 +184,19 @@ func (m *Manifest) RemoveOne(skill, platform, scope string) bool {
 	}
 	return false
 }
+
+// FindPrevious returns the installation for the first of names that has an
+// entry on this platform/scope. It is how a renamed skill locates the
+// installation it supersedes, so the user's preserved data can be carried
+// forward instead of stranded under the old name.
+func (m *Manifest) FindPrevious(names []string, platform, scope string) *Installation {
+	for _, name := range names {
+		if name == "" {
+			continue
+		}
+		if inst := m.FindOne(name, platform, scope); inst != nil {
+			return inst
+		}
+	}
+	return nil
+}

--- a/cli/internal/registry/types.go
+++ b/cli/internal/registry/types.go
@@ -36,6 +36,10 @@ type Skill struct {
 	Platforms []string `json:"platforms,omitempty"`
 	Requires  []string `json:"requires,omitempty"`
 	Preserve  []string `json:"preserve,omitempty"`
+	// PreviousNames are names this skill was published under before a rename.
+	// The installer uses them to find and carry over an existing installation's
+	// preserved data instead of stranding it under the old name.
+	PreviousNames []string `json:"previous_names,omitempty"`
 	// Upstream is set for skills that mirror a skill published elsewhere.
 	// Carried through from SKILL.md so consumers can render provenance and
 	// detect drift without reading every skill directory.

--- a/registry.json
+++ b/registry.json
@@ -1,10 +1,10 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-07-30T21:37:28Z",
+  "generated_at": "2026-07-30T22:01:32Z",
   "source": {
     "repo": "github.com/jjfantini/humblSKILLS",
-    "ref": "main",
-    "sha": "ca4111f944fdad27655f74473c0a07dbfcafdcf6"
+    "ref": "feat/rename-preserves-user-data",
+    "sha": "8d41cec43764d15f95ff558d6326624cfccdcd7a"
   },
   "skills": [
     {
@@ -33,7 +33,7 @@
         "analyze-ml-system-design"
       ],
       "path": "skills/analyze-smart-ml-system-design",
-      "dir_sha": "43e222dc1b3048f393e473d60f2923839dad22802e8a636a7f15838804efd57f"
+      "dir_sha": "7414c8f89a2b17be4199c53052a97553b349ab899c2ce9f578d3ca97b454951e"
     },
     {
       "name": "analyze-smart-system-design",
@@ -61,7 +61,7 @@
         "analyze-system-design"
       ],
       "path": "skills/analyze-smart-system-design",
-      "dir_sha": "b1a6702f89195d415baa6a3c63f2f2f758870f5615bb75acda6f2eef6b27f25b"
+      "dir_sha": "493b42cdf2cf673bc177f687b5c8e05d3871057a52dd22b7a7bbf17403bae04a"
     },
     {
       "name": "better-accessibility",
@@ -103,7 +103,7 @@
         ]
       },
       "path": "skills/better-accessibility",
-      "dir_sha": "d52eae30ea866bab4078cc3ba0644226d92a490f331fc8ac07e94b4dfbf72080"
+      "dir_sha": "4afd8d0ced5d67710ed0c243cd97b3686ab9f6cc303a75cfdd163e9978671789"
     },
     {
       "name": "better-colors",
@@ -146,7 +146,7 @@
         ]
       },
       "path": "skills/better-colors",
-      "dir_sha": "724d9e6f5740d38f6db032ffafceb45f54821d36a386f185f9fbacee219671c4"
+      "dir_sha": "a58d444f7a72e9e3aba830fa45aa88ba13d86ad8cbaec36342f62a67f66da602"
     },
     {
       "name": "better-interface",
@@ -189,7 +189,7 @@
         ]
       },
       "path": "skills/better-interface",
-      "dir_sha": "540b20172cb049cca58f80b2ceb32ba4872ea6a7a74a4b8cd68f53ce6be53bbe"
+      "dir_sha": "d0e9e637fe6d5cecb138dca571596aadaa8311cc7fc9cc0d2ec8160ef596633e"
     },
     {
       "name": "better-layout",
@@ -231,7 +231,7 @@
         ]
       },
       "path": "skills/better-layout",
-      "dir_sha": "c15579c8f238c330a7ab9d90061ff01788d65e65e32f553cbeb1f724428eae9d"
+      "dir_sha": "9b4e9eead0984a3f87028eac546237e014014bd93565ed75daf6c55a7335355f"
     },
     {
       "name": "better-typography",
@@ -273,7 +273,7 @@
         ]
       },
       "path": "skills/better-typography",
-      "dir_sha": "87438735ac2f24a8fbf94fbf0b90ef1762ebfea2a8fae3d66cc10af39e98abd5"
+      "dir_sha": "3dd11706cfc504666b9119fa11e57bad09a8304b42da4e179ccb857bf926f1ff"
     },
     {
       "name": "better-ui",
@@ -316,7 +316,7 @@
         ]
       },
       "path": "skills/better-ui",
-      "dir_sha": "903b4673b7cc5d1fe1f2b25a1507e8a0bee4cd5edeba947673816afa327004c0"
+      "dir_sha": "2fbfdaf34b78694e25709e004c676bc34396037d95603712e1d674becd1372d5"
     },
     {
       "name": "better-writing",
@@ -357,7 +357,7 @@
         ]
       },
       "path": "skills/better-writing",
-      "dir_sha": "afb20ce14066f37be6ec4789b8c0496c566419922301baf4b1bb95ca0fdab5f3"
+      "dir_sha": "20cb8e32d3940e3886baeb1aeae0066ab6c6178fb963b7ab6fd58f18d0fb7c56"
     },
     {
       "name": "create-smart-html",
@@ -391,7 +391,7 @@
         "generate-smart-html"
       ],
       "path": "skills/create-smart-html",
-      "dir_sha": "cd6b9e6dca81997da1666f1084c1be6dbc9951ceba23779762e59379d3d1bf67"
+      "dir_sha": "e7854d86e5014db031ca144de9f7f35b231d5d3c64e11588f313ece8c4068ab7"
     },
     {
       "name": "create-smart-scroll-animation",
@@ -426,7 +426,7 @@
         "create-scroll-animation"
       ],
       "path": "skills/create-smart-scroll-animation",
-      "dir_sha": "b4c912e50c02e785db5fa4c38fc4b0d39fc13435783341eac416186b01a3a401"
+      "dir_sha": "f45db9f36b7cb5b55b51d920ceee594991a1d4d18df134c7b64f0ff95b72e516"
     },
     {
       "name": "create-smart-video-transition",
@@ -457,7 +457,7 @@
         "create-video-transition"
       ],
       "path": "skills/create-smart-video-transition",
-      "dir_sha": "5ccdda224f0b4625a1d178e9587fdf7b82d121ebc7e2e2aba511145092862d00"
+      "dir_sha": "5d190b3890e1f76dc1400bfa9fb6d742a362fa9b655834867fa7fb85efd46249"
     },
     {
       "name": "smart-animation",
@@ -493,7 +493,7 @@
         "use-smart-animation"
       ],
       "path": "skills/smart-animation",
-      "dir_sha": "4c7ad69f6e8cb7e85b2d399349f4231a2633bb129b64988fd593304c580e7115"
+      "dir_sha": "f1db4765581c0527aaeff8f85388472e39a01339bd00ba1eaffdfb111c79125e"
     },
     {
       "name": "smart-claude-init",
@@ -520,7 +520,7 @@
         "references/patterns.md"
       ],
       "path": "skills/smart-claude-init",
-      "dir_sha": "ab2a00d67ebb3c3ebdf620a5020dc0a7b3a95b20be5be04fee56e34f7aed8924"
+      "dir_sha": "ef5375300f51a6919deaf35914928c3e9026a44ac5da1ad73a76154d5a05b645"
     },
     {
       "name": "smart-commit",
@@ -550,7 +550,7 @@
         "use-smart-commit"
       ],
       "path": "skills/smart-commit",
-      "dir_sha": "da1118812d08765dfb1611fa7eae4605f8909405b873337c814c3a17393c80d9"
+      "dir_sha": "697b9f8649e08c326a90e00e051a935a4f68c59abdc25095fe2e953832e1ad9b"
     },
     {
       "name": "smart-frontend-design",
@@ -592,7 +592,7 @@
         ]
       },
       "path": "skills/smart-frontend-design",
-      "dir_sha": "f73ef7f88e7eff69f7f44ded8a209d0843717f5f9e8cd61c91379536ef934e41"
+      "dir_sha": "7d63d1021afa19ebd1844f9801d4900b546e6d92352ef2484eab3ef91560074d"
     },
     {
       "name": "smart-humanize-text",
@@ -615,7 +615,7 @@
         "use-smart-humanize-text"
       ],
       "path": "skills/smart-humanize-text",
-      "dir_sha": "7553d0f09647e67ebf9b1dab38454a85834f4092d354ae8fdbf4eed979695a0f"
+      "dir_sha": "e3da6901949bb358f922281255347d49309a0d940292fddb1985a9bc00abe37a"
     },
     {
       "name": "smart-skill",
@@ -645,7 +645,7 @@
         "use-smart-skill"
       ],
       "path": "skills/smart-skill",
-      "dir_sha": "e8869c47aab2042ed285a5cc03cf7083853e30b8ff71e987ee6d4ff36f26aea4"
+      "dir_sha": "e859da02c646bb0676a238a9fb7c6323a6bf1a8a2678b38cabb97e2c034beb52"
     },
     {
       "name": "smart-upload-thing",
@@ -676,7 +676,7 @@
         "use-upload-thing"
       ],
       "path": "skills/smart-upload-thing",
-      "dir_sha": "29da6601c960f75531c9ec137f684f091b26bd92f30475d172bdb53e77c77083"
+      "dir_sha": "56f0d82196973fb3f3337ec37a9802f9032f680933e2e7e28d7a7f3f7b990ea5"
     },
     {
       "name": "smart-worktree-flow",
@@ -707,7 +707,7 @@
         "use-worktree-flow"
       ],
       "path": "skills/smart-worktree-flow",
-      "dir_sha": "9365999c517a50af556533bee18d28215002b94c6cee89aac1e43ae6b1308d75"
+      "dir_sha": "04ed00803e220013a7b17abb4a9dee09ea868a6c3354bac7bc9f78c3a7eaee2a"
     }
   ]
 }

--- a/registry.json
+++ b/registry.json
@@ -1,10 +1,10 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-07-30T21:35:19Z",
+  "generated_at": "2026-07-30T21:37:28Z",
   "source": {
     "repo": "github.com/jjfantini/humblSKILLS",
-    "ref": "feat/standardize-smart-namespace",
-    "sha": "d2c112cfbeb3a31679aa4ae95efbecb3eb3aaa73"
+    "ref": "main",
+    "sha": "ca4111f944fdad27655f74473c0a07dbfcafdcf6"
   },
   "skills": [
     {
@@ -29,8 +29,11 @@
         "references/log.md",
         "references/patterns.md"
       ],
+      "previous_names": [
+        "analyze-ml-system-design"
+      ],
       "path": "skills/analyze-smart-ml-system-design",
-      "dir_sha": "f604b5c42cc47c0f1ea85129ccca6a1df41ee3d28786ead11059cd68d19af4af"
+      "dir_sha": "43e222dc1b3048f393e473d60f2923839dad22802e8a636a7f15838804efd57f"
     },
     {
       "name": "analyze-smart-system-design",
@@ -54,8 +57,11 @@
         "references/log.md",
         "references/patterns.md"
       ],
+      "previous_names": [
+        "analyze-system-design"
+      ],
       "path": "skills/analyze-smart-system-design",
-      "dir_sha": "d93007a3fdc6fbd513adb5c12956226ab38a6da94f0130c6b99000b618d8e3a0"
+      "dir_sha": "b1a6702f89195d415baa6a3c63f2f2f758870f5615bb75acda6f2eef6b27f25b"
     },
     {
       "name": "better-accessibility",
@@ -381,8 +387,11 @@
         "references/log.md",
         "references/patterns.md"
       ],
+      "previous_names": [
+        "generate-smart-html"
+      ],
       "path": "skills/create-smart-html",
-      "dir_sha": "2affc20f03a0315ce45316253d0070e940031ab06c56c2d81d69cb9f909aee52"
+      "dir_sha": "cd6b9e6dca81997da1666f1084c1be6dbc9951ceba23779762e59379d3d1bf67"
     },
     {
       "name": "create-smart-scroll-animation",
@@ -413,8 +422,11 @@
         "references/log.md",
         "references/patterns.md"
       ],
+      "previous_names": [
+        "create-scroll-animation"
+      ],
       "path": "skills/create-smart-scroll-animation",
-      "dir_sha": "014a7db6a17d685edb75d50d6205a1f8cafec2598ddede9e68d40faf20d12a12"
+      "dir_sha": "b4c912e50c02e785db5fa4c38fc4b0d39fc13435783341eac416186b01a3a401"
     },
     {
       "name": "create-smart-video-transition",
@@ -441,8 +453,11 @@
         "references/log.md",
         "references/patterns.md"
       ],
+      "previous_names": [
+        "create-video-transition"
+      ],
       "path": "skills/create-smart-video-transition",
-      "dir_sha": "cf22bfc97d835a76404e90cfdea2737e65c0b5e5be6594a015dc6f4fc85b9c98"
+      "dir_sha": "5ccdda224f0b4625a1d178e9587fdf7b82d121ebc7e2e2aba511145092862d00"
     },
     {
       "name": "smart-animation",
@@ -474,8 +489,11 @@
         "references/log.md",
         "references/patterns.md"
       ],
+      "previous_names": [
+        "use-smart-animation"
+      ],
       "path": "skills/smart-animation",
-      "dir_sha": "3f5b355fca1dde51ba5db34e72a06f5538351656768cb1308e3ba4d04a9731b6"
+      "dir_sha": "4c7ad69f6e8cb7e85b2d399349f4231a2633bb129b64988fd593304c580e7115"
     },
     {
       "name": "smart-claude-init",
@@ -528,8 +546,11 @@
         "references/log.md",
         "references/patterns.md"
       ],
+      "previous_names": [
+        "use-smart-commit"
+      ],
       "path": "skills/smart-commit",
-      "dir_sha": "e35f08d4807457e32329122bc51b731bfd419c6c43e2d1c517dff5f04297f476"
+      "dir_sha": "da1118812d08765dfb1611fa7eae4605f8909405b873337c814c3a17393c80d9"
     },
     {
       "name": "smart-frontend-design",
@@ -590,8 +611,11 @@
         "references/log.md",
         "references/patterns.md"
       ],
+      "previous_names": [
+        "use-smart-humanize-text"
+      ],
       "path": "skills/smart-humanize-text",
-      "dir_sha": "1a3ddfb68718f15c10fa32da1706b599cbda1a8d0a6b2a68e7b1999122b258a1"
+      "dir_sha": "7553d0f09647e67ebf9b1dab38454a85834f4092d354ae8fdbf4eed979695a0f"
     },
     {
       "name": "smart-skill",
@@ -617,8 +641,11 @@
         "references/log.md",
         "references/patterns.md"
       ],
+      "previous_names": [
+        "use-smart-skill"
+      ],
       "path": "skills/smart-skill",
-      "dir_sha": "9b5661c5881285e9de0563836574b433755e3f3e3f1125f8a05272b37f1d5a87"
+      "dir_sha": "e8869c47aab2042ed285a5cc03cf7083853e30b8ff71e987ee6d4ff36f26aea4"
     },
     {
       "name": "smart-upload-thing",
@@ -645,8 +672,11 @@
         "references/log.md",
         "references/patterns.md"
       ],
+      "previous_names": [
+        "use-upload-thing"
+      ],
       "path": "skills/smart-upload-thing",
-      "dir_sha": "3b2c2314174b712bc3f0f0cd4946c6842321ce679a37ad8fd248d075c48b0f7d"
+      "dir_sha": "29da6601c960f75531c9ec137f684f091b26bd92f30475d172bdb53e77c77083"
     },
     {
       "name": "smart-worktree-flow",
@@ -673,8 +703,11 @@
         "references/log.md",
         "references/patterns.md"
       ],
+      "previous_names": [
+        "use-worktree-flow"
+      ],
       "path": "skills/smart-worktree-flow",
-      "dir_sha": "d3d9afe7eaf8023191eee024cc0ae4e75a9661729e2af88c80c02fa5afd6706f"
+      "dir_sha": "9365999c517a50af556533bee18d28215002b94c6cee89aac1e43ae6b1308d75"
     }
   ]
 }

--- a/skills/analyze-smart-ml-system-design/SKILL.md
+++ b/skills/analyze-smart-ml-system-design/SKILL.md
@@ -5,6 +5,7 @@ license: MIT
 metadata:
   author: Jennings Fantini
   version: "2.0.3"
+  previous_names: ["analyze-ml-system-design"]
   category: development
   tags: [ml-system-design, interviews, machine-learning]
   platforms: [claude-code, cursor, codex]

--- a/skills/analyze-smart-ml-system-design/references/log.md
+++ b/skills/analyze-smart-ml-system-design/references/log.md
@@ -26,3 +26,5 @@ Entry shape:
 [LINT 2026-07-30] 14 wiki, 10 raw. Hard: 0, Soft: 0. Regenerated _index.md.
 
 [LINT 2026-07-30] 14 wiki, 10 raw. Hard: 0, Soft: 0. Regenerated _index.md.
+
+[LINT 2026-07-30] 14 wiki, 10 raw. Hard: 0, Soft: 0. Regenerated _index.md.

--- a/skills/analyze-smart-system-design/SKILL.md
+++ b/skills/analyze-smart-system-design/SKILL.md
@@ -5,6 +5,7 @@ license: MIT
 metadata:
   author: Jennings Fantini
   version: "2.0.3"
+  previous_names: ["analyze-system-design"]
   category: development
   tags: [system-design, interviews, architecture]
   platforms: [claude-code, cursor, codex]

--- a/skills/analyze-smart-system-design/references/log.md
+++ b/skills/analyze-smart-system-design/references/log.md
@@ -42,3 +42,5 @@ Entry shape:
 [LINT 2026-07-30] 75 wiki, 74 raw. Hard: 0, Soft: 12. Regenerated _index.md.
 
 [LINT 2026-07-30] 75 wiki, 74 raw. Hard: 0, Soft: 12. Regenerated _index.md.
+
+[LINT 2026-07-30] 75 wiki, 74 raw. Hard: 0, Soft: 12. Regenerated _index.md.

--- a/skills/better-accessibility/references/log.md
+++ b/skills/better-accessibility/references/log.md
@@ -34,3 +34,5 @@ Entry shape:
 [LINT 2026-07-30] 7 wiki, 7 raw. Hard: 0, Soft: 0. Regenerated _index.md.
 
 [LINT 2026-07-30] 7 wiki, 7 raw. Hard: 0, Soft: 0. Regenerated _index.md.
+
+[LINT 2026-07-30] 7 wiki, 7 raw. Hard: 0, Soft: 0. Regenerated _index.md.

--- a/skills/better-colors/references/log.md
+++ b/skills/better-colors/references/log.md
@@ -28,3 +28,5 @@ Entry shape:
 [LINT 2026-07-30] 6 wiki, 6 raw. Hard: 0, Soft: 0. Regenerated _index.md.
 
 [LINT 2026-07-30] 6 wiki, 6 raw. Hard: 0, Soft: 0. Regenerated _index.md.
+
+[LINT 2026-07-30] 6 wiki, 6 raw. Hard: 0, Soft: 0. Regenerated _index.md.

--- a/skills/better-interface/references/log.md
+++ b/skills/better-interface/references/log.md
@@ -28,3 +28,5 @@ Entry shape:
 [LINT 2026-07-30] 3 wiki, 1 raw. Hard: 0, Soft: 0. Regenerated _index.md.
 
 [LINT 2026-07-30] 3 wiki, 1 raw. Hard: 0, Soft: 0. Regenerated _index.md.
+
+[LINT 2026-07-30] 3 wiki, 1 raw. Hard: 0, Soft: 0. Regenerated _index.md.

--- a/skills/better-layout/references/log.md
+++ b/skills/better-layout/references/log.md
@@ -28,3 +28,5 @@ Entry shape:
 [LINT 2026-07-30] 3 wiki, 3 raw. Hard: 0, Soft: 0. Regenerated _index.md.
 
 [LINT 2026-07-30] 3 wiki, 3 raw. Hard: 0, Soft: 0. Regenerated _index.md.
+
+[LINT 2026-07-30] 3 wiki, 3 raw. Hard: 0, Soft: 0. Regenerated _index.md.

--- a/skills/better-typography/references/log.md
+++ b/skills/better-typography/references/log.md
@@ -28,3 +28,5 @@ Entry shape:
 [LINT 2026-07-30] 7 wiki, 7 raw. Hard: 0, Soft: 0. Regenerated _index.md.
 
 [LINT 2026-07-30] 7 wiki, 7 raw. Hard: 0, Soft: 0. Regenerated _index.md.
+
+[LINT 2026-07-30] 7 wiki, 7 raw. Hard: 0, Soft: 0. Regenerated _index.md.

--- a/skills/better-ui/references/log.md
+++ b/skills/better-ui/references/log.md
@@ -28,3 +28,5 @@ Entry shape:
 [LINT 2026-07-30] 5 wiki, 5 raw. Hard: 0, Soft: 0. Regenerated _index.md.
 
 [LINT 2026-07-30] 5 wiki, 5 raw. Hard: 0, Soft: 0. Regenerated _index.md.
+
+[LINT 2026-07-30] 5 wiki, 5 raw. Hard: 0, Soft: 0. Regenerated _index.md.

--- a/skills/better-writing/references/log.md
+++ b/skills/better-writing/references/log.md
@@ -28,3 +28,5 @@ Entry shape:
 [LINT 2026-07-30] 5 wiki, 1 raw. Hard: 0, Soft: 0. Regenerated _index.md.
 
 [LINT 2026-07-30] 5 wiki, 1 raw. Hard: 0, Soft: 0. Regenerated _index.md.
+
+[LINT 2026-07-30] 5 wiki, 1 raw. Hard: 0, Soft: 0. Regenerated _index.md.

--- a/skills/create-smart-html/SKILL.md
+++ b/skills/create-smart-html/SKILL.md
@@ -15,6 +15,7 @@ compatibility: Requires bash and Google Chrome (or Chromium) on PATH or in a sta
 metadata:
   author: jjfantini
   version: "0.1.0"
+  previous_names: ["generate-smart-html"]
   category: design
   tags: [html, pdf, print, us-letter, single-file, headless-chrome, typography, report, humblskill]
   platforms: [claude-code, cursor, codex]

--- a/skills/create-smart-html/references/log.md
+++ b/skills/create-smart-html/references/log.md
@@ -27,3 +27,5 @@ Entry shape:
 [LINT 2026-07-30] 5 wiki, 0 raw. Hard: 0, Soft: 5. Regenerated _index.md.
 
 [LINT 2026-07-30] 5 wiki, 0 raw. Hard: 0, Soft: 5. Regenerated _index.md.
+
+[LINT 2026-07-30] 5 wiki, 0 raw. Hard: 0, Soft: 5. Regenerated _index.md.

--- a/skills/create-smart-scroll-animation/SKILL.md
+++ b/skills/create-smart-scroll-animation/SKILL.md
@@ -17,6 +17,7 @@ allowed-tools: "Read Write Edit Glob Grep Bash(ffmpeg:*) Bash(ffprobe:*) Bash(cw
 metadata:
   author: jjfantini
   version: "0.1.3"
+  previous_names: ["create-scroll-animation"]
   category: design
   tags: [scroll, canvas, framer-motion, nextjs, react, ffmpeg, webp, apple-style, hero, humblskill]
   platforms: [claude-code, cursor, codex]

--- a/skills/create-smart-scroll-animation/references/log.md
+++ b/skills/create-smart-scroll-animation/references/log.md
@@ -38,3 +38,5 @@ Entry shape:
 [LINT 2026-07-30] 15 wiki, 4 raw. Hard: 0, Soft: 7. Regenerated _index.md.
 
 [LINT 2026-07-30] 15 wiki, 4 raw. Hard: 0, Soft: 7. Regenerated _index.md.
+
+[LINT 2026-07-30] 15 wiki, 4 raw. Hard: 0, Soft: 7. Regenerated _index.md.

--- a/skills/create-smart-video-transition/SKILL.md
+++ b/skills/create-smart-video-transition/SKILL.md
@@ -19,6 +19,7 @@ allowed-tools: "Read Write Edit Glob Grep Bash(open:*) Bash(xdg-open:*) Bash(bas
 metadata:
   author: jjfantini
   version: "1.0.3"
+  previous_names: ["create-video-transition"]
   category: design
   tags: [video, prompt, transition, image-generation, commercial-director, humblskill]
   platforms: [claude-code, cursor, codex]

--- a/skills/create-smart-video-transition/references/log.md
+++ b/skills/create-smart-video-transition/references/log.md
@@ -39,3 +39,5 @@ Entry shape:
 [LINT 2026-07-30] 12 wiki, 0 raw. Hard: 0, Soft: 12. Regenerated _index.md.
 
 [LINT 2026-07-30] 12 wiki, 0 raw. Hard: 0, Soft: 12. Regenerated _index.md.
+
+[LINT 2026-07-30] 12 wiki, 0 raw. Hard: 0, Soft: 12. Regenerated _index.md.

--- a/skills/smart-animation/SKILL.md
+++ b/skills/smart-animation/SKILL.md
@@ -21,6 +21,7 @@ compatibility: Requires bash, POSIX utilities (awk, sed, find, grep), python3, w
 metadata:
   author: jjfantini
   version: "0.4.0"
+  previous_names: ["use-smart-animation"]
   category: design
   tags: [animation, transitions, frontend, motion, css, react, webgl, performance, accessibility, agent-ui, humblskill]
   platforms: [claude-code, cursor, codex]

--- a/skills/smart-animation/references/log.md
+++ b/skills/smart-animation/references/log.md
@@ -66,3 +66,5 @@ Entry shape:
 [LINT 2026-07-30] 16 wiki, 10 raw. Hard: 0, Soft: 11. Regenerated _index.md.
 
 [LINT 2026-07-30] 16 wiki, 10 raw. Hard: 0, Soft: 11. Regenerated _index.md.
+
+[LINT 2026-07-30] 16 wiki, 10 raw. Hard: 0, Soft: 11. Regenerated _index.md.

--- a/skills/smart-claude-init/references/log.md
+++ b/skills/smart-claude-init/references/log.md
@@ -29,3 +29,5 @@ Entry shape:
 [LINT 2026-07-30] 6 wiki, 3 raw. Hard: 0, Soft: 0. Regenerated _index.md.
 
 [LINT 2026-07-30] 6 wiki, 3 raw. Hard: 0, Soft: 0. Regenerated _index.md.
+
+[LINT 2026-07-30] 6 wiki, 3 raw. Hard: 0, Soft: 0. Regenerated _index.md.

--- a/skills/smart-commit/SKILL.md
+++ b/skills/smart-commit/SKILL.md
@@ -12,6 +12,7 @@ license: MIT
 metadata:
   author: jjfantini
   version: "1.0.3"
+  previous_names: ["use-smart-commit"]
   category: development
   tags: [git, commits, conventional-commits, workflow, humblskill]
   platforms: [claude-code, cursor, codex]

--- a/skills/smart-commit/references/log.md
+++ b/skills/smart-commit/references/log.md
@@ -35,3 +35,5 @@ Entry shape:
 [LINT 2026-07-30] 3 wiki, 0 raw. Hard: 0, Soft: 3. Regenerated _index.md.
 
 [LINT 2026-07-30] 3 wiki, 0 raw. Hard: 0, Soft: 3. Regenerated _index.md.
+
+[LINT 2026-07-30] 3 wiki, 0 raw. Hard: 0, Soft: 3. Regenerated _index.md.

--- a/skills/smart-frontend-design/references/log.md
+++ b/skills/smart-frontend-design/references/log.md
@@ -43,3 +43,5 @@ Entry shape:
 [LINT 2026-07-30] 10 wiki, 1 raw. Hard: 0, Soft: 0. Regenerated _index.md.
 
 [LINT 2026-07-30] 10 wiki, 1 raw. Hard: 0, Soft: 0. Regenerated _index.md.
+
+[LINT 2026-07-30] 10 wiki, 1 raw. Hard: 0, Soft: 0. Regenerated _index.md.

--- a/skills/smart-humanize-text/SKILL.md
+++ b/skills/smart-humanize-text/SKILL.md
@@ -11,6 +11,7 @@ license: MIT
 metadata:
   author: jjfantini
   version: 2.0.3
+  previous_names: ["use-smart-humanize-text"]
   category: writing
   platforms: [claude-code, cursor, codex]
   preserve:

--- a/skills/smart-humanize-text/references/log.md
+++ b/skills/smart-humanize-text/references/log.md
@@ -36,3 +36,5 @@ Entry shape:
 [LINT 2026-07-30] 27 wiki, 1 raw. Hard: 0, Soft: 0. Regenerated _index.md.
 
 [LINT 2026-07-30] 27 wiki, 1 raw. Hard: 0, Soft: 0. Regenerated _index.md.
+
+[LINT 2026-07-30] 27 wiki, 1 raw. Hard: 0, Soft: 0. Regenerated _index.md.

--- a/skills/smart-skill/SKILL.md
+++ b/skills/smart-skill/SKILL.md
@@ -15,6 +15,7 @@ allowed-tools: "Bash(bash:*) Bash(sh:*) Read Write Edit Glob Grep"
 metadata:
   author: jjfantini
   version: 1.1.3
+  previous_names: ["use-smart-skill"]
   category: meta
   tags: [meta, skill-authoring, smart-skill, scaffolding, humblskill]
   platforms: [claude-code, cursor, codex]

--- a/skills/smart-skill/references/log.md
+++ b/skills/smart-skill/references/log.md
@@ -78,3 +78,5 @@ Entry shape:
 [LINT 2026-07-30] 23 wiki, 2 raw. Hard: 0, Soft: 16. Regenerated _index.md.
 
 [LINT 2026-07-30] 23 wiki, 2 raw. Hard: 0, Soft: 16. Regenerated _index.md.
+
+[LINT 2026-07-30] 23 wiki, 2 raw. Hard: 0, Soft: 16. Regenerated _index.md.

--- a/skills/smart-upload-thing/SKILL.md
+++ b/skills/smart-upload-thing/SKILL.md
@@ -13,6 +13,7 @@ compatibility: "Requires bash, curl, jq, and network access to api.uploadthing.c
 metadata:
   author: jjfantini
   version: "1.0.3"
+  previous_names: ["use-upload-thing"]
   category: development
   tags: [uploadthing, file-upload, storage, rest-api, ufs, humblskill]
   platforms: [claude-code, cursor, codex]

--- a/skills/smart-upload-thing/references/log.md
+++ b/skills/smart-upload-thing/references/log.md
@@ -34,3 +34,5 @@ Entry shape:
 [LINT 2026-07-30] 4 wiki, 5 raw. Hard: 0, Soft: 0. Regenerated _index.md.
 
 [LINT 2026-07-30] 4 wiki, 5 raw. Hard: 0, Soft: 0. Regenerated _index.md.
+
+[LINT 2026-07-30] 4 wiki, 5 raw. Hard: 0, Soft: 0. Regenerated _index.md.

--- a/skills/smart-worktree-flow/SKILL.md
+++ b/skills/smart-worktree-flow/SKILL.md
@@ -12,6 +12,7 @@ compatibility: "Requires git 2.5+, GitHub CLI (`gh`) for PR/check operations, an
 metadata:
   author: jjfantini
   version: "1.0.3"
+  previous_names: ["use-worktree-flow"]
   category: development
   tags: [git, worktree, pull-requests, release, workflow, humblskill]
   platforms: [claude-code, cursor, codex]

--- a/skills/smart-worktree-flow/references/log.md
+++ b/skills/smart-worktree-flow/references/log.md
@@ -24,3 +24,5 @@ Entry shape:
 [LINT 2026-07-30] 6 wiki, 1 raw. Hard: 0, Soft: 0. Regenerated _index.md.
 
 [LINT 2026-07-30] 6 wiki, 1 raw. Hard: 0, Soft: 0. Regenerated _index.md.
+
+[LINT 2026-07-30] 6 wiki, 1 raw. Hard: 0, Soft: 0. Regenerated _index.md.


### PR DESCRIPTION
## The bug

A rename silently destroyed user brain data.

`preserve` is resolved by looking up an existing installation with `FindOne(skill.Name, ...)`. A renamed skill matches nothing, so `preserveSource` stays empty and **every preserved path is written fresh from the tarball**. The user's `log.md`, `decisions.md`, `patterns.md`, and local `raw/` material stay stranded in a directory nothing points at — then get removed as "the old one".

This is not hypothetical. Migrating to the `smart-*` namespace in #217, the carry-over had to be done by hand, and `create-smart-html` held a same-day entry a normal upgrade would have wiped:

```
[SESSION 2026-07-30] First real-world use: client-facing OAuth incident brief for DHL (DGFF Salesforce)
```

## The fix

Skills declare `metadata.previous_names`. When no installation exists under the current name, the engine looks up the declared previous names on the same platform+scope and uses that installation as the preserve source.

The rename then behaves **exactly like an update** — no new preserve semantics to reason about, which is the point. Same list, same merge, same local-preserve-list override.

```yaml
metadata:
  version: "0.4.0"
  previous_names: ["use-smart-animation"]
```

### Ordering is deliberate

The superseded installation is retired **only after** the new one is fully written and its data carried over. Retiring earlier would risk destroying the only copy if any step above failed. The canonical store is deleted only when nothing else references it, and the carry-over is announced as a warning rather than happening silently:

```
renamed from use-smart-animation — carried over preserved data (references/raw/, references/log.md, ...)
```

### Blast radius is bounded by declaration

Retirement fires only for names a skill **explicitly claims**. A skill that merely shares a prefix is never touched — covered by a dedicated test asserting `FindPrevious` matches nothing for `nil`, unrelated names, or a different platform.

## Verified by negative test

Disabling the lookup makes the new test fail exactly where it should:

```
--- FAIL: TestRename_CarriesPreservedDataToNewName
    engine_test.go:1563: user brain data lost across rename
    engine_test.go:1568: old install directory should be removed after a successful rename
    engine_test.go:1575: manifest should no longer track the old name
```

## Coverage

All 11 renamed skills declare their previous name, so anyone still on the `use-*` / `analyze-*` / `create-*` / `generate-*` names upgrades cleanly:

| Declares | Previous |
| --- | --- |
| `smart-animation` | `use-smart-animation` |
| `smart-commit` | `use-smart-commit` |
| `smart-humanize-text` | `use-smart-humanize-text` |
| `smart-skill` | `use-smart-skill` |
| `smart-upload-thing` | `use-upload-thing` |
| `smart-worktree-flow` | `use-worktree-flow` |
| `analyze-smart-system-design` | `analyze-system-design` |
| `analyze-smart-ml-system-design` | `analyze-ml-system-design` |
| `create-smart-scroll-animation` | `create-scroll-animation` |
| `create-smart-video-transition` | `create-video-transition` |
| `create-smart-html` | `generate-smart-html` |

No version bumps needed — `dir_sha` changes, and the up-to-date check already compares it.

## Verification

- 2 new tests in `internal/install`; full Go suite passes; `go vet` clean
- 20/20 skill lints exit 0
- `registry.json` regenerated — carries `previous_names` for all 11

🤖 Generated with [Claude Code](https://claude.com/claude-code)
