### PR TITLE
docs: align the site and README with v2.42 (registries, platforms, renames, generated catalog)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@ agent platform you use — Claude Code, Cursor, Codex, and friends.
 ## What's in this repo
 
 1. **Skill registry** — a monorepo of agent skills authored in the
-   agentskills.io format with light humblSKILLS frontmatter extensions
-   (`requires`, `platforms`, `tags`, `preserve`).
+   agentskills.io format with light humblSKILLS frontmatter extensions under
+   `metadata:` (`version`, `category`, `role`, `requires`, `platforms`, `tags`,
+   `previous_names`, `preserve`).
 2. **`humblskills` CLI** — fetches a skill directory and drops it in the right
    place for your agent platform. Zero servers, zero accounts, zero telemetry.
 
@@ -81,15 +82,32 @@ Use explicit subcommands below for scripts, CI, or non-TTY environments.
 
 ```sh
 humblskills doctor                    # verify the environment
-humblskills search                    # browse the registry
+humblskills search                    # browse the registry (--category=, --role=)
 humblskills install smart-skill
 humblskills list
 humblskills update                    # pick which drifted skills to upgrade
 humblskills update --all --yes        # non-interactive bulk upgrade
+humblskills upgrade                   # upgrade the CLI binary itself
 humblskills uninstall smart-skill
 humblskills export                    # snapshot installed skills to humblskills.json
 humblskills sync                      # install everything in humblskills.json
+humblskills export desktop            # zips to upload at claude.ai / Claude Desktop
 ```
+
+Full skill catalog, generated from `registry.json`:
+[jjfantini.github.io/humblSKILLS/skills](https://jjfantini.github.io/humblSKILLS/skills/).
+
+### Platforms
+
+Installs land in one canonical store (`~/.humblskills/skills/<skill>` by default)
+and are exposed per platform. `claude-code`, `cursor`, and `codex` get symlinks
+(`~/.claude/skills`, `~/.cursor/skills`, `~/.agents/skills`); **`claude-desktop`**
+gets an upload **zip** in `~/.humblskills/desktop/`, because Claude Desktop and
+claude.ai can't read skills off the filesystem — upload it at *Settings →
+Capabilities → Skills*, and re-upload after an update. Restrict targets with
+`--platform`, or persist a default with `humblskills profile set platforms
+claude-code,cursor`. Details:
+[Platforms](https://jjfantini.github.io/humblSKILLS/using_humblskills/platforms/).
 
 ### Private registries
 
@@ -157,6 +175,9 @@ skill against **its** registry, and `doctor` reports each registry's reachabilit
 and skill count. When none are configured, everything falls back to the single registry
 above (`--registry`/`HUMBLSKILLS_REGISTRY`/`profile set registry`/hosted default).
 
+Beginner-friendly walkthrough:
+[Registries](https://jjfantini.github.io/humblSKILLS/using_humblskills/registries/).
+
 ### Sharing skill sets across a team
 
 `humblskills export` snapshots the skills you have installed into a
@@ -188,6 +209,12 @@ set match the file exactly — any installed skill the skillset doesn't list is
 uninstalled (you're asked to confirm unless `--yes`). Platforms/scope follow the
 same rules as `install`.
 
+If any of your skills come from a **named** registry, `export` records that
+registry in the file too (under `"registries"`), and `sync` on another machine
+adds it to that user's profile and walks them through a token if it's private.
+Registries you already have keep your own URL. Everything there is non-fatal — an
+unreachable registry degrades to per-skill "not found" warnings.
+
 Every command accepts `--json` for machine-readable output and `--yes` to
 skip confirmation prompts.
 
@@ -204,7 +231,7 @@ in an ablation.
 
 **Latest published showcase:** [adaptive-brand-voice-discovery · 2026-04-20](https://jjfantini.github.io/humblSKILLS/eval/reports/) — a 6-session compounding scenario over 10 idiosyncratic brand-voice rules. On cursor-agent, `smart_skill` scored pass_rate **0.935** vs `no_skill` **0.740** (**+26.3%**) and `flat_skill` **0.679** (**+37.7%**), while using **67% fewer tokens** than `no_skill`. Reproduce locally with `humblskills eval brand-voice`. Full index: [live docs](https://jjfantini.github.io/humblSKILLS/eval/reports/) · [source](docs/eval/reports/).
 
-**4-arm ablation showcase:** [indie-launch-copy-iteration](https://jjfantini.github.io/humblSKILLS/eval/indie-launch-analysis/) — 6 sessions over 13 indie-launch voice rules, three runs per arm (72 sessions total) on claudecode. Separates **brain value** (`smart_skill` vs `flat_skill_wiki`) from **wiki value** (`flat_skill_wiki` vs `flat_skill`) with identical preamble and scaffolding. The cumulative-retention outcome assertion (S5 + S6 violations ≤ 1) passes **3/3 for `smart_skill` and 0/3 for every other arm**. `smart_skill` hits 43% fewer violations than `flat_skill_wiki` while using 2.6% fewer tokens and 8.9% less wall time. Surprising finding surfaced by the ablation: `flat_skill_wiki` is the **worst** of the four arms — static wiki knowledge adjacent to the task can distract without helping. Reproduce with `humblskills eval run smart-humanize-text --scenario indie-launch-copy-iteration`. Full analysis: [docs/eval/indie-launch-analysis.md](docs/eval/indie-launch-analysis.md).
+**4-arm ablation showcase:** [indie-launch-copy-iteration · 2026-04-27](https://jjfantini.github.io/humblSKILLS/eval/reports/smart-humanize-text/indie-launch-copy-iteration/) — 6 sessions over 13 indie-launch voice rules, three runs per arm (72 sessions total) on cursor-agent. Separates **brain value** (`smart_skill` vs `flat_skill_wiki`) from **wiki value** (`flat_skill_wiki` vs `flat_skill`) with identical preamble and scaffolding. `smart_skill` is the only arm above 0.9 pass rate on **both** no-feedback sessions (S5 0.922, S6 0.944); the brain-only delta over `flat_skill_wiki` is **+9.4% on S5 and +13.3% on S6**, and it beats `flat_skill` on quality while using **29% fewer tokens**. Surprising finding surfaced by the ablation: `flat_skill_wiki` lands *below* `no_skill` on aggregate and is the weakest arm on S6 — static wiki knowledge adjacent to the task can distract without helping. Reproduce with `humblskills eval run smart-humanize-text --scenario indie-launch-copy-iteration --runner cursor-agent`. Full write-up: [docs/eval/reports/smart-humanize-text/indie-launch-copy-iteration.md](docs/eval/reports/smart-humanize-text/indie-launch-copy-iteration.md).
 
 Six runners ship behind one interface - pick whichever agent you already
 use, or point an API key directly at the hosted model:
@@ -367,6 +394,21 @@ humblskills uninstall <skill> && humblskills install <skill>   # equivalent
 with exactly what the registry ships. This is the escape hatch for "throw
 away my customizations and give me the author's version."
 
+### When a skill is renamed upstream
+
+`update` **follows** renames instead of skipping them. A skill that declares the
+old name in **`metadata.previous_names`** is installed under its new name, your
+**preserved files are carried across** from the old install, and the old
+installation is retired. The picker and summary show it as
+`use-smart-commit → smart-commit`, and the detail pane carries a `renamed from`
+row, so nothing happens invisibly.
+
+`humblskills update <new-name>` also reaches an install still recorded under the
+old name. A rename is never guessed: a name still published in its own right is
+never treated as a rename target, a name claimed by two skills is ignored, and a
+skill that simply left the registry is left alone. (The `use-*` → `smart-*`
+namespace change in v2.41 is the reason this exists.)
+
 ## Developing the CLI
 
 The CLI source lives under [`cli/`](cli) as a nested Go module.
@@ -376,6 +418,26 @@ make build           # builds ./bin/humblskills
 make test            # runs go test ./...
 make registry        # regenerates registry.json from skills/ + embedded adapters
 ```
+
+### Mirrored skills
+
+Skills distilled from an upstream source (the `better-*` family, and
+`smart-frontend-design`) declare a top-level `upstream:` block naming where the
+source lives, which file preserves the copy the distillation was written
+against, and any deliberate `deltas:`. Because the preserved copy *is* the
+baseline, drift needs no hashes or lockfile:
+
+```sh
+humblskills mirrors check         # which mirrors drifted, and how badly
+humblskills mirrors plan <skill>  # emit a re-sync work order
+```
+
+`check` reports `current` / `drifted` / `rewritten` / `unknown` (a failed fetch is
+never reported as healthy). `plan` writes the two files to diff, the wiki
+concepts that cite the preserved copy, the declared deltas that must survive, and
+a completion checklist. Detection is deterministic and automated;
+re-distillation is judgment and is never automated. Both read a source checkout,
+not installed copies.
 
 Releases are cut by pushing a semver tag (e.g. `git tag v0.1.0 && git push
 origin v0.1.0`); the workflow in [`.github/workflows/release.yml`](.github/workflows/release.yml)

--- a/docs/eval/quickstart.md
+++ b/docs/eval/quickstart.md
@@ -5,11 +5,17 @@ humblskills doctor                          # check runner availability
 humblskills eval set-key anthropic          # store key in the OS keyring
 humblskills eval runners                    # one-liner per-runner status
 humblskills eval                            # dashboard entry → Eval Home TUI
-humblskills eval run smart-skill        # non-TUI run
+humblskills eval run smart-skill            # non-TUI run
 humblskills eval showcase                   # canonical demo
+humblskills eval brand-voice                # the published 3-arm compounding showcase
 humblskills eval ls                         # iterations per skill
+humblskills eval where                      # print where artifacts are written
 humblskills eval prune smart-skill --keep-last 5
 ```
+
+Other subcommands: `eval init <skill>` scaffolds a `scenarios.json`, and
+`eval aggregate` / `eval report` / `eval compare` work on iteration directories
+after the fact.
 
 ## Secrets
 

--- a/docs/getting_started/index.md
+++ b/docs/getting_started/index.md
@@ -1,11 +1,15 @@
 # Getting started
 
-Use this section to install `humblskills` and run your first commands.
+Two steps: get the binary, then run your first commands.
 
 | Page | What it covers |
 |------|----------------|
 | [Installation](installation.md) | **Recommended:** agent prompt + raw `SKILL.md`; Homebrew, shell installer, `go install`, release archives |
-| [Quickstart](quickstart.md) | `humblskills start` / dashboard, core commands, `--json`, `--yes` |
+| [Quickstart](quickstart.md) | The five-command loop, the dashboard, profiles, `--json` / `--yes`, completions |
 | [Agent install SKILL (raw Markdown)](https://jjfantini.github.io/humblSKILLS/getting_started/installation/SKILL.md) | Same content as the install `SKILL.md` for fetch-by-URL tools (no HTML) |
+
+Once installed, the two pages worth knowing about are the
+[skill catalog](../skills.md) (what you can install) and
+[Platforms](../using_humblskills/platforms.md) (where it lands on disk).
 
 If you plan to run [eval](../eval/index.md), you will also configure runners and API keys as described there.

--- a/docs/getting_started/installation-agent/SKILL.md
+++ b/docs/getting_started/installation-agent/SKILL.md
@@ -52,6 +52,15 @@ Download the archive for your OS and architecture from [GitHub releases](https:/
 humblskills doctor
 ```
 
+### Upgrade the CLI later
+
+```sh
+humblskills upgrade            # self-update; --dry-run to check only
+brew upgrade humblskills       # use this instead for Homebrew installs
+```
+
+`upgrade` updates the CLI binary; `update` updates installed skills.
+
 ## CLI behavior
 
 - **Interactive TTY:** `humblskills` or `humblskills start` opens the dashboard. Use **`--fullscreen`** for full-screen TUI when supported.
@@ -61,18 +70,53 @@ humblskills doctor
 
 ```sh
 humblskills doctor
-humblskills search
-humblskills install smart-skill
+humblskills search                       # --category=<c> / --role=<r> to narrow
+humblskills install smart-skill          # --platform, --scope/--global, --from, --force
 humblskills list
-humblskills update
+humblskills update                       # --check to dry-run
 humblskills update --all --yes
 humblskills uninstall smart-skill
 ```
 
 Every command accepts **`--json`** (machine-readable output) and **`--yes`** (skip prompts).
 
+### Platforms
+
+Installs go to every detected platform: `claude-code`, `cursor`, `codex`
+(symlinks into `~/.claude/skills`, `~/.cursor/skills`, `~/.agents/skills`) and
+`claude-desktop`, which writes an upload zip to `~/.humblskills/desktop/` because
+Claude Desktop and claude.ai can't read skills from disk. Restrict with
+`--platform`, or persist a default with
+`humblskills profile set platforms claude-code,cursor`.
+
+### Private / additional registries
+
+```sh
+humblskills registry add work my-company/our-skills   # owner/repo shorthand works
+humblskills registry login --name work                # token → OS keychain (or pipe it on stdin)
+humblskills registry list
+humblskills install <skill> --from work               # if a name exists in several registries
+```
+
+Non-interactive alternative: `HUMBLSKILLS_REGISTRY` + `HUMBLSKILLS_TOKEN`, or the
+global `--registry` / `--token` flags.
+
+### Team skillsets
+
+```sh
+humblskills init --from-installed        # scaffold ./humblskills.json
+humblskills export -o humblskills.json   # snapshot installed skills (+ their named registries)
+humblskills sync                         # install everything the file lists
+humblskills sync --prune --yes           # make the local set match the file exactly
+```
+
 ## Deeper topics
 
+- [Skill catalog](https://jjfantini.github.io/humblSKILLS/skills/)
+- [Platforms and where skills land](https://jjfantini.github.io/humblSKILLS/using_humblskills/platforms/)
+- [Registries](https://jjfantini.github.io/humblSKILLS/using_humblskills/registries/)
+- [Updating skills](https://jjfantini.github.io/humblSKILLS/using_humblskills/updating/)
 - [Registry and skill format](https://jjfantini.github.io/humblSKILLS/using_humblskills/registry_and_format/)
 - [Preserving user content](https://jjfantini.github.io/humblSKILLS/using_humblskills/preserving_user_content/)
+- [Sharing skillsets](https://jjfantini.github.io/humblSKILLS/using_humblskills/sharing_skillsets/)
 - [Eval quickstart](https://jjfantini.github.io/humblSKILLS/eval/quickstart/)

--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -69,4 +69,38 @@ Each release publishes `checksums.txt` with SHA-256 sums.
 humblskills doctor
 ```
 
-See [Quickstart](quickstart.md) for everyday commands.
+`doctor` prints the agent platforms it found, whether each install target is
+writable, and the health of every configured registry. If it reports a problem,
+fix that before installing skills.
+
+## Staying up to date
+
+```sh
+humblskills upgrade              # self-update: download, verify, swap the binary
+humblskills upgrade --dry-run    # just show the version you'd move to
+```
+
+Homebrew installs are upgraded through Homebrew instead, so its bookkeeping stays
+correct — `upgrade` will tell you so:
+
+```sh
+brew upgrade humblskills
+```
+
+`upgrade` updates the **CLI**; `humblskills update` updates your installed
+**skills**. See [Updating skills](../using_humblskills/updating.md).
+
+## Optional: shell completions
+
+Tab-complete skill names, registry names, and flag values:
+
+```sh
+humblskills completion zsh --help    # also: bash, fish, powershell
+```
+
+Each shell's `--help` prints the exact line to add to your shell config.
+
+## Next
+
+See [Quickstart](quickstart.md) for everyday commands, or jump straight to the
+[skill catalog](../skills.md).

--- a/docs/getting_started/quickstart.md
+++ b/docs/getting_started/quickstart.md
@@ -1,8 +1,96 @@
 # Quickstart
 
+New to the CLI? Do these five things in order and you're done.
+
+```sh
+humblskills doctor                    # 1. is my environment OK?
+humblskills search                    # 2. what can I install?
+humblskills install smart-commit      # 3. install one
+humblskills list                      # 4. what do I have?
+humblskills update                    # 5. keep them current
+```
+
+That's the whole loop. Everything below is detail you can come back for.
+
+!!! tip "Prefer clicking to typing?"
+    Just run **`humblskills`** with no arguments — it opens a dashboard with a
+    tile for every command. See [Interactive dashboard](#interactive-dashboard-tui).
+
+## 1. Check your environment
+
+```sh
+humblskills doctor
+```
+
+`doctor` reports which agent platforms it detected (Claude Code, Cursor, Codex,
+Claude Desktop), whether each install target is writable (`rw` / `ro`), the
+health of every configured registry, and anything wrong with your install
+manifest. If something later doesn't work, run this first.
+
+## 2. Find a skill
+
+```sh
+humblskills search                    # no query → open the interactive browser
+humblskills search commit             # match name, description, and tags
+humblskills search --category=design  # narrow to one category
+humblskills search --role=fde         # narrow to one target role
+```
+
+Or read the full [skill catalog](../skills.md).
+
+## 3. Install it
+
+```sh
+humblskills install smart-commit
+humblskills install                              # no name → pick from a list
+humblskills install smart-commit --yes           # skip the confirmation
+humblskills install smart-commit --platform claude-code
+humblskills install smart-commit --scope project # this repo only
+```
+
+By default a skill installs once into `~/.humblskills/skills/<skill>` and is
+linked into every agent platform found on your machine. See
+[Platforms & where skills land](../using_humblskills/platforms.md) for the paths,
+scopes, and the Claude Desktop zip flow.
+
+Save your preferences so you can stop passing flags:
+
+```sh
+humblskills profile set platforms claude-code,cursor
+humblskills profile set scope global
+humblskills profile show
+```
+
+## 4. See what you have
+
+```sh
+humblskills list          # installed skills, versions, and available updates
+humblskills uninstall smart-commit
+```
+
+`list` tags each skill with the registry it came from and flags any that have a
+newer version waiting.
+
+## 5. Keep things current
+
+```sh
+humblskills update              # pick which drifted skills to upgrade
+humblskills update --check      # dry run: show what would change
+humblskills update --all --yes  # upgrade everything, no prompts
+humblskills upgrade             # upgrade the humblskills CLI itself
+```
+
+`update` handles skills; `upgrade` handles the binary. Your customizations
+inside a skill survive an update, and renamed skills are followed automatically
+— see [Updating skills](../using_humblskills/updating.md).
+
 ## Interactive dashboard (TUI)
 
-On a normal terminal, **`humblskills`** with no subcommand opens the same experience as **`humblskills start`**: a full-screen **dashboard** (tile grid with fuzzy search) that routes into install, list, update, search, uninstall, profile, eval, doctor, registry refresh, and version. Press **ESC** from a sub-screen to return to the grid.
+On a normal terminal, **`humblskills`** with no subcommand opens the same
+experience as **`humblskills start`**: a full-screen **dashboard** (tile grid
+with fuzzy search) that routes into install, list, update, search, uninstall,
+profile, eval, doctor, registry, and version. Press **ESC** from any sub-screen
+to return to the grid.
 
 ```sh
 humblskills          # TTY: open dashboard; non-TTY: print command summary
@@ -13,43 +101,65 @@ Optional global flag:
 
 - **`--fullscreen`** - use full-screen TUI mode (also valid on `start`; requires a TTY).
 
-Non-interactive environments (pipes, CI, agents) do not get the TUI: the binary prints a short command summary instead. Use **`--json`**, **`--yes`**, and explicit subcommands (below) for scripts.
-
-## Core commands (CLI)
+Skill lists nest under collapsible **category** headings. Turn that off for one
+flat list:
 
 ```sh
-humblskills doctor                    # verify the environment
-humblskills search                    # browse the registry
-humblskills install smart-skill
-humblskills install smart-skill --global --yes
-humblskills migrate claude-code --global --yes
-humblskills list
-humblskills update                    # pick which drifted skills to upgrade
-humblskills update --all --yes        # non-interactive bulk upgrade
-humblskills uninstall smart-skill
-humblskills init --from-installed      # scaffold a shareable humblskills.json
-humblskills sync                       # install everything a skillset lists
+humblskills profile set group_by_category off
 ```
 
-Use `install --global` when you want one canonical copy in
-`~/.humblskills/skills/<skill>` with symlinks into every detected agent
-platform. Codex reads the symlink from `$HOME/.agents/skills/<skill>`.
+## Scripts, CI, and agents
 
-Use `migrate claude-code --global` to adopt existing registry-known skills from
-`~/.claude/skills` into the canonical store, then fan them out with symlinks.
-Unregistered personal Claude Code skills are reported and skipped.
-
-## Machine-friendly output
-
-Every command accepts:
+Non-interactive environments (pipes, CI, agents) don't get the TUI — the binary
+prints a short command summary instead. Use explicit subcommands plus:
 
 - **`--json`** - machine-readable output
 - **`--yes`** - skip confirmation prompts
 
-Use these in scripts and CI.
+```sh
+humblskills install smart-commit --yes --json
+humblskills update --all --yes --json
+```
+
+## Shell completions
+
+Skill names, registry names, and flag values tab-complete once the completion
+script is installed:
+
+```sh
+humblskills completion zsh --help    # also: bash, fish, powershell
+```
+
+## Command reference at a glance
+
+| Command | What it does |
+|---------|--------------|
+| `humblskills` / `start` | Interactive dashboard |
+| `doctor` | Check platforms, targets, registries, manifest |
+| `search` | Find skills (`--category`, `--role`, `--json`) |
+| `install` | Install a skill (`--platform`, `--scope`, `--global`, `--from`, `--force`) |
+| `list` | Installed skills + available updates |
+| `update` | Upgrade installed skills (`--check`, `--all`, `--force`) |
+| `upgrade` | Upgrade the CLI binary (`--dry-run`) |
+| `uninstall` | Remove a skill |
+| `migrate` | Adopt hand-installed skills into humblskills |
+| `registry` | Add / list / rename / remove registries, login, refresh |
+| `profile` | Defaults: platforms, scope, registry, TUI options |
+| `init` / `export` / `sync` | Share a skillset with a team |
+| `export desktop` | Write Claude Desktop / claude.ai upload zips |
+| `eval` | Benchmark a skill across arms |
+| `mirrors` | Check mirrored skills against upstream (maintainers) |
+| `completion` | Generate a shell completion script |
+| `version` | Print the CLI version |
+
+Add `--help` to any of them for the full flag list.
 
 ## Related topics
 
+- [Skill catalog](../skills.md)
+- [Platforms & where skills land](../using_humblskills/platforms.md)
+- [Registries](../using_humblskills/registries.md) - private and multiple registries
+- [Updating skills](../using_humblskills/updating.md)
 - [Registry & skill format](../using_humblskills/registry_and_format.md)
 - [Preserving user content](../using_humblskills/preserving_user_content.md)
 - [Sharing skillsets](../using_humblskills/sharing_skillsets.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,18 +1,36 @@
 # humblSKILLS
 
-humblSKILLS is a **skill registry** plus a single-binary Go CLI, **`humblskills`**, that installs [agentskills.io](https://agentskills.io)-format skills for the agent stack you already use (Claude Code, Cursor, Codex, and similar).
+humblSKILLS is a **skill registry** plus a single-binary Go CLI, **`humblskills`**, that installs [agentskills.io](https://agentskills.io)-format skills for the agent stack you already use — Claude Code, Cursor, Codex, and Claude Desktop.
+
+A **skill** is a folder with a `SKILL.md` that teaches your coding agent how to do one thing well. humblskills fetches those folders and puts them where each agent looks for them, so you don't have to know where that is.
+
+## Three commands to try
+
+```sh
+brew install jjfantini/humbl/humblskills   # or see Installation for other options
+humblskills search                         # browse what's available
+humblskills install smart-commit           # install one
+```
+
+No account, no server, no telemetry. [Full installation options →](getting_started/installation.md)
 
 ## What you get
 
-1. **Skill registry** - A monorepo of skills in the agentskills.io shape, with humblSKILLS extensions under `metadata:` in `SKILL.md` (`requires`, `platforms`, `tags`, `preserve`, `version`, and similar).
-2. **`humblskills` CLI** - Pulls a skill directory from the registry and installs it in the right place for your platform. No hosted account, no telemetry.
+1. **Skill registry** - A monorepo of skills in the agentskills.io shape, with humblSKILLS extensions under `metadata:` in `SKILL.md` (`version`, `category`, `role`, `requires`, `platforms`, `tags`, `previous_names`, `preserve`).
+2. **`humblskills` CLI** - Pulls a skill directory from a registry and installs it in the right place for your platform, keeps it updated, and preserves the content you accumulate inside it.
 
-## Next steps
+## Where to go next
 
-- [Installation](getting_started/installation.md) - **Recommended:** agent prompt + raw `SKILL.md`; Homebrew, shell, Go, releases
-- [Quickstart](getting_started/quickstart.md) - dashboard (`start`), `doctor`, `search`, `install`, `update`
-- [Eval](eval/index.md) - benchmark skills and inspect compound smart-skill runs
-- [Preserving user content](using_humblskills/preserving_user_content.md) - `metadata.preserve` in `SKILL.md`
-- [Sharing skillsets](using_humblskills/sharing_skillsets.md) - `init`, `export`, `sync`, `sync --prune`
+| If you want to… | Read |
+|-----------------|------|
+| Install the CLI | [Installation](getting_started/installation.md) - agent prompt, Homebrew, shell, Go, releases |
+| Learn the everyday commands | [Quickstart](getting_started/quickstart.md) - `doctor`, `search`, `install`, `list`, `update` |
+| See what's installable | [Skill catalog](skills.md) - every skill in the public registry |
+| Know where skills land on disk | [Platforms](using_humblskills/platforms.md) - paths, scopes, Claude Desktop zips |
+| Use a private or second registry | [Registries](using_humblskills/registries.md) - tokens, multiple registries, `--from` |
+| Keep skills current | [Updating skills](using_humblskills/updating.md) - `update` vs `upgrade`, renames |
+| Keep your own notes inside a skill | [Preserving user content](using_humblskills/preserving_user_content.md) |
+| Share a skill set with a team | [Sharing skillsets](using_humblskills/sharing_skillsets.md) - `init`, `export`, `sync` |
+| Author or benchmark a skill | [Registry & skill format](using_humblskills/registry_and_format.md) · [Eval](eval/index.md) |
 
 Documentation is hosted on [GitHub Pages](https://jjfantini.github.io/humblSKILLS/); the live site is **published from `main`** so it stays aligned with released, installable `humblskills` builds. Source lives in the [humblSKILLS repo](https://github.com/jjfantini/humblSKILLS).

--- a/docs/mkdocs_hooks.py
+++ b/docs/mkdocs_hooks.py
@@ -1,7 +1,13 @@
-"""Remove MkDocs built-in fenced_code so pymdownx.superfences handles fenced blocks."""
+"""Remove MkDocs built-in fenced_code so pymdownx.superfences handles fenced blocks.
+
+Also renders the skill catalog into docs/skills.md from registry.json at build
+time, so the published list can't drift from the released registry.
+"""
 
 from __future__ import annotations
 
+import json
+import re
 import shutil
 from pathlib import Path
 from typing import Any
@@ -9,12 +15,79 @@ from typing import Any
 _AGENT_SKILL_SRC = Path("getting_started") / "installation-agent" / "SKILL.md"
 _AGENT_SKILL_DEST = Path("getting_started") / "installation" / "SKILL.md"
 
+_CATALOG_MARKER = "<!-- SKILL_CATALOG -->"
+
+# Human labels for the closed category set in cli/internal/frontmatter.
+_CATEGORY_LABELS = {
+    "development": "Development",
+    "design": "Design",
+    "writing": "Writing",
+    "meta": "Meta (skill authoring & project setup)",
+}
+
 
 def on_config(config: Any, **kwargs: Any) -> Any:
     config["markdown_extensions"] = [
         ext for ext in config["markdown_extensions"] if ext != "fenced_code"
     ]
     return config
+
+
+def _first_sentence(description: str) -> str:
+    """The lead sentence of a skill description, for a table cell.
+
+    Skill descriptions are long trigger paragraphs written for the agent's
+    router, not for humans reading a list.
+    """
+    text = " ".join(description.split())
+    # Cut at whichever comes first: the end of the lead sentence, or the
+    # trigger/anti-trigger boilerplate every description tails off into. Taking
+    # the earliest of the two keeps one-sentence output even when a sentence end
+    # is missed (abbreviations) or the boilerplate is several sentences down.
+    cuts = [text.find(m) for m in (" Use when", " Use this", " Do NOT", " Trigger")]
+    if match := re.search(r"\.\s", text):
+        cuts.append(match.start() + 1)
+    cuts = [c for c in cuts if c > 0]
+    return text[: min(cuts)].rstrip() if cuts else text
+
+
+def _render_catalog(registry_path: Path) -> str:
+    """A category-grouped Markdown table of every skill in registry.json."""
+    data = json.loads(registry_path.read_text(encoding="utf-8"))
+    skills = data.get("skills", [])
+    by_category: dict[str, list[dict[str, Any]]] = {}
+    for skill in skills:
+        by_category.setdefault(skill.get("category", "other"), []).append(skill)
+
+    lines: list[str] = []
+    # Known categories first, in taxonomy order, then anything unexpected.
+    ordered = list(_CATEGORY_LABELS) + sorted(set(by_category) - set(_CATEGORY_LABELS))
+    for category in ordered:
+        entries = by_category.get(category)
+        if not entries:
+            continue
+        lines.append(f"## {_CATEGORY_LABELS.get(category, category.title())}")
+        lines.append("")
+        lines.append("| Skill | Version | What it does |")
+        lines.append("|-------|---------|--------------|")
+        for skill in sorted(entries, key=lambda s: s["name"]):
+            mirrored = " ↗" if skill.get("upstream") else ""
+            summary = _first_sentence(skill.get("description", ""))
+            lines.append(
+                f"| `{skill['name']}`{mirrored} | {skill.get('version', '-')} | {summary} |"
+            )
+        lines.append("")
+    lines.append(f"**{len(skills)} skills** in the registry.")
+    return "\n".join(lines)
+
+
+def on_page_markdown(markdown: str, page: Any, config: Any, **kwargs: Any) -> str:
+    if _CATALOG_MARKER not in markdown:
+        return markdown
+    registry = Path(config["config_file_path"]).parent / "registry.json"
+    if not registry.is_file():
+        raise FileNotFoundError(f"registry.json missing, cannot build catalog: {registry}")
+    return markdown.replace(_CATALOG_MARKER, _render_catalog(registry))
 
 
 def on_post_build(config: Any, **kwargs: Any) -> None:

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -4,4 +4,8 @@ This page is a lightweight stub. Track larger direction in [GitHub Issues](https
 
 Planned doc improvements:
 
-- Auto-generated **CLI reference** (Cobra → Markdown → MkDocs) in a follow-up pass.
+- Auto-generated **CLI reference** (Cobra → Markdown → MkDocs) in a follow-up pass. The [Quickstart](getting_started/quickstart.md#command-reference-at-a-glance) carries a hand-maintained command table until then; `--help` on any command is always authoritative.
+
+Already generated at build time:
+
+- The [skill catalog](skills.md) is rendered from `registry.json` on every docs build, so it cannot drift from the released registry.

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -1,0 +1,39 @@
+# Skill catalog
+
+Everything the public humblSKILLS registry currently ships. Install any of them
+with:
+
+```sh
+humblskills install <skill-name>
+```
+
+Or browse them interactively — `humblskills search` with no query opens a
+fuzzy-searchable browser, grouped by the categories below.
+
+This page is generated from [`registry.json`](https://github.com/jjfantini/humblSKILLS/blob/main/registry.json)
+at docs build time, so it always matches the released registry.
+
+<!-- SKILL_CATALOG -->
+
+## Legend
+
+- **Version** - the skill package version, independent of the CLI version.
+  `humblskills update` compares your installed copy against this.
+- **↗ mirrored** - the skill is a distillation of an upstream source, with the
+  original preserved verbatim inside the skill. See
+  [provenance for mirrored skills](using_humblskills/registry_and_format.md#provenance-for-mirrored-skills-upstream).
+
+Every skill here targets **Claude Code, Cursor, and Codex**, and can also be
+exported as a [Claude Desktop zip](using_humblskills/platforms.md#claude-desktop-and-claudeai-zip-upload).
+
+## Adding your own
+
+Skills are directories with a `SKILL.md`. To author one, install the
+`smart-skill` scaffolder:
+
+```sh
+humblskills install smart-skill
+```
+
+Then see [Registry & skill format](using_humblskills/registry_and_format.md) for
+the frontmatter humblSKILLS understands.

--- a/docs/using_humblskills/platforms.md
+++ b/docs/using_humblskills/platforms.md
@@ -1,0 +1,107 @@
+# Platforms & where skills land
+
+`humblskills install` writes **one** copy of a skill into a canonical store,
+then makes it visible to each agent platform. Understanding that split answers
+most "where did my skill go?" questions.
+
+## Supported platforms
+
+| Platform | How the skill is delivered | User target |
+|----------|---------------------------|-------------|
+| `claude-code` | Symlink | `~/.claude/skills/<skill-id>` |
+| `cursor` | Symlink | `~/.cursor/skills/<skill-id>` |
+| `codex` | Symlink | `~/.agents/skills/<skill-id>` |
+| `claude-desktop` | **Zip you upload** (see below) | `~/.humblskills/desktop/<skill-id>.zip` |
+
+By default the CLI installs to every platform it **detects** on your machine
+(it looks for `~/.claude`, `~/.cursor`, `~/.codex` / `~/.agents`, and Claude
+Desktop's data directory). Restrict that with `--platform`:
+
+```sh
+humblskills install smart-commit --platform claude-code
+humblskills install smart-commit --platform claude-code,cursor
+```
+
+Set a default once so you don't repeat the flag:
+
+```sh
+humblskills profile set platforms claude-code,cursor
+```
+
+Check what was detected and whether each target is writable:
+
+```sh
+humblskills doctor
+```
+
+## The canonical store (and scopes)
+
+The real skill directory lives in the store; platform locations are symlinks
+into it. That means one copy on disk, one place to update.
+
+| Scope | Canonical directory |
+|-------|---------------------|
+| `global` (the default) | `~/.humblskills/skills/<skill-id>` |
+| `user` | `$XDG_DATA_HOME/humblskills/skills/<skill-id>` |
+| `project` | `<current repo>/.humblskills/skills/<skill-id>` |
+
+```sh
+humblskills install smart-commit                    # global (default)
+humblskills install smart-commit --scope project    # this repo only
+humblskills install smart-commit --global           # alias for --scope global
+humblskills profile set scope project               # change your default
+```
+
+Use `project` scope for skills a specific repository needs, so they're not
+installed machine-wide.
+
+## Claude Desktop and claude.ai (zip upload)
+
+Claude Desktop and claude.ai **cannot read skills from your filesystem** — they
+take an account-level zip upload. So the `claude-desktop` platform doesn't
+symlink; it writes an upload-ready zip (the skill folder at the zip root).
+
+Select it like any other platform and `install` / `update` keep the zips
+current for you:
+
+```sh
+humblskills install smart-commit --platform claude-desktop
+# → ~/.humblskills/desktop/smart-commit.zip
+```
+
+Then upload the zip: **claude.ai (or the Claude desktop app) → Settings →
+Capabilities → Skills → upload the zip**.
+
+Need zips without reinstalling anything?
+
+```sh
+humblskills export desktop                       # every installed skill
+humblskills export desktop smart-commit          # just one
+humblskills export desktop -o ./dist             # write somewhere else
+```
+
+!!! warning "Uploads don't auto-update"
+    A zip you've uploaded is a copy inside your Claude account. `humblskills
+    update` refreshes the local zip, but you have to **re-upload** it for Claude
+    to see the new version. The filesystem platforms don't have this problem.
+
+## Adopting skills you already installed by hand
+
+If you have skills sitting in `~/.claude/skills` that you installed manually,
+`migrate` brings the registry-known ones under humblskills management:
+
+```sh
+humblskills migrate claude-code --global --yes
+```
+
+It reads each `SKILL.md`, matches the `name` against the registry, copies
+matches into the canonical store (keeping their preserved local files), and
+replaces the Claude Code directory with a symlink. Your own personal skills that
+aren't in any registry are reported and **skipped** — nothing of yours is
+deleted.
+
+## Related topics
+
+- [Registry & skill format](registry_and_format.md)
+- [Updating skills](updating.md)
+- [Preserving user content](preserving_user_content.md)

--- a/docs/using_humblskills/registries.md
+++ b/docs/using_humblskills/registries.md
@@ -1,0 +1,164 @@
+# Registries
+
+A **registry** is just a JSON file (`registry.json`) that lists skills and where
+to download each one. The CLI reads a registry, then installs the skill
+directory it points at.
+
+You do **not** have to set any of this up to get started. humblskills ships with
+the public humblSKILLS registry built in, so `humblskills search` and
+`humblskills install <skill>` work on a fresh install with zero configuration.
+
+Read this page when you want to:
+
+- pull skills from a **private** repo (your company's own skill library), or
+- use **several registries at once** (public + private), or
+- share a registry setup with teammates.
+
+## The mental model
+
+| Thing | What it is |
+|-------|------------|
+| **Registry** | A `registry.json` URL (or local file) listing available skills |
+| **Named registry** | A registry you've given a short name, e.g. `public`, `work` |
+| **Token** | A GitHub personal access token, needed only for **private** registries |
+| **Default registry** | The public humblSKILLS one, used when you've configured nothing |
+
+Tokens are stored in your **OS keychain** (macOS Keychain, Windows Credential
+Manager, Linux Secret Service), not in a config file. They never appear in
+`humblskills profile show`.
+
+## Add a second registry
+
+`registry add` takes a name and a location. The location can be a full URL, or
+the `owner/repo` shorthand — the CLI expands that into the raw `registry.json`
+URL for you.
+
+```sh
+humblskills registry add public     jjfantini/humblSKILLS
+humblskills registry add work       my-company/our-skills
+humblskills registry add work       my-company/our-skills@develop   # pick a branch
+humblskills registry add                                            # no args → prompts you
+```
+
+Run `humblskills registry add` with no arguments and it asks for the name, the
+URL, and (optionally) a token — handy if you'd rather not remember the flags.
+
+Once more than one registry is configured, `search` and the skill browser show
+them **together, grouped by registry**, with each skill tagged by where it came
+from:
+
+```text
+── work ──
+  internal-deploy-runbook   …
+── public ──
+  smart-commit              …
+```
+
+## Private registries: add a token
+
+If the registry lives in a private GitHub repo, the CLI needs a token to read
+both `registry.json` and each skill download. Use a GitHub personal access token
+with **read access** to that repo.
+
+```sh
+humblskills registry login --name work
+```
+
+You'll get a masked prompt. The token is verified against the registry before it
+is saved, so a typo fails immediately instead of at install time. Then:
+
+```sh
+humblskills search                  # includes the private registry
+humblskills install <skill>         # token is applied automatically
+humblskills registry logout --name work   # remove the stored token
+```
+
+Other ways to supply the token — useful in CI, where there's no prompt:
+
+```sh
+echo "$GITHUB_TOKEN" | humblskills registry login --name work   # piped stdin
+humblskills registry login --name work --token "$GITHUB_TOKEN"  # flag
+```
+
+!!! note "Where the token is looked up"
+    Highest precedence first: `--token` → `HUMBLSKILLS_TOKEN` → OS keychain →
+    a `0600` fallback file (used only when no keychain is available). Tokens are
+    ignored for `file://` registries and for the public default.
+
+## Installing when a name exists in two registries
+
+Skill names are unique **within** a registry, not across them. When two
+registries publish the same name, disambiguate with `--from`:
+
+```sh
+humblskills install smart-commit --from public
+```
+
+When only one registry has the name, no flag is needed. When several do and you
+omit `--from`, the CLI asks you to pick on a normal terminal, and fails with the
+list of candidates in a script or CI so nothing ambiguous gets installed
+silently.
+
+## Managing registries
+
+```sh
+humblskills registry list                     # names, URLs, and token state
+humblskills registry rename work acme         # rename (moves its stored token too)
+humblskills registry add work <new-url>       # re-add an existing name to change its URL
+humblskills registry remove work              # drop it (and its stored token)
+humblskills registry refresh                  # force-refresh the cached registry
+```
+
+Or run bare **`humblskills registry`** (also the **registry** tile on the
+dashboard) to open the interactive **registry manager** — add, rename, login,
+logout, remove, and refresh from one screen. On a non-interactive terminal it
+falls back to printing `registry list`.
+
+## Registries show up everywhere
+
+Once configured, registry provenance flows through the rest of the CLI:
+
+| Command | What it shows |
+|---------|---------------|
+| `humblskills list` | Tags each installed skill with the registry it came from |
+| `humblskills update` | Checks each skill against **its own** registry |
+| `humblskills doctor` | Per-registry reachability, token state, and skill count |
+| `humblskills profile show` | A **Registries** section listing all of them |
+
+## Single-registry setup (no names)
+
+If you only ever use one registry, you can skip named registries entirely and
+just point the CLI at it:
+
+```sh
+humblskills profile set registry https://raw.githubusercontent.com/<owner>/<repo>/main/registry.json
+humblskills registry login       # token for that one registry
+humblskills search
+```
+
+Or set it per-command / per-shell:
+
+```sh
+export HUMBLSKILLS_REGISTRY=https://raw.githubusercontent.com/<owner>/<repo>/main/registry.json
+export HUMBLSKILLS_TOKEN=<github token with read access>
+humblskills search
+```
+
+Registry resolution order, highest precedence first: `--registry` →
+`HUMBLSKILLS_REGISTRY` → named registries / `profile set registry` → the hosted
+public default.
+
+## Tab completion
+
+Registry names, skill names, and `--from` / `--name` values all tab-complete
+once you install the completion script:
+
+```sh
+humblskills completion zsh --help     # also: bash, fish, powershell
+```
+
+## Related topics
+
+- [Sharing skillsets](sharing_skillsets.md) - ship a registry list to teammates so `sync` configures it for them
+- [Registry & skill format](registry_and_format.md) - what a skill looks like inside a registry
+- [Quickstart](../getting_started/quickstart.md)

--- a/docs/using_humblskills/registry_and_format.md
+++ b/docs/using_humblskills/registry_and_format.md
@@ -8,11 +8,14 @@ humblSKILLS-specific keys live under the optional **`metadata:`** map so the top
 
 | Key under `metadata:` | Purpose |
 |-------------------------|---------|
+| `version` | Skill package version (semver, `MAJOR.MINOR.PATCH`) |
+| `author` | Who maintains the skill |
 | `requires` | Dependencies or constraints (as defined by the skill) |
 | `platforms` | Which agent platforms the skill targets |
 | `category` | One coarse browsing bucket, from a closed set (see below) |
+| `role` | Optional target role, from a closed set (see below) |
 | `tags` | Freeform keywords for search (many per skill) |
-| `version` | Skill package version (semver) |
+| `previous_names` | Names this skill used to publish under, so `update` can follow a rename (see [Updating skills](updating.md)) |
 | `preserve` | Paths to keep on `update` when replacing an installed skill (see [Preserving user content](preserving_user_content.md)) |
 
 Other top-level frontmatter follows the normal agentskills.io expectations.
@@ -35,6 +38,60 @@ Adding a new category is a taxonomy decision (edit `frontmatter.Categories` in
 `cli/internal/frontmatter/validate.go`), not something an individual skill
 author should do by picking a new value.
 
+Filter by it, or turn the grouping off if you prefer one flat list:
+
+```sh
+humblskills search --category=design
+humblskills profile set group_by_category off    # on | off | default (on)
+```
+
+The skills browser and `install` / `list` pickers nest skills under collapsible
+category headings by default; `group_by_category` is the toggle.
+
+### Roles
+
+`role` is optional and, like `category`, single-valued and validated against a
+closed set. It scopes a skill to a job function rather than a subject area,
+which is mainly useful for private, company-internal registries.
+
+| Role | Meaning |
+|------|---------|
+| `fde` | Forward-deployed engineer |
+| `ds` | Data scientist |
+| `sdr` | Sales development representative |
+
+```sh
+humblskills search --role=fde
+```
+
+A skill with no `role` is unscoped and shows up regardless. No first-party
+humblSKILLS skill sets a role today — the taxonomy exists so registries that
+need it can use it. Adding a role, like adding a category, is a taxonomy change
+that ships in a CLI release.
+
+### Provenance for mirrored skills (`upstream:`)
+
+Some skills are **distillations of an upstream source** rather than original
+work — the `better-*` family, for example. Those declare a top-level `upstream:`
+block naming where the source lives, which file in the skill preserves the copy
+it was written against, and any deliberate divergences (`deltas:`).
+
+Because the preserved copy *is* the baseline, drift is detectable as a plain
+comparison — no hashes or lockfiles. That check is a maintainer tool and runs
+against a source checkout of the repo, not installed copies:
+
+```sh
+humblskills mirrors check          # which mirrors drifted from upstream, and how badly
+humblskills mirrors plan <skill>   # write a re-sync work order for a drifted mirror
+```
+
+`check` reports `current`, `drifted` (structure intact — review the diff),
+`rewritten` (upstream changed enough to re-distil), or `unknown` (upstream
+couldn't be fetched — never silently treated as healthy). `plan` writes the two
+files to diff, the concepts affected, the declared deltas that must survive, and
+a checklist. Detection is automated; the re-distillation is judgment and is
+deliberately never automated.
+
 ## Where skills live in the repo
 
 Published skills live under `skills/<skill-id>/` in the [humblSKILLS repository](https://github.com/jjfantini/humblSKILLS). The CLI reads the bundled registry and installs the matching directory to your configured location for Cursor, Claude Code, Codex, etc.
@@ -42,37 +99,25 @@ Published skills live under `skills/<skill-id>/` in the [humblSKILLS repository]
 ## Local install layout
 
 `humblskills install` writes one canonical skill directory, then exposes that
-directory to agent platforms with symlinks.
-
-| Mode | Canonical directory |
-|------|---------------------|
-| `--global` | `~/.humblskills/skills/<skill-id>` |
-| User scope | `$XDG_DATA_HOME/humblskills/skills/<skill-id>` |
-| Project scope | `<repo>/.humblskills/skills/<skill-id>` |
-
-Platform targets are symlinks:
-
-| Platform | User target |
-|----------|-------------|
-| Claude Code | `~/.claude/skills/<skill-id>` |
-| Cursor | `~/.cursor/skills/<skill-id>` |
-| Codex | `$HOME/.agents/skills/<skill-id>` |
+directory to each agent platform — by symlink for Claude Code, Cursor, and
+Codex, and by zip for Claude Desktop. See
+[Platforms & where skills land](platforms.md) for the full path tables, scopes,
+and the Claude Desktop upload flow.
 
 Codex officially supports symlinked skill folders in `.agents/skills`, so
 humblSKILLS uses direct skill folders for local discovery. Codex plugins remain
 out of scope for local installs; use plugins only when distributing reusable
 skills with app or MCP integrations.
 
-## Migrating existing Claude Code installs
+## Multiple registries
 
-Run:
+A registry is just a `registry.json` URL, and you can configure several at once
+(a public one plus your company's private one). See
+[Registries](registries.md).
 
-```sh
-humblskills migrate claude-code --global --yes
-```
+## Related topics
 
-The migration scans `~/.claude/skills`, reads each `SKILL.md`, and matches the
-skill `name` against the humblSKILLS registry. Registry-known skills are copied
-into `~/.humblskills/skills`, their preserved local files are retained, and the
-Claude Code directory is replaced with a symlink. Unregistered personal skills
-are reported and skipped.
+- [Platforms & where skills land](platforms.md)
+- [Registries](registries.md)
+- [Updating skills](updating.md)
+- [Preserving user content](preserving_user_content.md)

--- a/docs/using_humblskills/sharing_skillsets.md
+++ b/docs/using_humblskills/sharing_skillsets.md
@@ -14,6 +14,41 @@ A **skillset** is a small, version-controlled manifest (default `humblskills.jso
 
 `version` is informational only (the version captured when the file was written); `sync` always installs whatever the registry currently ships for that skill, matching `install` semantics.
 
+## Skillsets can carry their registries
+
+If any of your skills come from a **named** registry (a private company one, say),
+`export` records that registry in the file so `sync` can configure it on the
+other machine for you:
+
+```json
+{
+  "schema_version": 1,
+  "registries": [
+    { "name": "work", "url": "https://raw.githubusercontent.com/my-company/our-skills/main/registry.json" }
+  ],
+  "skills": [
+    { "name": "internal-deploy-runbook", "version": "0.3.0" },
+    { "name": "smart-commit", "version": "1.0.3" }
+  ]
+}
+```
+
+On `sync`, for each listed registry the CLI:
+
+1. **Adds it** to your profile if you don't have it (a registry you already have
+   under that name keeps *your* URL — the CLI tells you and moves on).
+2. **Checks it's readable**, and if it isn't and no token is stored, walks you
+   through creating and storing one — the same path as
+   [`registry login`](registries.md#private-registries-add-a-token).
+
+None of this is fatal: if a registry stays unreachable, `sync` continues and
+reports the skills it couldn't find as warnings.
+
+Skills from the public default registry contribute nothing here — every install
+of the CLI already has it. When a skill name exists in more than one registry,
+`sync` prefers the order the skillset lists them in, on the grounds that the
+file's author knows where their skills live.
+
 ## Create a skillset
 
 ```sh
@@ -53,6 +88,8 @@ Pruning is destructive, so it asks for confirmation (skip with `--yes`, or run w
 
 ## Related topics
 
+- [Registries](registries.md)
+- [Platforms & where skills land](platforms.md)
 - [Registry & skill format](registry_and_format.md)
 - [Preserving user content](preserving_user_content.md)
 - [Quickstart](../getting_started/quickstart.md)

--- a/docs/using_humblskills/updating.md
+++ b/docs/using_humblskills/updating.md
@@ -1,0 +1,94 @@
+# Updating skills and the CLI
+
+Two different things get updated, with two different commands. Mixing them up is
+the most common confusion:
+
+| You want to update… | Command |
+|---------------------|---------|
+| The **skills** you installed | `humblskills update` |
+| The **`humblskills` binary** itself | `humblskills upgrade` |
+
+## Updating installed skills
+
+```sh
+humblskills update                    # pick from the list of skills that drifted
+humblskills update --check            # print what would change, change nothing
+humblskills update --all --yes        # update everything, no prompts (CI-friendly)
+humblskills update smart-commit       # just one skill
+```
+
+Run with no arguments on a normal terminal and you get a picker listing every
+skill whose installed copy differs from what its registry now publishes. Nothing
+is written until you confirm.
+
+A skill counts as **drifted** when its version or its registry content hash has
+changed. The humblSKILLS repo's own commit SHA is deliberately *not* used — it
+moves on every commit, which would flag every skill as stale after each CLI
+release.
+
+`update` re-checks each skill against **the registry it was installed from**, so
+a mixed public + private setup updates correctly.
+
+### Your customizations survive
+
+By default `update` keeps the files a skill declares in `metadata.preserve` —
+memory files, curated notes, raw sources. This is what makes a "smart" skill's
+accumulated knowledge survive an upgrade. See
+[Preserving user content](preserving_user_content.md) for the full contract.
+
+To throw your local changes away and take exactly what the registry ships:
+
+```sh
+humblskills update --force <skill>
+```
+
+## When a skill gets renamed
+
+Skills occasionally get renamed upstream (for example, the `use-*` family was
+renamed to `smart-*`). You don't have to do anything special — `update` follows
+the rename instead of skipping it:
+
+The picker and the update summary show the rename explicitly, as
+`use-smart-commit → smart-commit`, so you can see what's happening before you
+confirm.
+
+What happens:
+
+1. The new skill is installed under its **new** name.
+2. Your **preserved files are carried across** from the old install — memory,
+   notes, and raw sources move with the skill.
+3. The old installation is retired.
+
+`humblskills update <new-name>` also reaches an install still recorded under the
+old name, so you can update by the name you now know the skill by.
+
+!!! note "Renames are never guessed"
+    A rename is only followed when a registry skill explicitly claims the old
+    name via `previous_names` in its frontmatter. A name that is still published
+    in its own right is never treated as a rename target, and a name claimed by
+    two skills is ignored rather than resolved by guessing. If a skill simply
+    disappeared from the registry, `update` leaves your copy alone — there is
+    nothing to upgrade to.
+
+## Upgrading the CLI
+
+```sh
+humblskills upgrade              # download + verify + swap in the latest release
+humblskills upgrade --dry-run    # just report the version you'd move to
+```
+
+The upgrade checks GitHub releases, verifies the checksum, and replaces the
+running binary in place.
+
+If you installed via Homebrew, `upgrade` tells you to use Homebrew instead, so
+Homebrew's own bookkeeping stays correct:
+
+```sh
+brew upgrade humblskills
+```
+
+## Related topics
+
+- [Preserving user content](preserving_user_content.md)
+- [Registries](registries.md)
+- [Quickstart](../getting_started/quickstart.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,6 +11,12 @@ exclude_docs: |
   requirements.txt
   getting_started/installation-agent/SKILL.md
 
+# Cross-page heading links are the easiest thing to break in a docs refactor;
+# with `mkdocs build --strict` in CI these warnings fail the build.
+validation:
+  anchors: warn
+  unrecognized_links: warn
+
 watch:
   - docs/
   - mkdocs.yml
@@ -21,10 +27,14 @@ nav:
     - getting_started/index.md
     - Installation: getting_started/installation.md
     - Quickstart: getting_started/quickstart.md
+  - Skills: skills.md
   - Using humblskills:
-    - Registry & skill format: using_humblskills/registry_and_format.md
+    - Platforms & where skills land: using_humblskills/platforms.md
+    - Registries: using_humblskills/registries.md
+    - Updating skills: using_humblskills/updating.md
     - Preserving user content: using_humblskills/preserving_user_content.md
     - Sharing skillsets: using_humblskills/sharing_skillsets.md
+    - Registry & skill format: using_humblskills/registry_and_format.md
   - Eval:
     - Overview: eval/index.md
     - Quickstart: eval/quickstart.md


### PR DESCRIPTION
## Why

The docs site had drifted to roughly **v2.23** content while the CLI shipped **2.42**. Everything from v2.24 onward was missing from the site — most importantly the registry work (private tokens, named registries, the registry manager, `--from`), which is the part of the CLI a user cannot discover from `--help` on a fresh install.

## Site changes

Four new pages, ordered the way a beginner hits the problems:

| Page | Covers |
|------|--------|
| `using_humblskills/platforms.md` | canonical store + symlinks, scopes, **Claude Desktop zip** flow, `migrate` |
| `using_humblskills/registries.md` | default registry → second registry → private tokens (keychain) → `--from` → manager TUI → completions |
| `using_humblskills/updating.md` | `update` (skills) vs `upgrade` (binary), drift, **rename-following** |
| `skills.md` | full skill catalog |

The catalog is **generated from `registry.json`** by the existing mkdocs hook, not hand-maintained — a hand-written list of 20 skills is wrong by the next release. Descriptions are trimmed to their lead sentence, since they are router prompts written for an agent.

Rewritten/updated: `index.md`, `getting_started/index.md`, `getting_started/quickstart.md` (now a five-command loop plus a command reference table), `installation.md` (adds `upgrade`, completions), the agent-facing `installation-agent/SKILL.md`, `registry_and_format.md` (adds `role`, `previous_names`, `upstream:`/`mirrors`; hands install layout to the platforms page), `sharing_skillsets.md` (skillset `registries` block + `sync` bootstrap), `eval/quickstart.md`, `roadmap.md`.

Added `validation.anchors` + `unrecognized_links` to `mkdocs.yml`. Cross-page heading links are the first thing a docs refactor breaks; with `--strict` already in CI these now fail the build. All anchors verified against the built HTML.

## README correction (worth a look)

The 4-arm indie-launch showcase block was **factually wrong and its link was dead**:

- linked `docs/eval/indie-launch-analysis.md`, deleted in 5390ee3
- said `claudecode`; the published report says `cursor-agent`
- "2.6% fewer tokens" was a misread of "+2.6% **pass rate**"
- the "3/3 vs 0/3" retention assertion and "8.9% less wall time" appear nowhere in the run
- "flat_skill_wiki is the worst of the four arms" is contradicted by the aggregate table (flat_skill is lowest)

It now quotes the published report directly, including the honest version of the surprising finding. The brand-voice showcase block was checked against its report and is accurate as-is.

The README also picks up: `claude-desktop`, `upgrade` vs `update`, `export desktop`, `--category`/`--role`, rename-following, skillset `registries`, and `mirrors` under Developing the CLI.

## Verification

- `mkdocs build --strict` passes, with anchor + link validation newly enabled
- every cross-page anchor confirmed present in the built HTML
- generated catalog spot-checked: 20 skills, correct categories, mirrored (`↗`) markers on the 8 mirrored skills
- no source under `skills/` touched, so `registry-check` is unaffected

Merging to `main` publishes the site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)