### PR TITLE
feat(update): follow skill renames instead of skipping them

### DIFF
--- a/cli/cmd/humblskills/update.go
+++ b/cli/cmd/humblskills/update.go
@@ -318,6 +318,9 @@ func (u updatePlanItem) Detail(th *ui.Theme, width int) string {
 	var sb strings.Builder
 	sb.WriteString(th.DetailTitle.Render(u.p.Skill) + "  " +
 		th.DetailSub.Render("v"+u.p.FromVersion+" → v"+u.p.ToVersion) + "\n\n")
+	if u.p.RenamedFrom != "" {
+		sb.WriteString(kvRow(th, "renamed from", th.KVValue.Render(u.p.RenamedFrom)))
+	}
 	sb.WriteString(kvRow(th, "from", th.KVValue.Render("v"+u.p.FromVersion)))
 	sb.WriteString(kvRow(th, "to", th.KVValue.Render("v"+u.p.ToVersion)))
 	sb.WriteString(kvRow(th, "targets", th.KVValue.Render(fmt.Sprintf("%d", len(u.p.Targets)))))
@@ -349,8 +352,14 @@ func printUpdateCheck(app *App, plans []install.UpdatePlan) error {
 	}
 	app.UI.Info("%d skill%s can be updated:", len(plans), textutil.Plural(len(plans)))
 	for _, p := range plans {
+		name := p.Skill
+		if p.RenamedFrom != "" {
+			// Say the old name out loud — the user knows the skill by that,
+			// and a silent swap looks like an unrelated install.
+			name = p.RenamedFrom + " → " + p.Skill
+		}
 		app.UI.Detail("  %s  %s → %s  (%d target%s)",
-			p.Skill, p.FromVersion, p.ToVersion, len(p.Targets), textutil.Plural(len(p.Targets)))
+			name, p.FromVersion, p.ToVersion, len(p.Targets), textutil.Plural(len(p.Targets)))
 	}
 	return nil
 }

--- a/cli/internal/install/update.go
+++ b/cli/internal/install/update.go
@@ -9,7 +9,11 @@ import (
 // registry. Targets lists every (platform, scope) the skill is currently
 // installed onto.
 type UpdatePlan struct {
-	Skill       string          `json:"skill"`
+	Skill string `json:"skill"`
+	// RenamedFrom is set when the installed skill has been renamed upstream.
+	// Skill then holds the NEW name, which is what gets installed; the engine
+	// carries the old installation's preserved data forward and retires it.
+	RenamedFrom string          `json:"renamed_from,omitempty"`
 	FromVersion string          `json:"from_version"`
 	ToVersion   string          `json:"to_version"`
 	FromSHA     string          `json:"from_source_sha,omitempty"`
@@ -41,6 +45,8 @@ func PlanUpdates(reg *registry.Registry, m *manifest.Manifest, only []string) []
 		regIndex[s.Name] = s
 	}
 
+	renameIndex := buildRenameIndex(reg, regIndex)
+
 	filter := map[string]struct{}{}
 	for _, n := range only {
 		filter[n] = struct{}{}
@@ -50,7 +56,16 @@ func PlanUpdates(reg *registry.Registry, m *manifest.Manifest, only []string) []
 	bySkill := map[string][]manifest.Installation{}
 	for _, inst := range m.Installations {
 		if len(filter) > 0 {
-			if _, ok := filter[inst.Skill]; !ok {
+			_, wanted := filter[inst.Skill]
+			// `update <new-name>` should also reach an installation still
+			// recorded under the old name, or the rename would be unreachable
+			// by the name the user now knows the skill by.
+			if !wanted {
+				if renamed, ok := renameIndex[inst.Skill]; ok {
+					_, wanted = filter[renamed.Name]
+				}
+			}
+			if !wanted {
 				continue
 			}
 		}
@@ -59,9 +74,23 @@ func PlanUpdates(reg *registry.Registry, m *manifest.Manifest, only []string) []
 
 	var out []UpdatePlan
 	for name, insts := range bySkill {
+		renamedFrom := ""
 		regSkill, ok := regIndex[name]
 		if !ok {
-			continue
+			// The installed name is gone from the registry. It is a rename only
+			// if some registry skill explicitly claims it; otherwise the skill
+			// was withdrawn and there is nothing to upgrade to.
+			regSkill, ok = renameIndex[name]
+			if !ok {
+				continue
+			}
+			// Both names installed at once (a half-finished migration): the
+			// direct match already plans the new name, so planning it again
+			// from the old entry would execute the same install twice.
+			if _, alsoInstalled := bySkill[regSkill.Name]; alsoInstalled {
+				continue
+			}
+			renamedFrom = name
 		}
 		// Any target that's drifted triggers an UpdatePlan for the skill.
 		//
@@ -71,8 +100,15 @@ func PlanUpdates(reg *registry.Registry, m *manifest.Manifest, only []string) []
 		// commits that don't touch this skill, which would flag every
 		// installation as drifted after each CLI release. Source.SHA is
 		// kept in the manifest purely as install-time metadata.
-		drifted := false
+		//
+		// A rename is drift by definition — the installed directory carries a
+		// name the registry no longer publishes — so it short-circuits the
+		// version/DirSHA comparison, which cannot decide it.
+		drifted := renamedFrom != ""
 		for _, i := range insts {
+			if drifted {
+				break
+			}
 			if i.Version != regSkill.Version ||
 				i.RegistryRef != regSkill.DirSHA {
 				drifted = true
@@ -85,7 +121,8 @@ func PlanUpdates(reg *registry.Registry, m *manifest.Manifest, only []string) []
 
 		first := insts[0]
 		plan := UpdatePlan{
-			Skill:       name,
+			Skill:       regSkill.Name,
+			RenamedFrom: renamedFrom,
 			FromVersion: first.Version,
 			ToVersion:   regSkill.Version,
 			FromSHA:     first.SourceSHA,
@@ -99,6 +136,39 @@ func PlanUpdates(reg *registry.Registry, m *manifest.Manifest, only []string) []
 			})
 		}
 		out = append(out, plan)
+	}
+	return out
+}
+
+// buildRenameIndex maps a superseded skill name to the registry skill that
+// claims it via previous_names.
+//
+// Two guards keep this from ever guessing, because a wrong answer here installs
+// the wrong skill and retires a real one:
+//
+//   - A name that is still published in its own right is never treated as a
+//     rename target. A live skill always wins over someone else's claim on its
+//     name, so a stale or mistaken previous_names entry cannot hijack it.
+//   - A name claimed by two or more skills is ambiguous and is dropped
+//     entirely rather than resolved by ordering.
+func buildRenameIndex(reg *registry.Registry, regIndex map[string]registry.Skill) map[string]registry.Skill {
+	claims := map[string][]registry.Skill{}
+	for _, s := range reg.Skills {
+		for _, prev := range s.PreviousNames {
+			if prev == "" || prev == s.Name {
+				continue
+			}
+			if _, live := regIndex[prev]; live {
+				continue
+			}
+			claims[prev] = append(claims[prev], s)
+		}
+	}
+	out := make(map[string]registry.Skill, len(claims))
+	for prev, cs := range claims {
+		if len(cs) == 1 {
+			out[prev] = cs[0]
+		}
 	}
 	return out
 }

--- a/cli/internal/install/update_test.go
+++ b/cli/internal/install/update_test.go
@@ -136,3 +136,152 @@ func TestPlanUpdates_NilInputs(t *testing.T) {
 		t.Errorf("nil inputs: expected nil, got %+v", got)
 	}
 }
+
+// regSkill is a tiny helper for the rename-planning tests below.
+func regSkillNamed(name, version, dirSHA string, previous ...string) registry.Skill {
+	return registry.Skill{
+		Name: name, Version: version, Path: "skills/" + name,
+		DirSHA: dirSHA, PreviousNames: previous,
+	}
+}
+
+func instNamed(skill, version, dirSHA string) manifest.Installation {
+	return manifest.Installation{
+		Skill: skill, Version: version, RegistryRef: dirSHA,
+		Platform: "test", Scope: "user", Path: "/tmp/" + skill,
+	}
+}
+
+// TestPlanUpdates_FollowsRename: an installation whose name the registry no
+// longer publishes must upgrade to the skill that claims it, rather than being
+// skipped as "withdrawn" and left behind forever.
+func TestPlanUpdates_FollowsRename(t *testing.T) {
+	reg := &registry.Registry{Skills: []registry.Skill{
+		regSkillNamed("foo", "2.0.0", "sha-new", "use-foo"),
+	}}
+	m := &manifest.Manifest{Installations: []manifest.Installation{
+		instNamed("use-foo", "1.0.0", "sha-old"),
+	}}
+
+	plans := PlanUpdates(reg, m, nil)
+	if len(plans) != 1 {
+		t.Fatalf("want 1 plan, got %d (%+v)", len(plans), plans)
+	}
+	if plans[0].Skill != "foo" {
+		t.Errorf("plan must target the NEW name, got %q", plans[0].Skill)
+	}
+	if plans[0].RenamedFrom != "use-foo" {
+		t.Errorf("plan must record the old name, got %q", plans[0].RenamedFrom)
+	}
+	if len(plans[0].Targets) != 1 {
+		t.Errorf("targets should carry over from the old installation, got %d", len(plans[0].Targets))
+	}
+}
+
+// TestPlanUpdates_RenameGuards covers every way this could install the wrong
+// skill or retire a real one. Each case must produce no rename plan.
+func TestPlanUpdates_RenameGuards(t *testing.T) {
+	tests := []struct {
+		name      string
+		reg       []registry.Skill
+		installed []manifest.Installation
+		wantPlans int
+		wantSkill string
+	}{
+		{
+			// The claimed name is still published. A live skill must always win
+			// over another skill's claim on its name.
+			name: "live skill is never hijacked by a claim",
+			reg: []registry.Skill{
+				regSkillNamed("foo", "2.0.0", "sha-new", "use-foo"),
+				regSkillNamed("use-foo", "1.0.0", "sha-old"),
+			},
+			installed: []manifest.Installation{instNamed("use-foo", "1.0.0", "sha-old")},
+			wantPlans: 0,
+		},
+		{
+			// Two skills claim the same previous name: ambiguous, so refuse
+			// rather than resolve by map/slice ordering.
+			name: "ambiguous claim is dropped",
+			reg: []registry.Skill{
+				regSkillNamed("foo", "2.0.0", "sha-a", "use-foo"),
+				regSkillNamed("bar", "2.0.0", "sha-b", "use-foo"),
+			},
+			installed: []manifest.Installation{instNamed("use-foo", "1.0.0", "sha-old")},
+			wantPlans: 0,
+		},
+		{
+			// Withdrawn, not renamed: nobody claims it, so there is nothing to
+			// upgrade to and the old behaviour (skip) must hold.
+			name: "withdrawn skill is still skipped",
+			reg: []registry.Skill{
+				regSkillNamed("other", "1.0.0", "sha-x"),
+			},
+			installed: []manifest.Installation{instNamed("use-foo", "1.0.0", "sha-old")},
+			wantPlans: 0,
+		},
+		{
+			// Half-finished migration: both names installed. The direct match
+			// already plans the new name; planning it twice would run the same
+			// install twice.
+			name: "both names installed plans the new name once",
+			reg: []registry.Skill{
+				regSkillNamed("foo", "2.0.0", "sha-new", "use-foo"),
+			},
+			installed: []manifest.Installation{
+				instNamed("use-foo", "1.0.0", "sha-old"),
+				instNamed("foo", "1.0.0", "sha-old"),
+			},
+			wantPlans: 1,
+			wantSkill: "foo",
+		},
+		{
+			// A skill listing itself must not become its own rename target.
+			name: "self-claim is ignored",
+			reg: []registry.Skill{
+				regSkillNamed("foo", "2.0.0", "sha-new", "foo"),
+			},
+			installed: []manifest.Installation{instNamed("use-foo", "1.0.0", "sha-old")},
+			wantPlans: 0,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			plans := PlanUpdates(&registry.Registry{Skills: tc.reg},
+				&manifest.Manifest{Installations: tc.installed}, nil)
+			if len(plans) != tc.wantPlans {
+				t.Fatalf("want %d plans, got %d (%+v)", tc.wantPlans, len(plans), plans)
+			}
+			if tc.wantSkill != "" && plans[0].Skill != tc.wantSkill {
+				t.Errorf("want plan for %q, got %q", tc.wantSkill, plans[0].Skill)
+			}
+			for _, p := range plans {
+				if p.RenamedFrom != "" && tc.wantPlans == 0 {
+					t.Errorf("unexpected rename plan: %+v", p)
+				}
+			}
+		})
+	}
+}
+
+// TestPlanUpdates_RenameReachableByEitherName: the user may type the name they
+// now know the skill by, even though the manifest still records the old one.
+func TestPlanUpdates_RenameReachableByEitherName(t *testing.T) {
+	reg := &registry.Registry{Skills: []registry.Skill{
+		regSkillNamed("foo", "2.0.0", "sha-new", "use-foo"),
+	}}
+	mk := func() *manifest.Manifest {
+		return &manifest.Manifest{Installations: []manifest.Installation{
+			instNamed("use-foo", "1.0.0", "sha-old"),
+		}}
+	}
+	for _, only := range []string{"foo", "use-foo"} {
+		plans := PlanUpdates(reg, mk(), []string{only})
+		if len(plans) != 1 || plans[0].Skill != "foo" {
+			t.Errorf("update %q should reach the rename, got %+v", only, plans)
+		}
+	}
+	if plans := PlanUpdates(reg, mk(), []string{"unrelated"}); len(plans) != 0 {
+		t.Errorf("an unrelated filter must match nothing, got %+v", plans)
+	}
+}

--- a/registry.json
+++ b/registry.json
@@ -1,10 +1,10 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-07-30T22:01:32Z",
+  "generated_at": "2026-07-30T22:25:16Z",
   "source": {
     "repo": "github.com/jjfantini/humblSKILLS",
-    "ref": "feat/rename-preserves-user-data",
-    "sha": "8d41cec43764d15f95ff558d6326624cfccdcd7a"
+    "ref": "feat/update-follows-renames",
+    "sha": "14b51f91f3b4626d40927a6de6ec8d69dc86f5df"
   },
   "skills": [
     {


### PR DESCRIPTION
## The gap #218 left

#218 made a rename preserve user data — but only if the user knew to run `install <new-name>`.

`update` still skipped renamed skills entirely. It looks each installed name up in the registry and `continue`s on a miss, which is *precisely* what a renamed skill is:

```go
regSkill, ok := regIndex[name]
if !ok {
    continue   // renamed skill lands here, forever
}
```

So the old copy sat there indefinitely, never updating, while the user reasonably assumed `update` covered everything. Updating a skill should bring across the whole package — new content **and** the new name.

## The change

Confined to the planner. When an installed name is absent from the registry, consult the skills that explicitly claim it via `previous_names` and emit the plan under the **new** name.

Nothing downstream needed touching: the executor already resolves plans by name (`install.Plan(reg, plan.Skill)`), and the #218 engine path already carries preserved data forward and retires the superseded install.

## Four guards, one per failure mode

The risk here is installing the wrong skill or retiring a real one, so every path that could guess is closed:

| Guard | Why |
| --- | --- |
| A name still published in its own right is **never** a rename target | A live skill beats another skill's claim on its name — a stale or mistaken `previous_names` entry cannot hijack it |
| A name claimed by **two or more** skills is dropped | Ambiguous; refuse rather than resolve by map ordering |
| A skill listing **itself** is ignored | Self-claim is meaningless |
| Both names installed → plan the new name **once** | Half-finished migration; planning twice would run the same install twice |

A **withdrawn** skill — one nobody claims — still skips exactly as before. The only behaviour that changes is for names a skill has explicitly claimed.

## Visible, not silent

```
2 skills can be updated:
  use-foo → foo   1.0.0 → 2.0.0  (2 targets)
  smart-commit    1.0.3 → 1.0.4  (2 targets)
```

The detail view gains a `renamed from` row. A rename also short-circuits the version/DirSHA drift check, which cannot decide it — the installed directory carries a name the registry no longer publishes.

`update <new-name>` reaches an installation still recorded under the old name too, so the skill is addressable by the name the user now knows it by.

## Verified by negative test

Disabling the rename lookup fails the new tests exactly where it should:

```
--- FAIL: TestPlanUpdates_FollowsRename
    update_test.go:168: want 1 plan, got 0 ([])
--- FAIL: TestPlanUpdates_RenameReachableByEitherName
    update_test.go:281: update "foo" should reach the rename, got []
    update_test.go:281: update "use-foo" should reach the rename, got []
```

## Verification

- 3 new tests (7 cases) in `internal/install`; full Go suite passes; `go vet` clean
- `make registry-check` in sync
- No skill content changed — planner + display only

🤖 Generated with [Claude Code](https://claude.com/claude-code)
