### PR TITLE
fix(install): stop platform-adds from destroying preserved skill memory; add update --platforms

### DIFF
--- a/cli/cmd/humblskills/confirm.go
+++ b/cli/cmd/humblskills/confirm.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/jjfantini/humblSKILLS/cli/internal/install"
+	"github.com/jjfantini/humblSKILLS/cli/internal/manifest"
+	"github.com/jjfantini/humblSKILLS/cli/internal/tui"
+)
+
+// errCancelled means the user declined a destructive action. Callers report it
+// as a normal outcome, not a failure.
+var errCancelled = errors.New("cancelled")
+
+// confirmDestructive gates anything that deletes user-owned files: uninstall,
+// a --force reinstall (which bypasses the preserve list), and skillset prune.
+//
+// Three rules, applied uniformly so the CLI and the TUI can't drift apart:
+//
+//   - --yes is consent. Proceed.
+//   - On a TTY, show exactly what will be destroyed and require an explicit
+//     yes. The default is No.
+//   - Non-interactive without --yes is an error, never an implied yes. A pipe
+//     or --json run has nobody to answer the question, and these paths delete
+//     files (LLM-maintained memory, raw notes) that no registry can restore.
+//     detail names them in the error, since the styled panel can't be printed
+//     there without corrupting --json output.
+func confirmDestructive(app *App, title, prompt, detail string, lines []string) error {
+	if app.Config.Yes {
+		return nil
+	}
+	if !app.Prompt.Interactive || app.Config.JSON {
+		msg := title
+		if detail != "" {
+			msg += ": " + detail
+		}
+		return fmt.Errorf("%s — re-run with --yes to confirm", msg)
+	}
+	ok, err := tui.ConfirmWithSummary(app.UI.Theme(), title, prompt, lines, false, true)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return errCancelled
+	}
+	return nil
+}
+
+// confirmForce gates a --force run. --force is the documented way to discard
+// local customizations, but it used to do so with no prompt at all, on skills
+// whose whole point is accumulating user-owned memory.
+//
+// Nothing at risk (skills not installed yet, or no preserved files on disk)
+// means no prompt: --force is then just a plain reinstall.
+func confirmForce(app *App, action string, skills []string) error {
+	m, err := manifest.Load(app.Config.ManifestPath)
+	if err != nil {
+		return fmt.Errorf("load manifest: %w", err)
+	}
+	var entries []*manifest.Installation
+	for _, s := range skills {
+		entries = append(entries, m.FindAll(s)...)
+	}
+	atRisk := preservedAcrossStores(entries)
+	if len(atRisk) == 0 {
+		return nil
+	}
+
+	theme := app.UI.Theme()
+	names := make([]string, 0, len(atRisk))
+	for skill := range atRisk {
+		names = append(names, skill)
+	}
+	sort.Strings(names)
+
+	lines := make([]string, 0, len(atRisk)*3)
+	for _, skill := range names {
+		lines = append(lines, theme.Name.Render(skill))
+		for _, p := range atRisk[skill] {
+			lines = append(lines, "  "+theme.Warn.Render("overwrites")+"  "+theme.Detail.Render(p))
+		}
+	}
+	lines = append(lines, "",
+		theme.Detail.Render("These are user-owned files (metadata.preserve). Without --force they survive."))
+
+	return confirmDestructive(app,
+		action,
+		"Overwrite them from the registry?",
+		flattenPreserved(atRisk, "overwrites"),
+		lines,
+	)
+}
+
+// preservedAcrossStores collects the user-owned preserved paths held by the
+// canonical stores behind these installations, deduplicated and labelled by
+// skill. It is what turns "are you sure?" into a list of files.
+func preservedAcrossStores(entries []*manifest.Installation) map[string][]string {
+	out := map[string][]string{}
+	seen := map[string]struct{}{}
+	for _, e := range entries {
+		if e.StorePath == "" {
+			continue
+		}
+		if _, done := seen[e.StorePath]; done {
+			continue
+		}
+		seen[e.StorePath] = struct{}{}
+		if at := install.PreservedAtRisk(e.StorePath, nil); len(at) > 0 {
+			out[e.Skill] = append(out[e.Skill], at...)
+		}
+	}
+	return out
+}
+
+// flattenPreserved renders the map from preservedAcrossStores as one plain
+// line for a non-interactive error message. verb is the caller's word for what
+// happens to the files ("deletes", "overwrites") — the two destructive paths do
+// different things and the message shouldn't blur them. Returns "" when nothing
+// is at risk, which lets callers skip the prompt entirely.
+func flattenPreserved(bySkill map[string][]string, verb string) string {
+	if len(bySkill) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(bySkill))
+	for skill, paths := range bySkill {
+		parts = append(parts, skill+" ("+strings.Join(paths, ", ")+")")
+	}
+	sort.Strings(parts)
+	return verb + " user-owned files: " + strings.Join(parts, "; ")
+}

--- a/cli/cmd/humblskills/install.go
+++ b/cli/cmd/humblskills/install.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"sort"
 
@@ -152,9 +153,10 @@ func runInstall(app *App, skill string, f installFlags, fromDashboard bool) erro
 	platforms := f.platforms
 	scope := f.scope
 	global := f.global
+	force := f.force
 	useTUIForModal := !explicitFlags && useTUI
 	if useTUIForModal {
-		plats, scp, glob, ok, err := promptInstallTargets(app, adapterList, skill)
+		res, ok, err := promptInstallTargets(app, adapterList, skill)
 		if err != nil {
 			return err
 		}
@@ -164,9 +166,13 @@ func runInstall(app *App, skill string, f installFlags, fromDashboard bool) erro
 			}
 			return fmt.Errorf("install cancelled")
 		}
-		platforms = plats
-		scope = scp
-		global = glob
+		platforms = res.Platforms
+		scope = res.Scope
+		global = res.Global
+		// The modal offers the same force toggle the flag does, so the TUI can
+		// reach every install the CLI can. --force on the command line still
+		// wins if it was passed.
+		force = force || res.Force
 	} else {
 		scope, global, err = resolveInstallScope(f, p)
 		if err != nil {
@@ -185,6 +191,22 @@ func runInstall(app *App, skill string, f installFlags, fromDashboard bool) erro
 	plan, err := install.Plan(target.Reg, skill)
 	if err != nil {
 		return err
+	}
+
+	// --force is what bypasses the preserve list, so it's the one install flag
+	// that can destroy user data. Name the files first and make the user agree.
+	if force {
+		names := make([]string, 0, len(plan))
+		for _, s := range plan {
+			names = append(names, s.Skill.Name)
+		}
+		if err := confirmForce(app, "install --force", names); err != nil {
+			if errors.Is(err, errCancelled) {
+				app.UI.Info("cancelled")
+				return nil
+			}
+			return err
+		}
 	}
 
 	engine := app.installEngineForToken(target.Token)
@@ -206,7 +228,7 @@ func runInstall(app *App, skill string, f installFlags, fromDashboard bool) erro
 			Adapters:     adapterList,
 			Platforms:    selected,
 			Scope:        scope,
-			Force:        f.force,
+			Force:        force,
 			Global:       global,
 			OnEvent:      sink,
 			RegistryName: target.Name,
@@ -315,7 +337,7 @@ func printInstall(app *App, r install.Result) {
 		app.UI.Warn("nothing to do - skill(s) declared no matching platforms")
 		return
 	}
-	var installed, replaced, skipped, forced []install.TargetResult
+	var installed, replaced, skipped, forced, linked []install.TargetResult
 	for _, t := range r.Results {
 		switch t.Outcome {
 		case install.OutcomeInstalled:
@@ -326,6 +348,8 @@ func printInstall(app *App, r install.Result) {
 			skipped = append(skipped, t)
 		case install.OutcomeForced:
 			forced = append(forced, t)
+		case install.OutcomeLinked:
+			linked = append(linked, t)
 		}
 	}
 	for _, t := range installed {
@@ -337,10 +361,15 @@ func printInstall(app *App, r install.Result) {
 	for _, t := range forced {
 		app.UI.Success("reinstalled %s → %s [%s/%s]", t.Skill, t.Path, t.Platform, t.Scope)
 	}
+	// "linked" is deliberately worded so nobody reads it as a content change:
+	// the skill was already current, this run only added a platform.
+	for _, t := range linked {
+		app.UI.Success("linked %s → %s [%s/%s] (no content change)", t.Skill, t.Path, t.Platform, t.Scope)
+	}
 	for _, t := range skipped {
 		app.UI.Detail("already up-to-date: %s [%s/%s]", t.Skill, t.Platform, t.Scope)
 	}
-	if len(installed)+len(replaced)+len(forced) == 0 {
+	if len(installed)+len(replaced)+len(forced)+len(linked) == 0 {
 		app.UI.Info("%d target%s already up-to-date (use --force to reinstall)", len(skipped), textutil.Plural(len(skipped)))
 	}
 	for _, t := range r.Results {
@@ -353,10 +382,10 @@ func printInstall(app *App, r install.Result) {
 
 // promptInstallTargets opens a huh modal asking the user which platforms to
 // install `skill` into (defaults come from profile), returning the confirmed
-// platforms + scope. If the user picks "edit profile" inside the modal, the
+// platforms, scope and force toggle. If the user picks "edit profile" inside the modal, the
 // profile editor opens and the modal re-prompts with the updated defaults.
 // Returns ok=false if the user cancelled.
-func promptInstallTargets(app *App, adapterList []adapters.Adapter, skill string) ([]string, string, bool, bool, error) {
+func promptInstallTargets(app *App, adapterList []adapters.Adapter, skill string) (tui.InstallModalResult, bool, error) {
 	detected := map[string]bool{}
 	for _, r := range adapters.Detect(adapterList) {
 		detected[r.Name] = r.Detected
@@ -364,22 +393,22 @@ func promptInstallTargets(app *App, adapterList []adapters.Adapter, skill string
 	for {
 		p, err := profile.Load(app.Config.ProfilePath)
 		if err != nil {
-			return nil, "", false, false, err
+			return tui.InstallModalResult{}, false, err
 		}
 		res, err := tui.RunInstallPlatformModal(app.UI.Theme(), skill, adapterList, detected, p)
 		if err != nil {
-			return nil, "", false, false, err
+			return tui.InstallModalResult{}, false, err
 		}
 		if res.EditProfile {
 			if err := runProfileEditor(app); err != nil {
-				return nil, "", false, false, err
+				return tui.InstallModalResult{}, false, err
 			}
 			continue
 		}
 		if !res.Confirmed {
-			return nil, "", false, false, nil
+			return tui.InstallModalResult{}, false, nil
 		}
-		return res.Platforms, res.Scope, res.Global, true, nil
+		return res, true, nil
 	}
 }
 

--- a/cli/cmd/humblskills/skillset.go
+++ b/cli/cmd/humblskills/skillset.go
@@ -16,7 +16,6 @@ import (
 	"github.com/jjfantini/humblSKILLS/cli/internal/secrets"
 	"github.com/jjfantini/humblSKILLS/cli/internal/skillset"
 	"github.com/jjfantini/humblSKILLS/cli/internal/textutil"
-	"github.com/jjfantini/humblSKILLS/cli/internal/tui"
 )
 
 // --- init -------------------------------------------------------------------
@@ -256,6 +255,18 @@ func runSync(app *App, path string, f installFlags, prune bool) error {
 
 	names := set.Names()
 	sort.Strings(names)
+
+	// Same gate as `install --force`: a sync that reinstalls cleanly wipes
+	// preserved files on every skill it touches, not just one.
+	if f.force {
+		if err := confirmForce(app, "sync --force", names); err != nil {
+			if errors.Is(err, errCancelled) {
+				app.UI.Info("cancelled")
+				return nil
+			}
+			return err
+		}
+	}
 	for _, name := range names {
 		matches := allRegistriesForSkill(loaded, name)
 		if len(matches) == 0 {
@@ -450,27 +461,32 @@ func pruneToSkillset(app *App, set *skillset.Set) ([]install.TargetResult, error
 	}
 	sort.Strings(extra)
 
-	if !app.Config.Yes && !app.Config.JSON {
-		theme := app.UI.Theme()
-		lines := make([]string, 0, len(extra))
-		for _, name := range extra {
-			lines = append(lines, theme.Name.Render(name))
+	theme := app.UI.Theme()
+	lines := make([]string, 0, len(extra)*3)
+	var entries []*manifest.Installation
+	for _, name := range extra {
+		lines = append(lines, theme.Name.Render(name))
+		entries = append(entries, m.FindAll(name)...)
+	}
+	// Prune is uninstall in bulk, so it destroys the same preserved memory
+	// files an uninstall does. Name them rather than just counting skills.
+	atRisk := preservedAcrossStores(entries)
+	for _, name := range extra {
+		for _, p := range atRisk[name] {
+			lines = append(lines, "  "+theme.Warn.Render("deletes")+"  "+theme.Detail.Render(p))
 		}
-		ok, err := tui.ConfirmWithSummary(
-			theme,
-			"Prune skills not in the skillset",
-			fmt.Sprintf("Uninstall %d skill%s not listed in the skillset?", len(extra), textutil.Plural(len(extra))),
-			lines,
-			false,
-			app.Prompt.Interactive,
-		)
-		if err != nil {
-			return nil, err
-		}
-		if !ok {
+	}
+	if err := confirmDestructive(app,
+		"Prune skills not in the skillset",
+		fmt.Sprintf("Uninstall %d skill%s not listed in the skillset?", len(extra), textutil.Plural(len(extra))),
+		flattenPreserved(atRisk, "deletes"),
+		lines,
+	); err != nil {
+		if errors.Is(err, errCancelled) {
 			app.UI.Info("prune cancelled — installed skills left untouched")
 			return nil, nil
 		}
+		return nil, err
 	}
 
 	engine := app.installEngine()

--- a/cli/cmd/humblskills/uninstall.go
+++ b/cli/cmd/humblskills/uninstall.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -85,7 +86,7 @@ func runUninstall(app *App, skill string) error {
 	}
 
 	theme := app.UI.Theme()
-	lines := make([]string, 0, len(entries))
+	lines := make([]string, 0, len(entries)+4)
 	for _, e := range entries {
 		lines = append(lines, fmt.Sprintf(
 			"%s  %s  %s",
@@ -94,24 +95,29 @@ func runUninstall(app *App, skill string) error {
 			theme.Detail.Render(e.Path),
 		))
 	}
-	ok := true
-	if !app.Config.Yes && !app.Config.JSON {
-		got, err := tui.ConfirmWithSummary(
-			theme,
-			fmt.Sprintf("Uninstall %s", skill),
-			fmt.Sprintf("Remove %d target%s?", len(entries), textutil.Plural(len(entries))),
-			lines,
-			true,
-			app.Prompt.Interactive,
-		)
-		if err != nil {
-			return err
+	// Uninstall deletes the canonical store once no target references it, and
+	// the store is where the skill's user-owned memory lives. Naming those
+	// files is the difference between an informed yes and a surprise.
+	atRisk := preservedAcrossStores(entries)
+	for _, paths := range atRisk {
+		lines = append(lines, "")
+		lines = append(lines, theme.Warn.Render("deletes user-owned files:"))
+		for _, p := range paths {
+			lines = append(lines, "  "+theme.Detail.Render(p))
 		}
-		ok = got
 	}
-	if !ok {
-		app.UI.Info("cancelled")
-		return nil
+
+	if err := confirmDestructive(app,
+		fmt.Sprintf("Uninstall %s", skill),
+		fmt.Sprintf("Remove %d target%s?", len(entries), textutil.Plural(len(entries))),
+		flattenPreserved(atRisk, "deletes"),
+		lines,
+	); err != nil {
+		if errors.Is(err, errCancelled) {
+			app.UI.Info("cancelled")
+			return nil
+		}
+		return err
 	}
 
 	engine := app.installEngine()

--- a/cli/cmd/humblskills/uninstall_test.go
+++ b/cli/cmd/humblskills/uninstall_test.go
@@ -177,3 +177,156 @@ func TestUninstall_PreservesOtherSkills(t *testing.T) {
 		t.Errorf("expected only bar remaining: %+v", m.Installations)
 	}
 }
+
+// preserveSkillMD declares user-owned memory files, the thing every
+// destructive path in this CLI has to stop and ask about.
+const preserveSkillMD = `---
+name: foo
+description: Example skill with user-owned memory
+metadata:
+  version: 1.0.0
+  preserve:
+    - references/log.md
+---
+
+# foo
+`
+
+// installFooWithMemory installs `foo` globally and writes real content into its
+// preserved file, returning (registry URL, canonical store path).
+func installFooWithMemory(t *testing.T, s *testutil.Sandbox) (string, string) {
+	t.Helper()
+	enableClaudeCode(t, s)
+	enableCodex(t, s)
+
+	regURL := seedTestRegistry(t, s, []testutil.SkillFixture{{
+		Name: "foo", Version: "1.0.0",
+		Files: testutil.SkillTree{
+			"SKILL.md":          preserveSkillMD,
+			"references/log.md": "seed\n",
+		},
+	}})
+	res := runCLIWithStdoutCapture(t,
+		"install", "foo",
+		"--registry", regURL,
+		"--cache-dir", s.CacheDir,
+		"--manifest", s.ManifestPath,
+		"--platform", "claude-code",
+		"--global",
+		"--yes", "--json",
+	)
+	if res.RunErr != nil {
+		t.Fatalf("install failed: %v\n%s", res.RunErr, res.Err)
+	}
+	m, _ := manifest.Load(s.ManifestPath)
+	if len(m.Installations) == 0 {
+		t.Fatal("precondition: expected an install")
+	}
+	store := m.Installations[0].StorePath
+	if store == "" {
+		t.Fatal("precondition: expected a canonical store")
+	}
+	if err := os.WriteFile(filepath.Join(store, "references", "log.md"),
+		[]byte("seed\n[SESSION] user work\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return regURL, store
+}
+
+// A non-interactive uninstall used to delete everything on an implied yes.
+// Now it refuses, names the files it would have destroyed, and changes nothing.
+func TestUninstall_NonInteractiveRequiresYes(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	_, store := installFooWithMemory(t, s)
+
+	res := runCLIWithStdoutCapture(t,
+		"uninstall", "foo",
+		"--manifest", s.ManifestPath,
+		"--cache-dir", s.CacheDir,
+		"--json",
+	)
+	if res.RunErr == nil {
+		t.Fatal("uninstall without --yes must not proceed non-interactively")
+	}
+	msg := res.RunErr.Error()
+	if !strings.Contains(msg, "--yes") {
+		t.Errorf("error should name the flag to pass, got %q", msg)
+	}
+	if !strings.Contains(msg, "references/log.md") {
+		t.Errorf("error should name the user-owned file at risk, got %q", msg)
+	}
+	if _, err := os.Stat(filepath.Join(store, "references", "log.md")); err != nil {
+		t.Errorf("refused uninstall must not delete anything: %v", err)
+	}
+	m, _ := manifest.Load(s.ManifestPath)
+	if len(m.Installations) == 0 {
+		t.Error("refused uninstall must leave the manifest alone")
+	}
+}
+
+// --force is the documented way to discard local content, so it must also be
+// gated: same rule, same error, nothing touched.
+func TestInstallForce_NonInteractiveRequiresYes(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	regURL, store := installFooWithMemory(t, s)
+	logPath := filepath.Join(store, "references", "log.md")
+	before, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	res := runCLIWithStdoutCapture(t,
+		"install", "foo", "--force",
+		"--registry", regURL,
+		"--cache-dir", s.CacheDir,
+		"--manifest", s.ManifestPath,
+		"--platform", "claude-code",
+		"--global",
+		"--json",
+	)
+	if res.RunErr == nil {
+		t.Fatal("install --force without --yes must not proceed non-interactively")
+	}
+	if !strings.Contains(res.RunErr.Error(), "references/log.md") {
+		t.Errorf("error should name what --force discards, got %q", res.RunErr.Error())
+	}
+	after, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(after) != string(before) {
+		t.Error("refused --force must not overwrite preserved content")
+	}
+}
+
+// Adding a platform to an installed skill is not destructive, so it must NOT
+// require --yes and must not disturb preserved content.
+func TestInstall_AddPlatformNeedsNoConfirmation(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	regURL, store := installFooWithMemory(t, s)
+	logPath := filepath.Join(store, "references", "log.md")
+	before, _ := os.ReadFile(logPath)
+
+	res := runCLIWithStdoutCapture(t,
+		"install", "foo",
+		"--registry", regURL,
+		"--cache-dir", s.CacheDir,
+		"--manifest", s.ManifestPath,
+		"--platform", "codex",
+		"--global",
+		"--json",
+	)
+	if res.RunErr != nil {
+		t.Fatalf("adding a platform should just work: %v\n%s", res.RunErr, res.Err)
+	}
+	assertContains(t, res.Out, `"outcome": "linked"`)
+
+	after, _ := os.ReadFile(logPath)
+	if string(after) != string(before) {
+		t.Errorf("platform add overwrote preserved content:\n got %q\nwant %q", after, before)
+	}
+	m, _ := manifest.Load(s.ManifestPath)
+	if len(m.Installations) != 2 {
+		t.Errorf("want an entry per platform, got %+v", m.Installations)
+	}
+}

--- a/cli/cmd/humblskills/update.go
+++ b/cli/cmd/humblskills/update.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -21,6 +22,9 @@ type updateFlags struct {
 	all   bool
 	check bool
 	force bool
+	// platforms reconciles each installed skill against the profile's
+	// default_platforms, adding any it doesn't target yet.
+	platforms bool
 }
 
 // regUpdatePlan records which registry (document + token + name) an update plan
@@ -42,14 +46,18 @@ func newUpdateCmd(app *App) *cobra.Command {
 			"--check prints the diff and exits without changing anything. " +
 			"By default, the preserve list on each installed SKILL.md is honored so " +
 			"your local customizations survive. --force ignores local preserve edits " +
-			"and reinstalls cleanly from the registry (equivalent to uninstall + install).",
+			"and reinstalls cleanly from the registry (equivalent to uninstall + install), " +
+			"and asks for confirmation first. --platforms additionally adds any platform " +
+			"in your profile's default_platforms that a skill doesn't target yet; that is " +
+			"a symlink plus a manifest entry, with no refetch when the skill is current.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runUpdate(app, args, f)
 		},
 	}
 	cmd.Flags().BoolVar(&f.all, "all", false, "update every drifted skill without prompting")
 	cmd.Flags().BoolVar(&f.check, "check", false, "print what would change and exit")
-	cmd.Flags().BoolVar(&f.force, "force", false, "bypass local preserve edits; reinstall cleanly from registry")
+	cmd.Flags().BoolVar(&f.force, "force", false, "bypass local preserve edits; reinstall cleanly from registry (asks to confirm)")
+	cmd.Flags().BoolVar(&f.platforms, "platforms", false, "also add missing platforms from your profile's default_platforms (symlink only)")
 	return cmd
 }
 
@@ -76,6 +84,21 @@ func runUpdate(app *App, only []string, f updateFlags) error {
 	})
 	if err != nil {
 		return err
+	}
+
+	// --platforms turns the profile's default_platforms into the target set every
+	// installed skill should cover, so adding a platform to the profile and
+	// running update is enough to backfill it everywhere.
+	var wantPlatforms []string
+	if f.platforms {
+		p, err := profile.Load(app.Config.ProfilePath)
+		if err != nil {
+			return err
+		}
+		wantPlatforms = p.DefaultPlatforms
+		if len(wantPlatforms) == 0 {
+			app.UI.Warn("--platforms needs default_platforms in your profile — run 'humblskills profile' to set them")
+		}
 	}
 
 	// Plan updates per ORIGIN registry so each installed skill is checked (and
@@ -107,7 +130,7 @@ func runUpdate(app *App, only []string, f updateFlags) error {
 			continue // registry unavailable/unknown — skip its installs
 		}
 		fm := &manifest.Manifest{SchemaVersion: m.SchemaVersion, Installations: insts}
-		for _, pl := range install.PlanUpdates(rs.Reg, fm, only) {
+		for _, pl := range install.PlanUpdatesFor(rs.Reg, fm, only, wantPlatforms) {
 			bySkill[pl.Skill] = regUpdatePlan{reg: rs.Reg, token: rs.Token, name: name}
 			plans = append(plans, pl)
 		}
@@ -119,21 +142,41 @@ func runUpdate(app *App, only []string, f updateFlags) error {
 	}
 
 	if len(plans) == 0 {
-		if len(only) > 0 {
+		switch {
+		case len(only) > 0:
 			app.UI.Info("selected skills are already up-to-date")
-		} else {
+		case f.platforms:
+			app.UI.Info("all skills are up-to-date and cover every platform in your profile")
+		default:
 			app.UI.Info("all skills are up-to-date")
 		}
 		return nil
 	}
 
-	selected, err := chooseUpdates(app, plans, f.all)
+	selected, forceOne, err := chooseUpdates(app, plans, f.all)
 	if err != nil {
 		return err
 	}
+	force := f.force || forceOne
 	if len(selected) == 0 {
 		app.UI.Info("nothing selected")
 		return nil
+	}
+
+	// --force here means "ignore my local preserve edits", which is the one
+	// update mode that destroys content. Confirm against the real file list.
+	if force {
+		names := make([]string, 0, len(selected))
+		for _, pl := range selected {
+			names = append(names, pl.Skill)
+		}
+		if err := confirmForce(app, "update --force", names); err != nil {
+			if errors.Is(err, errCancelled) {
+				app.UI.Info("cancelled")
+				return nil
+			}
+			return err
+		}
 	}
 
 	adapters, err := app.Adapters()
@@ -188,6 +231,28 @@ func runUpdate(app *App, only []string, f updateFlags) error {
 				return groups[i].scope < groups[j].scope
 			})
 
+			// Backfilled platforms join an existing group rather than forming
+			// their own, so one Execute call covers "refresh this skill" and
+			// "also link it here". Two calls would fetch twice and, worse, the
+			// second would see the store mid-refresh.
+			if len(plan.AddPlatforms) > 0 {
+				add := make([]string, 0, len(plan.AddPlatforms))
+				for _, p := range plan.AddPlatforms {
+					if _, ok := adapterKnown[p]; !ok {
+						app.UI.Warn("skipping unknown platform %q for %s", p, plan.Skill)
+						continue
+					}
+					add = append(add, p)
+				}
+				if len(groups) == 0 {
+					if len(add) > 0 {
+						app.UI.Warn("skipping %s: no known platform to anchor %v to", plan.Skill, add)
+					}
+				} else {
+					byGroup[groups[0]] = append(byGroup[groups[0]], add...)
+				}
+			}
+
 			for _, group := range groups {
 				plats := byGroup[group]
 				sort.Strings(plats)
@@ -195,7 +260,7 @@ func runUpdate(app *App, only []string, f updateFlags) error {
 					Adapters:     adapters,
 					Platforms:    plats,
 					Scope:        group.scope,
-					Force:        f.force,
+					Force:        force,
 					Global:       group.global,
 					OnEvent:      sink,
 					RegistryName: rp.name,
@@ -238,12 +303,12 @@ func runUpdate(app *App, only []string, f updateFlags) error {
 // inspect each drifted skill before applying. Non-interactive (pipe, --json)
 // returns every plan so scripts that don't pass --all still work — matching
 // the pre-refactor behaviour.
-func chooseUpdates(app *App, plans []install.UpdatePlan, all bool) ([]install.UpdatePlan, error) {
+func chooseUpdates(app *App, plans []install.UpdatePlan, all bool) ([]install.UpdatePlan, bool, error) {
 	if all || app.Config.Yes {
-		return plans, nil
+		return plans, false, nil
 	}
 	if !tui.ShouldUseTUI(app.Config.JSON, app.Config.Quiet, app.Config.Yes) {
-		return plans, nil
+		return plans, false, nil
 	}
 
 	items := make([]tui.Item, 0, len(plans))
@@ -274,24 +339,27 @@ func chooseUpdates(app *App, plans []install.UpdatePlan, all bool) ([]install.Up
 		Actions: []tui.ActionSpec{
 			{Key: "u", Label: "apply all", Action: "all"},
 			{Key: "enter", Label: "apply one", Action: "one"},
+			{Key: "f", Label: "force one", Action: "force"},
 		},
 		EmptyMsg: "all skills are up-to-date",
 	})
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
 	switch res.Action {
 	case "all":
-		return plans, nil
-	case "one":
+		return plans, false, nil
+	case "one", "force":
 		it, ok := res.Item.(updatePlanItem)
 		if !ok {
-			return nil, nil
+			return nil, false, nil
 		}
-		return []install.UpdatePlan{it.p}, nil
+		// "force one" is the TUI's counterpart to `update --force <skill>`;
+		// runUpdate still routes it through the confirmation gate.
+		return []install.UpdatePlan{it.p}, res.Action == "force", nil
 	}
-	return nil, nil
+	return nil, false, nil
 }
 
 // updatePlanItem adapts install.UpdatePlan to tui.Item.
@@ -302,22 +370,48 @@ func (u updatePlanItem) FilterValue() string {
 	return strings.ToLower(u.p.Skill)
 }
 func (u updatePlanItem) NaturalWidth(th *ui.Theme) int {
+	if u.p.LinkOnly {
+		what := "link " + strings.Join(u.p.AddPlatforms, ", ")
+		badge := tui.Badge(th, tui.BadgeRO, "no content change")
+		return 1 + 1 + lipgloss.Width(u.p.Skill) + 2 + lipgloss.Width(what) + 2 + lipgloss.Width(badge)
+	}
 	ver := u.p.FromVersion + " → " + u.p.ToVersion
 	badge := tui.Badge(th, tui.BadgeRO, fmt.Sprintf("%d target%s", len(u.p.Targets), textutil.Plural(len(u.p.Targets))))
 	// 1 (arrow) + 1 (space) + skill + 2 (gap) + version + 2 (gap) + badge.
 	return 1 + 1 + lipgloss.Width(u.p.Skill) + 2 + lipgloss.Width(ver) + 2 + lipgloss.Width(badge)
 }
 func (u updatePlanItem) Row(th *ui.Theme, width int, selected bool) string {
-	arrow := th.DotWarn.Render("↑")
 	name := rowName(th, u.p.Skill, selected, true)
+	// A link-only plan changes no content, so it must not borrow the visual
+	// language of an upgrade: no ↑, no version transition.
+	if u.p.LinkOnly {
+		arrow := th.DotOK.Render("+")
+		what := th.Version.Render("link " + strings.Join(u.p.AddPlatforms, ", "))
+		badge := tui.Badge(th, tui.BadgeRO, "no content change")
+		return rowWithTrailingBadge(arrow+" "+name+"  "+what, badge, width)
+	}
+	arrow := th.DotWarn.Render("↑")
 	ver := th.Version.Render(u.p.FromVersion + " → " + u.p.ToVersion)
-	badge := tui.Badge(th, tui.BadgeRO, fmt.Sprintf("%d target%s", len(u.p.Targets), textutil.Plural(len(u.p.Targets))))
+	label := fmt.Sprintf("%d target%s", len(u.p.Targets), textutil.Plural(len(u.p.Targets)))
+	if len(u.p.AddPlatforms) > 0 {
+		label += " +" + strings.Join(u.p.AddPlatforms, " +")
+	}
+	badge := tui.Badge(th, tui.BadgeRO, label)
 	return rowWithTrailingBadge(arrow+" "+name+"  "+ver, badge, width)
 }
 func (u updatePlanItem) Detail(th *ui.Theme, width int) string {
 	var sb strings.Builder
-	sb.WriteString(th.DetailTitle.Render(u.p.Skill) + "  " +
-		th.DetailSub.Render("v"+u.p.FromVersion+" → v"+u.p.ToVersion) + "\n\n")
+	sub := "v" + u.p.FromVersion + " → v" + u.p.ToVersion
+	if u.p.LinkOnly {
+		sub = "v" + u.p.FromVersion + " (already current)"
+	}
+	sb.WriteString(th.DetailTitle.Render(u.p.Skill) + "  " + th.DetailSub.Render(sub) + "\n\n")
+	if len(u.p.AddPlatforms) > 0 {
+		sb.WriteString(kvRow(th, "add platforms", th.Platform.Render(strings.Join(u.p.AddPlatforms, "  "))))
+		sb.WriteString(kvRow(th, "changes files", th.KVValue.Render(map[bool]string{
+			true: "no — symlink + manifest only", false: "yes — content refresh",
+		}[u.p.LinkOnly])))
+	}
 	if u.p.RenamedFrom != "" {
 		sb.WriteString(kvRow(th, "renamed from", th.KVValue.Render(u.p.RenamedFrom)))
 	}
@@ -350,7 +444,13 @@ func printUpdateCheck(app *App, plans []install.UpdatePlan) error {
 		app.UI.Info("all skills are up-to-date")
 		return nil
 	}
-	app.UI.Info("%d skill%s can be updated:", len(plans), textutil.Plural(len(plans)))
+	app.UI.Info("%d skill%s to act on:", len(plans), textutil.Plural(len(plans)))
+	// Println, not Detail: --check exists to show this list, and Detail is
+	// verbose-only — so the list was invisible unless you also passed -v.
+	th := app.UI.Theme()
+	line := func(format string, args ...any) {
+		app.UI.Println(th.Detail.Render(fmt.Sprintf(format, args...)))
+	}
 	for _, p := range plans {
 		name := p.Skill
 		if p.RenamedFrom != "" {
@@ -358,8 +458,19 @@ func printUpdateCheck(app *App, plans []install.UpdatePlan) error {
 			// and a silent swap looks like an unrelated install.
 			name = p.RenamedFrom + " → " + p.Skill
 		}
-		app.UI.Detail("  %s  %s → %s  (%d target%s)",
-			name, p.FromVersion, p.ToVersion, len(p.Targets), textutil.Plural(len(p.Targets)))
+		// Never print a version transition for a plan that changes no content:
+		// "1.0.0 → 1.0.0" reads as a bug, and the real work is the link.
+		if p.LinkOnly {
+			line("  %s  link only  (+%s, no content change)",
+				name, strings.Join(p.AddPlatforms, " +"))
+			continue
+		}
+		extra := ""
+		if len(p.AddPlatforms) > 0 {
+			extra = ", +" + strings.Join(p.AddPlatforms, " +")
+		}
+		line("  %s  %s → %s  (%d target%s%s)",
+			name, p.FromVersion, p.ToVersion, len(p.Targets), textutil.Plural(len(p.Targets)), extra)
 	}
 	return nil
 }

--- a/cli/cmd/humblskills/update_test.go
+++ b/cli/cmd/humblskills/update_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/jjfantini/humblSKILLS/cli/internal/manifest"
+	"github.com/jjfantini/humblSKILLS/cli/internal/profile"
 	"github.com/jjfantini/humblSKILLS/cli/internal/testutil"
 )
 
@@ -224,4 +225,80 @@ func TestUpdate_OnlyNamedSkillUpToDate(t *testing.T) {
 	if !strings.Contains(res.Out+res.Err, "up-to-date") {
 		t.Errorf("expected up-to-date message, got:\n%s", res.Out+res.Err)
 	}
+}
+
+// `update --platforms` is the CLI half of profile-driven backfill: add a
+// platform to the profile, run update, and every installed skill gains it —
+// as a symlink, with no content change and no refetch.
+func TestUpdate_PlatformsBackfillsFromProfile(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	regURL, store := installFooWithMemory(t, s)
+	logPath := filepath.Join(store, "references", "log.md")
+	before, _ := os.ReadFile(logPath)
+
+	if err := profile.Save(s.ProfilePath, &profile.Profile{
+		DefaultPlatforms: []string{"claude-code", "codex"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// --check first: it must describe the work without implying an upgrade.
+	chk := runCLIWithStdoutCapture(t,
+		"update", "--check", "--platforms",
+		"--registry", regURL,
+		"--cache-dir", s.CacheDir,
+		"--manifest", s.ManifestPath,
+		"--profile", s.ProfilePath,
+	)
+	if chk.RunErr != nil {
+		t.Fatalf("update --check --platforms: %v\n%s", chk.RunErr, chk.Err)
+	}
+	assertContains(t, chk.Out+chk.Err, "link only")
+	assertContains(t, chk.Out+chk.Err, "codex")
+	assertNotContains(t, chk.Out+chk.Err, "1.0.0 → 1.0.0")
+
+	// --check must not have changed anything.
+	if m, _ := manifest.Load(s.ManifestPath); len(m.Installations) != 1 {
+		t.Fatalf("--check must not install: %+v", m.Installations)
+	}
+
+	res := runCLIWithStdoutCapture(t,
+		"update", "--platforms", "--all",
+		"--registry", regURL,
+		"--cache-dir", s.CacheDir,
+		"--manifest", s.ManifestPath,
+		"--profile", s.ProfilePath,
+		"--json",
+	)
+	if res.RunErr != nil {
+		t.Fatalf("update --platforms: %v\n%s", res.RunErr, res.Err)
+	}
+	assertContains(t, res.Out, `"outcome": "linked"`)
+
+	m, _ := manifest.Load(s.ManifestPath)
+	plats := map[string]bool{}
+	for _, inst := range m.Installations {
+		plats[inst.Platform] = true
+	}
+	if !plats["claude-code"] || !plats["codex"] {
+		t.Errorf("backfill did not cover the profile platforms: %+v", m.Installations)
+	}
+
+	after, _ := os.ReadFile(logPath)
+	if string(after) != string(before) {
+		t.Errorf("backfill overwrote preserved content:\n got %q\nwant %q", after, before)
+	}
+
+	// Second run: nothing left to do, and it says so without inventing drift.
+	again := runCLIWithStdoutCapture(t,
+		"update", "--platforms", "--all",
+		"--registry", regURL,
+		"--cache-dir", s.CacheDir,
+		"--manifest", s.ManifestPath,
+		"--profile", s.ProfilePath,
+	)
+	if again.RunErr != nil {
+		t.Fatalf("idempotent re-run failed: %v\n%s", again.RunErr, again.Err)
+	}
+	assertContains(t, again.Out+again.Err, "every platform in your profile")
 }

--- a/cli/internal/install/engine.go
+++ b/cli/internal/install/engine.go
@@ -27,6 +27,11 @@ const (
 	OutcomeSkipped Outcome = "skipped"
 	// OutcomeForced means --force replaced an up-to-date target anyway.
 	OutcomeForced Outcome = "forced"
+	// OutcomeLinked means the canonical store already held this exact registry
+	// revision, so the target was symlinked to it and the manifest updated
+	// without fetching or rewriting any content. This is what adding a platform
+	// to an already-installed skill does.
+	OutcomeLinked Outcome = "linked"
 )
 
 // TargetResult is the outcome of installing one skill onto one adapter+scope.
@@ -312,7 +317,7 @@ func (e *Engine) installOne(
 		} else if !targetLinksToStore(pg.final, storePath) {
 			upToDate = false
 		}
-		if _, err := os.Stat(filepath.Join(storePath, "SKILL.md")); err != nil {
+		if !storeHasSkill(storePath) {
 			upToDate = false
 		}
 
@@ -365,70 +370,36 @@ func (e *Engine) installOne(
 		}
 	}
 
+	// Every platform for one skill shares a single canonical store, so adding a
+	// NEW platform finds that store already populated even though every
+	// per-adapter lookup above missed. Without this fallback the freshly
+	// fetched tree overwrites the store and silently discards the user's
+	// metadata.preserve files (references/log.md and friends) — data loss with
+	// --force never passed.
+	if preserveSource == "" && storeHasSkill(storePath) {
+		preserveSource = storePath
+	}
+
 	if len(toWrite) == 0 {
 		return skipped, nil
 	}
 
-	staging := filepath.Join(e.StagingDir, skill.Name+"-"+shortSHA(reg.Source.SHA))
-	if err := os.RemoveAll(staging); err != nil {
-		return nil, fmt.Errorf("clean staging: %w", err)
-	}
-
-	tarPath, err := e.Fetcher.Fetch(reg.Source.Repo, reg.Source.SHA)
-	if err != nil {
-		return nil, err
-	}
-	if err := fetch.Extract(tarPath, skill.Path, staging); err != nil {
-		return nil, fmt.Errorf("extract: %w", err)
-	}
-
-	gotSHA, err := registry.DirSHA(staging)
-	if err != nil {
-		return nil, fmt.Errorf("hash staging: %w", err)
-	}
-	if gotSHA != skill.DirSHA {
-		return nil, fmt.Errorf("dir_sha mismatch for %s: want %s got %s", skill.Name, skill.DirSHA, gotSHA)
-	}
-
-	writeSrc := staging
-	if preserveSource != "" && !opts.Force {
-		preserveList, userOwnsPreserve, err := e.preserveListForStore(skill, preserveSource, toWrite, opts)
-		if err != nil {
+	// When the store already holds this exact registry revision, the only thing
+	// these targets lack is a symlink. Refetching would rewrite a directory
+	// full of live user data to arrive at content that's already there, so link
+	// straight off the store and touch nothing. This is the common case for
+	// "I installed a new agent and want my skills on it too".
+	linkOnly := !opts.Force && storeIsCurrent(m, skill, storePath)
+	if !linkOnly {
+		if err := e.refreshStore(reg, skill, storePath, preserveSource, renamedFrom, toWrite, opts); err != nil {
 			return nil, err
 		}
-		if len(preserveList) > 0 || userOwnsPreserve {
-			perStore := filepath.Join(e.StagingDir, skill.Name+"-"+shortSHA(reg.Source.SHA)+"-store")
-			if err := os.RemoveAll(perStore); err != nil {
-				return nil, fmt.Errorf("clean store staging: %w", err)
-			}
-			defer os.RemoveAll(perStore)
-			if err := fsutil.CopyTree(staging, perStore, fsutil.Options{RejectSymlinks: true}); err != nil {
-				return nil, fmt.Errorf("copy store staging: %w", err)
-			}
-			if len(preserveList) > 0 {
-				if err := applyPreserve(preserveSource, perStore, preserveList); err != nil {
-					return nil, err
-				}
-			}
-			if userOwnsPreserve {
-				skillMDPath := filepath.Join(perStore, "SKILL.md")
-				if err := mergePreserveIntoSkillMD(skillMDPath, preserveList); err != nil {
-					return nil, fmt.Errorf("merge preserve into SKILL.md: %w", err)
-				}
-			}
-			writeSrc = perStore
-			if renamedFrom != "" {
-				opts.OnEvent.emit(Event{
-					Phase: PhaseWarn, Skill: skill.Name,
-					Msg: fmt.Sprintf("renamed from %s — carried over preserved data (%s)",
-						renamedFrom, strings.Join(preserveList, ", ")),
-				})
-			}
-		}
-	}
-
-	if err := replaceDir(writeSrc, storePath); err != nil {
-		return nil, fmt.Errorf("place canonical store %s: %w", storePath, err)
+		// Sibling targets on other platforms point at this same store, so the
+		// refresh moved them to the new revision too. Leaving their manifest
+		// rows behind makes `list` report a version that's no longer on disk
+		// and makes `update` re-plan work that is already done. Zip targets are
+		// excluded: their artifact really is stale until regenerated.
+		m.RefreshStoreRevision(storePath, skill.Version, reg.Source.SHA, skill.DirSHA, InstallModeZip)
 	}
 
 	results := append([]TargetResult(nil), skipped...)
@@ -443,13 +414,23 @@ func (e *Engine) installOne(
 			}
 		}
 		targetMode := mode
+		out := pt.out
 		if pt.pending.adapter.Transform == adapters.TransformZip {
 			targetMode = InstallModeZip
 			if err := WriteSkillZip(storePath, skill.Name, pt.pending.final); err != nil {
 				return nil, fmt.Errorf("zip %s -> %s: %w", storePath, pt.pending.final, err)
 			}
-		} else if err := linkStore(storePath, pt.pending.final); err != nil {
-			return nil, fmt.Errorf("link %s -> %s: %w", pt.pending.final, storePath, err)
+		} else {
+			if err := linkStore(storePath, pt.pending.final); err != nil {
+				return nil, fmt.Errorf("link %s -> %s: %w", pt.pending.final, storePath, err)
+			}
+			// Nothing was fetched or rewritten, so "installed"/"replaced" would
+			// overstate what happened: only a symlink appeared. A zip target
+			// keeps its own outcome — the archive really is new bytes on disk,
+			// just derived from the store instead of downloaded.
+			if linkOnly {
+				out = OutcomeLinked
+			}
 		}
 		m.Upsert(manifest.Installation{
 			Skill:        skill.Name,
@@ -471,12 +452,12 @@ func (e *Engine) installOne(
 			Scope:     pt.pending.target.Scope,
 			Path:      pt.pending.final,
 			StorePath: storePath,
-			Outcome:   pt.out,
+			Outcome:   out,
 		})
 		opts.OnEvent.emit(Event{
 			Phase: PhaseTargetDone, Skill: skill.Name, IsDep: step.IsDep,
 			Platform: pt.pending.adapter.Name, Scope: pt.pending.target.Scope,
-			Outcome: pt.out, Path: pt.pending.final, Version: skill.Version, StorePath: storePath,
+			Outcome: out, Path: pt.pending.final, Version: skill.Version, StorePath: storePath,
 		})
 	}
 
@@ -492,6 +473,113 @@ func (e *Engine) installOne(
 		results = append(results, removed...)
 	}
 	return results, nil
+}
+
+// refreshStore fetches the skill at the registry's revision, verifies its
+// content hash, carries user-owned preserved paths over from preserveSource
+// (unless --force), and replaces the canonical store with the result.
+//
+// Split out of installOne so the "store is already current" path can skip all
+// of it — including the network round trip — instead of rewriting a directory
+// full of live user data to reproduce content that's already on disk.
+func (e *Engine) refreshStore(
+	reg *registry.Registry,
+	skill registry.Skill,
+	storePath, preserveSource, renamedFrom string,
+	toWrite []installPlanTarget,
+	opts ExecuteOpts,
+) error {
+	staging := filepath.Join(e.StagingDir, skill.Name+"-"+shortSHA(reg.Source.SHA))
+	if err := os.RemoveAll(staging); err != nil {
+		return fmt.Errorf("clean staging: %w", err)
+	}
+
+	tarPath, err := e.Fetcher.Fetch(reg.Source.Repo, reg.Source.SHA)
+	if err != nil {
+		return err
+	}
+	if err := fetch.Extract(tarPath, skill.Path, staging); err != nil {
+		return fmt.Errorf("extract: %w", err)
+	}
+
+	gotSHA, err := registry.DirSHA(staging)
+	if err != nil {
+		return fmt.Errorf("hash staging: %w", err)
+	}
+	if gotSHA != skill.DirSHA {
+		return fmt.Errorf("dir_sha mismatch for %s: want %s got %s", skill.Name, skill.DirSHA, gotSHA)
+	}
+
+	writeSrc := staging
+	if preserveSource != "" && !opts.Force {
+		preserveList, userOwnsPreserve, err := e.preserveListForStore(skill, preserveSource, toWrite, opts)
+		if err != nil {
+			return err
+		}
+		if len(preserveList) > 0 || userOwnsPreserve {
+			perStore := filepath.Join(e.StagingDir, skill.Name+"-"+shortSHA(reg.Source.SHA)+"-store")
+			if err := os.RemoveAll(perStore); err != nil {
+				return fmt.Errorf("clean store staging: %w", err)
+			}
+			defer os.RemoveAll(perStore)
+			if err := fsutil.CopyTree(staging, perStore, fsutil.Options{RejectSymlinks: true}); err != nil {
+				return fmt.Errorf("copy store staging: %w", err)
+			}
+			if len(preserveList) > 0 {
+				if err := applyPreserve(preserveSource, perStore, preserveList); err != nil {
+					return err
+				}
+			}
+			if userOwnsPreserve {
+				skillMDPath := filepath.Join(perStore, "SKILL.md")
+				if err := mergePreserveIntoSkillMD(skillMDPath, preserveList); err != nil {
+					return fmt.Errorf("merge preserve into SKILL.md: %w", err)
+				}
+			}
+			writeSrc = perStore
+			if renamedFrom != "" {
+				opts.OnEvent.emit(Event{
+					Phase: PhaseWarn, Skill: skill.Name,
+					Msg: fmt.Sprintf("renamed from %s — carried over preserved data (%s)",
+						renamedFrom, strings.Join(preserveList, ", ")),
+				})
+			}
+		}
+	}
+
+	if err := replaceDir(writeSrc, storePath); err != nil {
+		return fmt.Errorf("place canonical store %s: %w", storePath, err)
+	}
+	return nil
+}
+
+// storeHasSkill reports whether storePath holds a real skill (its SKILL.md is
+// readable). Used both to invalidate an up-to-date claim the manifest makes
+// about a store that's gone, and to decide that a store is worth preserving
+// from before it gets replaced.
+func storeHasSkill(storePath string) bool {
+	_, err := os.Stat(filepath.Join(storePath, "SKILL.md"))
+	return err == nil
+}
+
+// storeIsCurrent reports whether the canonical store already holds this exact
+// registry revision, according to any manifest entry pointing at it — on any
+// platform, which is what makes "add a platform" a no-fetch operation.
+//
+// Content hashing deliberately isn't used: a store carrying preserved user
+// edits legitimately differs from the registry's dir_sha, so hashing would
+// report drift forever and refetch on every run.
+func storeIsCurrent(m *manifest.Manifest, skill registry.Skill, storePath string) bool {
+	if !storeHasSkill(storePath) {
+		return false
+	}
+	for _, inst := range m.Installations {
+		if inst.Skill == skill.Name && inst.StorePath == storePath &&
+			inst.Version == skill.Version && inst.RegistryRef == skill.DirSHA {
+			return true
+		}
+	}
+	return false
 }
 
 // retireRenamed removes installations published under a superseded name after

--- a/cli/internal/install/engine_test.go
+++ b/cli/internal/install/engine_test.go
@@ -17,7 +17,9 @@ import (
 
 // seedTarball writes a fake GitHub-style tarball into cacheDir in the exact
 // location the Fetcher expects, so Execute's Fetch call becomes a cache hit.
-func seedTarball(t *testing.T, cacheDir, owner, name, sha, repoPrefix string, files map[string]string) {
+// seedTarball writes the fixture tarball and returns its path, so a test can
+// delete it to prove a later run does not fetch.
+func seedTarball(t *testing.T, cacheDir, owner, name, sha, repoPrefix string, files map[string]string) string {
 	t.Helper()
 	var buf bytes.Buffer
 	gz := gzip.NewWriter(&buf)
@@ -49,9 +51,11 @@ func seedTarball(t *testing.T, cacheDir, owner, name, sha, repoPrefix string, fi
 		t.Fatal(err)
 	}
 	fname := owner + "-" + name + "-" + sha + ".tar.gz"
-	if err := os.WriteFile(filepath.Join(dir, fname), buf.Bytes(), 0o644); err != nil {
+	path := filepath.Join(dir, fname)
+	if err := os.WriteFile(path, buf.Bytes(), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	return path
 }
 
 // expectedDirSHA extracts a copy of the skill tree to a temp dir and computes
@@ -128,7 +132,7 @@ func TestEngine_InstallReplaceSkipForce(t *testing.T) {
 		DefaultScope:   "user",
 	}
 
-	engine := NewEngine(cacheDir, manifestPath)
+	engine := newTestEngine(t, root, cacheDir, manifestPath)
 	engine.Now = func() time.Time { return time.Unix(1700000000, 0).UTC() }
 
 	plan, err := Plan(reg, "foo")
@@ -240,7 +244,7 @@ func TestEngine_SkipOnStaleSourceSHA(t *testing.T) {
 		InstallTargets: map[string]string{"user": installRoot},
 		DefaultScope:   "user",
 	}
-	engine := NewEngine(cacheDir, manifestPath)
+	engine := newTestEngine(t, root, cacheDir, manifestPath)
 	engine.Now = func() time.Time { return time.Unix(1700000000, 0).UTC() }
 
 	// Install under sha1.
@@ -316,7 +320,7 @@ func TestEngine_ProjectScopeMovesOldInstall(t *testing.T) {
 		DefaultScope:   "project",
 	}
 
-	engine := NewEngine(cacheDir, manifestPath)
+	engine := newTestEngine(t, root, cacheDir, manifestPath)
 	engine.Now = func() time.Time { return time.Unix(1700000000, 0).UTC() }
 	plan, err := Plan(reg, "foo")
 	if err != nil {
@@ -386,7 +390,7 @@ func TestInstall_PreserveFreshInstall_SeedsFromStaging(t *testing.T) {
 		DefaultScope:   "user",
 	}
 
-	engine := NewEngine(cacheDir, manifestPath)
+	engine := newTestEngine(t, root, cacheDir, manifestPath)
 	engine.Now = func() time.Time { return time.Unix(1700000000, 0).UTC() }
 	plan, _ := Plan(reg, "foo")
 	if _, err := engine.Execute(reg, plan, ExecuteOpts{
@@ -434,7 +438,7 @@ func TestInstall_PreserveFile_UserWinsOnReplace(t *testing.T) {
 		InstallTargets: map[string]string{"user": installRoot},
 		DefaultScope:   "user",
 	}
-	engine := NewEngine(cacheDir, manifestPath)
+	engine := newTestEngine(t, root, cacheDir, manifestPath)
 	engine.Now = func() time.Time { return time.Unix(1700000000, 0).UTC() }
 
 	// Install v1.
@@ -518,7 +522,7 @@ func TestInstall_PreserveDir_DeepMerge(t *testing.T) {
 		InstallTargets: map[string]string{"user": installRoot},
 		DefaultScope:   "user",
 	}
-	engine := NewEngine(cacheDir, manifestPath)
+	engine := newTestEngine(t, root, cacheDir, manifestPath)
 	engine.Now = func() time.Time { return time.Unix(1700000000, 0).UTC() }
 
 	reg1 := &registry.Registry{
@@ -607,7 +611,7 @@ func TestInstall_ForceBypassesPreserve(t *testing.T) {
 		InstallTargets: map[string]string{"user": installRoot},
 		DefaultScope:   "user",
 	}
-	engine := NewEngine(cacheDir, manifestPath)
+	engine := newTestEngine(t, root, cacheDir, manifestPath)
 	engine.Now = func() time.Time { return time.Unix(1700000000, 0).UTC() }
 
 	plan, _ := Plan(reg, "foo")
@@ -688,7 +692,7 @@ func TestUpdate_UsesLocalPreserveList(t *testing.T) {
 		InstallTargets: map[string]string{"user": installRoot},
 		DefaultScope:   "user",
 	}
-	engine := NewEngine(cacheDir, manifestPath)
+	engine := newTestEngine(t, root, cacheDir, manifestPath)
 	engine.Now = func() time.Time { return time.Unix(1700000000, 0).UTC() }
 
 	reg1 := &registry.Registry{
@@ -795,7 +799,7 @@ func TestUpdate_MergesPreserveKeyKeepsUpstreamBody(t *testing.T) {
 		InstallTargets: map[string]string{"user": installRoot},
 		DefaultScope:   "user",
 	}
-	engine := NewEngine(cacheDir, manifestPath)
+	engine := newTestEngine(t, root, cacheDir, manifestPath)
 	engine.Now = func() time.Time { return time.Unix(1700000000, 0).UTC() }
 
 	reg1 := &registry.Registry{
@@ -898,7 +902,7 @@ func TestUpdate_PreserveSurvivesMultipleUpdates(t *testing.T) {
 		InstallTargets: map[string]string{"user": installRoot},
 		DefaultScope:   "user",
 	}
-	engine := NewEngine(cacheDir, manifestPath)
+	engine := newTestEngine(t, root, cacheDir, manifestPath)
 	engine.Now = func() time.Time { return time.Unix(1700000000, 0).UTC() }
 
 	reg := func(version, sha, dirSHA string) *registry.Registry {
@@ -997,7 +1001,7 @@ func TestUpdate_LocalPreserveRemovedEntryWipes(t *testing.T) {
 		InstallTargets: map[string]string{"user": installRoot},
 		DefaultScope:   "user",
 	}
-	engine := NewEngine(cacheDir, manifestPath)
+	engine := newTestEngine(t, root, cacheDir, manifestPath)
 	engine.Now = func() time.Time { return time.Unix(1700000000, 0).UTC() }
 
 	reg1 := &registry.Registry{
@@ -1080,7 +1084,7 @@ func TestUpdate_LocalSkillMdUnparseable_FallsBackToRegistry(t *testing.T) {
 		InstallTargets: map[string]string{"user": installRoot},
 		DefaultScope:   "user",
 	}
-	engine := NewEngine(cacheDir, manifestPath)
+	engine := newTestEngine(t, root, cacheDir, manifestPath)
 	engine.Now = func() time.Time { return time.Unix(1700000000, 0).UTC() }
 
 	reg1 := &registry.Registry{
@@ -1166,7 +1170,7 @@ func TestUpdate_LocalPreserveInvalid_FallsBackToRegistry(t *testing.T) {
 		InstallTargets: map[string]string{"user": installRoot},
 		DefaultScope:   "user",
 	}
-	engine := NewEngine(cacheDir, manifestPath)
+	engine := newTestEngine(t, root, cacheDir, manifestPath)
 	engine.Now = func() time.Time { return time.Unix(1700000000, 0).UTC() }
 
 	reg1 := &registry.Registry{
@@ -1274,7 +1278,7 @@ func TestInstall_PreserveScopeMove(t *testing.T) {
 		InstallTargets: map[string]string{"project": newRoot},
 		DefaultScope:   "project",
 	}
-	engine := NewEngine(cacheDir, manifestPath)
+	engine := newTestEngine(t, root, cacheDir, manifestPath)
 	engine.Now = func() time.Time { return time.Unix(1700000000, 0).UTC() }
 	plan, _ := Plan(reg, "foo")
 	if _, err := engine.Execute(reg, plan, ExecuteOpts{
@@ -1323,7 +1327,7 @@ func TestInstall_PreserveMissingOnDisk_UsesStaging(t *testing.T) {
 		InstallTargets: map[string]string{"user": installRoot},
 		DefaultScope:   "user",
 	}
-	engine := NewEngine(cacheDir, manifestPath)
+	engine := newTestEngine(t, root, cacheDir, manifestPath)
 	engine.Now = func() time.Time { return time.Unix(1700000000, 0).UTC() }
 
 	reg1 := &registry.Registry{
@@ -1396,7 +1400,7 @@ func TestInstall_PreserveTypeMismatch_Errors(t *testing.T) {
 		InstallTargets: map[string]string{"user": installRoot},
 		DefaultScope:   "user",
 	}
-	engine := NewEngine(cacheDir, manifestPath)
+	engine := newTestEngine(t, root, cacheDir, manifestPath)
 	engine.Now = func() time.Time { return time.Unix(1700000000, 0).UTC() }
 
 	reg1 := &registry.Registry{
@@ -1468,7 +1472,7 @@ func TestEngine_DirSHAMismatchFails(t *testing.T) {
 		DefaultScope:   "user",
 	}
 
-	engine := NewEngine(cacheDir, manifestPath)
+	engine := newTestEngine(t, root, cacheDir, manifestPath)
 	plan, _ := Plan(reg, "foo")
 	_, err := engine.Execute(reg, plan, ExecuteOpts{
 		Adapters:  []adapters.Adapter{adapter},
@@ -1513,7 +1517,7 @@ func TestRename_CarriesPreservedDataToNewName(t *testing.T) {
 		InstallTargets: map[string]string{"user": installRoot},
 		DefaultScope:   "user",
 	}
-	engine := NewEngine(cacheDir, manifestPath)
+	engine := newTestEngine(t, root, cacheDir, manifestPath)
 	engine.Now = func() time.Time { return time.Unix(1700000000, 0).UTC() }
 
 	reg1 := &registry.Registry{
@@ -1607,5 +1611,254 @@ func TestRename_WithoutPreviousNamesLeavesOldAlone(t *testing.T) {
 	}
 	if got := m.FindPrevious([]string{"use-foo"}, "other", "user"); got != nil {
 		t.Error("must not cross platform boundaries")
+	}
+}
+
+// TestInstall_AddPlatform_KeepsPreservedContentWithoutFetching reproduces the
+// incident this whole path exists for: a skill installed --global for one
+// platform, then installed for a SECOND platform. The canonical store is
+// shared, so the second install must not overwrite it — the user's
+// metadata.preserve files are their accumulated memory, and --force was never
+// passed.
+//
+// The cached tarball is deleted before the second run: any fetch attempt fails
+// the test, which is what locks in "adding a platform costs no network".
+func TestInstall_AddPlatform_KeepsPreservedContentWithoutFetching(t *testing.T) {
+	root := t.TempDir()
+	cacheDir := filepath.Join(root, "cache")
+	claudeRoot := filepath.Join(root, "home", ".claude", "skills")
+	agentsRoot := filepath.Join(root, "home", ".agents", "skills")
+	manifestPath := filepath.Join(root, "manifest.json")
+
+	body := skillMD("foo", "0.1.0", []string{"references/log.md"})
+	files := map[string]string{
+		"skills/foo/SKILL.md":          body,
+		"skills/foo/references/log.md": "seed\n",
+	}
+	dirSHA := expectedDirSHA(t, map[string]string{
+		"SKILL.md": body, "references/log.md": "seed\n",
+	})
+	sha := "shaaddplat111"
+	tarName := seedTarball(t, cacheDir, "ex", "r", sha, "ex-r-abc", files)
+
+	claude := adapters.Adapter{
+		Name: "claude-code", InstallTargets: map[string]string{"user": claudeRoot}, DefaultScope: "user",
+	}
+	codex := adapters.Adapter{
+		Name: "codex", InstallTargets: map[string]string{"user": agentsRoot}, DefaultScope: "user",
+	}
+	all := []adapters.Adapter{claude, codex}
+
+	engine := newTestEngine(t, root, cacheDir, manifestPath)
+	engine.Now = func() time.Time { return time.Unix(1700000000, 0).UTC() }
+
+	reg := &registry.Registry{
+		SchemaVersion: registry.SchemaVersion,
+		Source:        registry.Source{Repo: "github.com/ex/r", SHA: sha},
+		Skills: []registry.Skill{{
+			Name: "foo", Version: "0.1.0", Path: "skills/foo",
+			DirSHA: dirSHA, Preserve: []string{"references/log.md"},
+		}},
+	}
+	plan, err := Plan(reg, "foo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := engine.Execute(reg, plan, ExecuteOpts{
+		Adapters: all, Platforms: []string{"claude-code"}, Global: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	storePath, err := CanonicalSkillPath("foo", "user", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	logPath := filepath.Join(storePath, "references", "log.md")
+
+	// Real accumulated use: content no upstream revision ever shipped.
+	userLog := "seed\n[SESSION] decisions the user cannot get back\n"
+	if err := os.WriteFile(logPath, []byte(userLog), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Nothing has drifted, so nothing may be downloaded. Removing the cache
+	// entry turns any fetch into a hard failure instead of a silent refetch.
+	if err := os.Remove(tarName); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := engine.Execute(reg, plan, ExecuteOpts{
+		Adapters: all, Platforms: []string{"codex"}, Global: true,
+	})
+	if err != nil {
+		t.Fatalf("adding a platform must not fetch: %v", err)
+	}
+
+	got, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("preserved file gone: %v", err)
+	}
+	if string(got) != userLog {
+		t.Errorf("preserved file was overwritten by the platform add:\n got %q\nwant %q", got, userLog)
+	}
+
+	if len(res.Results) != 1 || res.Results[0].Outcome != OutcomeLinked {
+		t.Fatalf("want one linked target, got %+v", res.Results)
+	}
+	link, err := os.Readlink(filepath.Join(agentsRoot, "foo"))
+	if err != nil {
+		t.Fatalf("codex target is not a symlink: %v", err)
+	}
+	if link != storePath {
+		t.Errorf("codex symlink -> %q, want the shared store %q", link, storePath)
+	}
+
+	// The first platform keeps working: same store, still one canonical copy.
+	if l, err := os.Readlink(filepath.Join(claudeRoot, "foo")); err != nil || l != storePath {
+		t.Errorf("claude-code symlink broke: %q %v", l, err)
+	}
+	m, err := manifest.Load(manifestPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(m.Installations) != 2 {
+		t.Errorf("want 2 manifest entries (one per platform), got %d", len(m.Installations))
+	}
+}
+
+// TestInstall_AddPlatformWithDrift_UpdatesStoreAndPreserves covers the awkward
+// case: the registry moved on AND the user is adding a platform in the same
+// run. The store must be refreshed to the new revision with preserved content
+// carried over, not skipped and not clobbered.
+func TestInstall_AddPlatformWithDrift_UpdatesStoreAndPreserves(t *testing.T) {
+	root := t.TempDir()
+	cacheDir := filepath.Join(root, "cache")
+	claudeRoot := filepath.Join(root, "home", ".claude", "skills")
+	agentsRoot := filepath.Join(root, "home", ".agents", "skills")
+	manifestPath := filepath.Join(root, "manifest.json")
+
+	v1 := skillMD("foo", "0.1.0", []string{"references/log.md"})
+	seedTarball(t, cacheDir, "ex", "r", "shadrift1aaa", "ex-r-abc", map[string]string{
+		"skills/foo/SKILL.md":          v1,
+		"skills/foo/references/log.md": "seed\n",
+	})
+	sha1 := expectedDirSHA(t, map[string]string{"SKILL.md": v1, "references/log.md": "seed\n"})
+
+	v2 := skillMD("foo", "0.2.0", []string{"references/log.md"})
+	seedTarball(t, cacheDir, "ex", "r", "shadrift2bbb", "ex-r-def", map[string]string{
+		"skills/foo/SKILL.md":          v2,
+		"skills/foo/references/log.md": "seed-v2\n",
+		"skills/foo/NEW.md":            "upstream addition\n",
+	})
+	sha2 := expectedDirSHA(t, map[string]string{
+		"SKILL.md": v2, "references/log.md": "seed-v2\n", "NEW.md": "upstream addition\n",
+	})
+
+	claude := adapters.Adapter{
+		Name: "claude-code", InstallTargets: map[string]string{"user": claudeRoot}, DefaultScope: "user",
+	}
+	codex := adapters.Adapter{
+		Name: "codex", InstallTargets: map[string]string{"user": agentsRoot}, DefaultScope: "user",
+	}
+	all := []adapters.Adapter{claude, codex}
+
+	engine := newTestEngine(t, root, cacheDir, manifestPath)
+	engine.Now = func() time.Time { return time.Unix(1700000000, 0).UTC() }
+
+	mkReg := func(sha, version, dirSHA string) *registry.Registry {
+		return &registry.Registry{
+			SchemaVersion: registry.SchemaVersion,
+			Source:        registry.Source{Repo: "github.com/ex/r", SHA: sha},
+			Skills: []registry.Skill{{
+				Name: "foo", Version: version, Path: "skills/foo",
+				DirSHA: dirSHA, Preserve: []string{"references/log.md"},
+			}},
+		}
+	}
+
+	reg1 := mkReg("shadrift1aaa", "0.1.0", sha1)
+	plan1, _ := Plan(reg1, "foo")
+	if _, err := engine.Execute(reg1, plan1, ExecuteOpts{
+		Adapters: all, Platforms: []string{"claude-code"}, Global: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	storePath, err := CanonicalSkillPath("foo", "user", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	userLog := "seed\n[SESSION] hard-won context\n"
+	if err := os.WriteFile(filepath.Join(storePath, "references", "log.md"), []byte(userLog), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	reg2 := mkReg("shadrift2bbb", "0.2.0", sha2)
+	plan2, _ := Plan(reg2, "foo")
+	res, err := engine.Execute(reg2, plan2, ExecuteOpts{
+		Adapters: all, Platforms: []string{"codex"}, Global: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, _ := os.ReadFile(filepath.Join(storePath, "references", "log.md"))
+	if string(got) != userLog {
+		t.Errorf("preserved file lost across the drifted platform add:\n got %q\nwant %q", got, userLog)
+	}
+	if _, err := os.Stat(filepath.Join(storePath, "NEW.md")); err != nil {
+		t.Errorf("upstream addition missing — store was not refreshed: %v", err)
+	}
+	if len(res.Results) != 1 || res.Results[0].Outcome != OutcomeInstalled {
+		t.Fatalf("want one installed target, got %+v", res.Results)
+	}
+
+	// The platform that wasn't named in this run shares the store, so its
+	// manifest row must report the revision that's actually on disk.
+	m, err := manifest.Load(manifestPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, inst := range m.Installations {
+		if inst.Version != "0.2.0" || inst.RegistryRef != sha2 {
+			t.Errorf("stale manifest row for %s: v%s ref %s", inst.Platform, inst.Version, inst.RegistryRef)
+		}
+	}
+}
+
+func TestPreservedAtRisk(t *testing.T) {
+	store := t.TempDir()
+	body := skillMD("foo", "0.1.0", []string{"references/log.md", "references/wiki/", "gone.md"})
+	if err := os.WriteFile(filepath.Join(store, "SKILL.md"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(store, "references", "wiki"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(store, "references", "log.md"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := PreservedAtRisk(store, nil)
+	want := []string{"references/log.md", "references/wiki/"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("got %v want %v", got, want)
+		}
+	}
+
+	// No local SKILL.md: fall back to the registry's list, still filtered by
+	// what exists on disk.
+	bare := t.TempDir()
+	if err := os.WriteFile(filepath.Join(bare, "keep.md"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got = PreservedAtRisk(bare, []string{"keep.md", "absent.md"})
+	if len(got) != 1 || got[0] != "keep.md" {
+		t.Errorf("registry fallback: got %v", got)
 	}
 }

--- a/cli/internal/install/main_test.go
+++ b/cli/internal/install/main_test.go
@@ -1,0 +1,80 @@
+package install
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/adrg/xdg"
+)
+
+// TestMain isolates HOME and every XDG base dir for the whole package.
+//
+// Tests that install at "user" scope resolve their canonical store through
+// xdg.DataFile, which on a developer machine is the *real* data dir
+// (~/Library/Application Support on macOS). Without this they write skills
+// into real user state and — worse — read each other's leftovers back on the
+// next run, because the engine now treats an existing store as a preserve
+// source. That made results depend on whether a previous run had crashed.
+func TestMain(m *testing.M) {
+	code, err := runIsolated(m)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "install tests: isolate env:", err)
+		os.Exit(1)
+	}
+	os.Exit(code)
+}
+
+// newTestEngine builds an Engine whose canonical store lives under this test's
+// own temp root.
+//
+// Nearly every test in this package installs a skill called "foo" at user
+// scope, and that store path resolves through xdg.DataFile — one shared
+// directory for the whole package. Without per-test isolation each test reads
+// the previous test's store back as a preserve source, so a failure anywhere
+// cascades into unrelated tests.
+func newTestEngine(t *testing.T, root, cacheDir, manifestPath string) *Engine {
+	t.Helper()
+	t.Setenv("XDG_DATA_HOME", filepath.Join(root, "xdg-data"))
+	// --global stores resolve through os.UserHomeDir(), not xdg.
+	t.Setenv("HOME", filepath.Join(root, "home"))
+	t.Setenv("USERPROFILE", filepath.Join(root, "home"))
+	xdg.Reload()
+	t.Cleanup(xdg.Reload)
+	return NewEngine(cacheDir, manifestPath)
+}
+
+func runIsolated(m *testing.M) (int, error) {
+	root, err := os.MkdirTemp("", "humblskills-install-tests-")
+	if err != nil {
+		return 0, err
+	}
+	defer os.RemoveAll(root)
+
+	home := filepath.Join(root, "home")
+	if err := os.MkdirAll(home, 0o755); err != nil {
+		return 0, err
+	}
+	env := map[string]string{
+		"HOME":            home,
+		"USERPROFILE":     home, // os.UserHomeDir() on Windows
+		"XDG_DATA_HOME":   filepath.Join(root, "xdg", "data"),
+		"XDG_CONFIG_HOME": filepath.Join(root, "xdg", "config"),
+		"XDG_STATE_HOME":  filepath.Join(root, "xdg", "state"),
+		"XDG_CACHE_HOME":  filepath.Join(root, "xdg", "cache"),
+	}
+	for k, v := range env {
+		if err := os.MkdirAll(v, 0o755); err != nil {
+			return 0, err
+		}
+		if err := os.Setenv(k, v); err != nil {
+			return 0, err
+		}
+	}
+	// xdg snapshots the environment at package init, so the overrides above
+	// only reach xdg.DataFile after a reload.
+	xdg.Reload()
+
+	return m.Run(), nil
+}

--- a/cli/internal/install/preserve.go
+++ b/cli/internal/install/preserve.go
@@ -43,6 +43,36 @@ func loadLocalPreserve(installPath string) (entries []string, ok bool, reason st
 	return preserve, true, ""
 }
 
+// PreservedAtRisk returns the preserve-list entries that actually exist inside
+// storePath — the user-owned files a --force reinstall or an uninstall
+// destroys. The installed SKILL.md's metadata.preserve wins; registryPreserve
+// is the fallback when that file is missing or unparseable.
+//
+// This exists so a destructive prompt can name the files by path instead of
+// asking "are you sure?" about an abstraction. Entries keep their declared
+// form (trailing slash for directories) so callers can print them verbatim.
+func PreservedAtRisk(storePath string, registryPreserve []string) []string {
+	if storePath == "" {
+		return nil
+	}
+	list, ok, _ := loadLocalPreserve(storePath)
+	if !ok {
+		list = registryPreserve
+	}
+	var out []string
+	for _, raw := range list {
+		rel := strings.TrimPrefix(strings.TrimSpace(raw), "./")
+		clean := filepath.FromSlash(strings.TrimSuffix(rel, "/"))
+		if clean == "" || clean == "." {
+			continue
+		}
+		if _, err := os.Lstat(filepath.Join(storePath, clean)); err == nil {
+			out = append(out, rel)
+		}
+	}
+	return out
+}
+
 const frontmatterDelimiter = "---"
 
 // mergePreserveIntoSkillMD rewrites path so its frontmatter's `preserve:` key

--- a/cli/internal/install/update.go
+++ b/cli/internal/install/update.go
@@ -21,6 +21,14 @@ type UpdatePlan struct {
 	FromDirSHA  string          `json:"from_dir_sha,omitempty"`
 	ToDirSHA    string          `json:"to_dir_sha,omitempty"`
 	Targets     []ManifestEntry `json:"targets"`
+	// AddPlatforms are platforms this skill should also be installed onto but
+	// isn't yet (see PlanUpdatesFor). Adding one is a symlink plus a manifest
+	// row; it never changes skill content.
+	AddPlatforms []string `json:"add_platforms,omitempty"`
+	// LinkOnly is true when the skill's content is already current and the only
+	// work is AddPlatforms. Callers must not describe such a plan as an
+	// upgrade: nothing is fetched and no file changes.
+	LinkOnly bool `json:"link_only,omitempty"`
 }
 
 // ManifestEntry mirrors the subset of manifest.Installation a caller needs to
@@ -37,6 +45,18 @@ type ManifestEntry struct {
 // missing is skipped (there's nothing to upgrade to). When `only` is
 // non-empty, only those skill names are considered.
 func PlanUpdates(reg *registry.Registry, m *manifest.Manifest, only []string) []UpdatePlan {
+	return PlanUpdatesFor(reg, m, only, nil)
+}
+
+// PlanUpdatesFor is PlanUpdates plus platform reconciliation: any platform in
+// wantPlatforms that an installed skill doesn't target yet is reported in the
+// plan's AddPlatforms.
+//
+// A skill with no content drift but a missing platform still yields a plan
+// (LinkOnly). That's deliberate — it's what makes a backfill visible in
+// --check, --json and the TUI picker instead of happening invisibly inside
+// whichever command the user happened to run.
+func PlanUpdatesFor(reg *registry.Registry, m *manifest.Manifest, only, wantPlatforms []string) []UpdatePlan {
 	if reg == nil || m == nil {
 		return nil
 	}
@@ -115,20 +135,23 @@ func PlanUpdates(reg *registry.Registry, m *manifest.Manifest, only []string) []
 				break
 			}
 		}
-		if !drifted {
+		add := missingPlatforms(insts, regSkill, wantPlatforms)
+		if !drifted && len(add) == 0 {
 			continue
 		}
 
 		first := insts[0]
 		plan := UpdatePlan{
-			Skill:       regSkill.Name,
-			RenamedFrom: renamedFrom,
-			FromVersion: first.Version,
-			ToVersion:   regSkill.Version,
-			FromSHA:     first.SourceSHA,
-			ToSHA:       reg.Source.SHA,
-			FromDirSHA:  first.RegistryRef,
-			ToDirSHA:    regSkill.DirSHA,
+			Skill:        regSkill.Name,
+			RenamedFrom:  renamedFrom,
+			FromVersion:  first.Version,
+			ToVersion:    regSkill.Version,
+			FromSHA:      first.SourceSHA,
+			ToSHA:        reg.Source.SHA,
+			FromDirSHA:   first.RegistryRef,
+			ToDirSHA:     regSkill.DirSHA,
+			AddPlatforms: add,
+			LinkOnly:     !drifted,
 		}
 		for _, i := range insts {
 			plan.Targets = append(plan.Targets, ManifestEntry{
@@ -136,6 +159,44 @@ func PlanUpdates(reg *registry.Registry, m *manifest.Manifest, only []string) []
 			})
 		}
 		out = append(out, plan)
+	}
+	return out
+}
+
+// missingPlatforms returns the wanted platforms this skill isn't installed on
+// yet, in the caller's order.
+//
+// The skill's own platforms[] allow-list is honoured so a plan never promises
+// a target the engine will drop on the floor — except for global installs,
+// which bypass the allow-list in installOne, and must bypass it here too or
+// the plan would hide a target the engine does accept.
+func missingPlatforms(insts []manifest.Installation, s registry.Skill, want []string) []string {
+	if len(want) == 0 {
+		return nil
+	}
+	have := make(map[string]struct{}, len(insts))
+	global := false
+	for _, i := range insts {
+		have[i.Platform] = struct{}{}
+		if i.InstallMode == InstallModeGlobal {
+			global = true
+		}
+	}
+	allow := make(map[string]struct{}, len(s.Platforms))
+	for _, p := range s.Platforms {
+		allow[p] = struct{}{}
+	}
+	var out []string
+	for _, p := range want {
+		if _, installed := have[p]; installed {
+			continue
+		}
+		if !global && len(allow) > 0 {
+			if _, ok := allow[p]; !ok {
+				continue
+			}
+		}
+		out = append(out, p)
 	}
 	return out
 }

--- a/cli/internal/install/update_test.go
+++ b/cli/internal/install/update_test.go
@@ -285,3 +285,91 @@ func TestPlanUpdates_RenameReachableByEitherName(t *testing.T) {
 		t.Errorf("an unrelated filter must match nothing, got %+v", plans)
 	}
 }
+
+// TestPlanUpdatesFor_PlatformBackfill: a skill whose content is current but
+// which is missing a wanted platform still yields a plan, flagged LinkOnly so
+// no caller describes it as an upgrade.
+func TestPlanUpdatesFor_PlatformBackfill(t *testing.T) {
+	reg := &registry.Registry{
+		SchemaVersion: registry.SchemaVersion,
+		Source:        registry.Source{Repo: "github.com/example/repo", SHA: "src"},
+		Skills: []registry.Skill{
+			{Name: "current", Version: "1.0.0", DirSHA: "sha-current"},
+			{Name: "drifted", Version: "2.0.0", DirSHA: "sha-drifted-new"},
+			{Name: "picky", Version: "1.0.0", DirSHA: "sha-picky", Platforms: []string{"claude-code"}},
+		},
+	}
+	m := &manifest.Manifest{
+		SchemaVersion: manifest.SchemaVersion,
+		Installations: []manifest.Installation{
+			{Skill: "current", Version: "1.0.0", Platform: "claude-code", Scope: "user",
+				RegistryRef: "sha-current", InstallMode: InstallModeLinked},
+			{Skill: "drifted", Version: "1.0.0", Platform: "claude-code", Scope: "user",
+				RegistryRef: "sha-drifted-old", InstallMode: InstallModeLinked},
+			{Skill: "picky", Version: "1.0.0", Platform: "claude-code", Scope: "user",
+				RegistryRef: "sha-picky", InstallMode: InstallModeLinked},
+		},
+	}
+
+	byName := map[string]UpdatePlan{}
+	for _, p := range PlanUpdatesFor(reg, m, nil, []string{"claude-code", "codex"}) {
+		byName[p.Skill] = p
+	}
+
+	cur, ok := byName["current"]
+	if !ok {
+		t.Fatal("a current skill missing a wanted platform must still be planned")
+	}
+	if !cur.LinkOnly {
+		t.Error("no content drift, so the plan must be LinkOnly")
+	}
+	if len(cur.AddPlatforms) != 1 || cur.AddPlatforms[0] != "codex" {
+		t.Errorf("AddPlatforms = %v, want [codex]", cur.AddPlatforms)
+	}
+
+	dr, ok := byName["drifted"]
+	if !ok {
+		t.Fatal("drifted skill missing from plans")
+	}
+	if dr.LinkOnly {
+		t.Error("drifted skill must not be LinkOnly")
+	}
+	if len(dr.AddPlatforms) != 1 || dr.AddPlatforms[0] != "codex" {
+		t.Errorf("drift + backfill should fold into one plan, got %v", dr.AddPlatforms)
+	}
+
+	// `picky` declares platforms: [claude-code], so codex is not a legal
+	// target and must not be promised.
+	if p, planned := byName["picky"]; planned {
+		t.Errorf("allow-list violated: %+v", p)
+	}
+
+	// Without wantPlatforms the behaviour is unchanged: drift only.
+	plans := PlanUpdatesFor(reg, m, nil, nil)
+	if len(plans) != 1 || plans[0].Skill != "drifted" {
+		t.Errorf("no wantPlatforms should mean drift-only, got %+v", plans)
+	}
+}
+
+// A --global install bypasses the platforms[] allow-list in the engine, so the
+// plan must bypass it too or it would hide a target Execute accepts.
+func TestPlanUpdatesFor_GlobalIgnoresAllowList(t *testing.T) {
+	reg := &registry.Registry{
+		SchemaVersion: registry.SchemaVersion,
+		Source:        registry.Source{Repo: "github.com/example/repo", SHA: "src"},
+		Skills: []registry.Skill{
+			{Name: "picky", Version: "1.0.0", DirSHA: "sha", Platforms: []string{"claude-code"}},
+		},
+	}
+	m := &manifest.Manifest{
+		SchemaVersion: manifest.SchemaVersion,
+		Installations: []manifest.Installation{
+			{Skill: "picky", Version: "1.0.0", Platform: "claude-code", Scope: "user",
+				RegistryRef: "sha", InstallMode: InstallModeGlobal},
+		},
+	}
+	plans := PlanUpdatesFor(reg, m, nil, []string{"codex"})
+	if len(plans) != 1 || len(plans[0].AddPlatforms) != 1 || plans[0].AddPlatforms[0] != "codex" {
+		t.Fatalf("global install should allow any platform, got %+v", plans)
+	}
+}

--- a/cli/internal/manifest/manifest.go
+++ b/cli/internal/manifest/manifest.go
@@ -157,6 +157,42 @@ func (m *Manifest) Upsert(inst Installation) {
 	m.Installations = append(m.Installations, inst)
 }
 
+// RefreshStoreRevision moves every entry pointing at storePath to the given
+// revision, and returns how many it touched. Entries whose InstallMode is in
+// skipModes are left alone.
+//
+// Platform targets are symlinks into one shared canonical store, so replacing
+// that store's content silently moves every platform to the new revision.
+// Without this, the platform that wasn't named in the run keeps reporting the
+// version it was installed at — a number no longer on disk — and `update`
+// re-plans work that's already done. Derived artifacts (zip targets) are the
+// exception a caller passes in skipModes: theirs really is stale until it's
+// regenerated.
+func (m *Manifest) RefreshStoreRevision(storePath, version, sourceSHA, registryRef string, skipModes ...string) int {
+	if storePath == "" {
+		return 0
+	}
+	skip := make(map[string]struct{}, len(skipModes))
+	for _, s := range skipModes {
+		skip[s] = struct{}{}
+	}
+	n := 0
+	for i := range m.Installations {
+		e := &m.Installations[i]
+		if e.StorePath != storePath {
+			continue
+		}
+		if _, skipped := skip[e.InstallMode]; skipped {
+			continue
+		}
+		e.Version = version
+		e.SourceSHA = sourceSHA
+		e.RegistryRef = registryRef
+		n++
+	}
+	return n
+}
+
 // Remove drops every Installation matching skill (all platforms and scopes)
 // and returns how many were removed.
 func (m *Manifest) Remove(skill string) int {

--- a/cli/internal/tui/install_modal.go
+++ b/cli/internal/tui/install_modal.go
@@ -103,8 +103,12 @@ type modalGroup int
 const (
 	groupPlatforms modalGroup = iota
 	groupScope
+	groupOptions
 	groupAction
 )
+
+// modalGroupCount is the number of focusable groups tab cycles through.
+const modalGroupCount = 4
 
 type installModalModel struct {
 	theme    *ui.Theme
@@ -119,8 +123,11 @@ type installModalModel struct {
 	// "adapter default" — there's no concrete option for that here, so the
 	// scope group shows a note explaining why nothing started pre-selected.
 	adapterDefaultNote bool
-	actions            []actionOpt
-	actionIdx          int
+	// force mirrors `install --force`. It lives here rather than as a flag-only
+	// option so the TUI can reach every install the CLI can.
+	force     bool
+	actions   []actionOpt
+	actionIdx int
 
 	group  modalGroup
 	cursor int
@@ -163,8 +170,11 @@ func (m installModalModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "shift+tab":
 			return m.nextGroup(-1), nil
 		case " ":
-			if m.group == groupPlatforms {
+			switch m.group {
+			case groupPlatforms:
 				m = m.togglePlatform()
+			case groupOptions:
+				m.force = !m.force
 			}
 			return m, nil
 		}
@@ -173,9 +183,9 @@ func (m installModalModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m installModalModel) nextGroup(dir int) installModalModel {
-	m.group = modalGroup((int(m.group) + dir + 3) % 3)
+	m.group = modalGroup((int(m.group) + dir + modalGroupCount) % modalGroupCount)
 	switch m.group {
-	case groupPlatforms:
+	case groupPlatforms, groupOptions:
 		m.cursor = 0
 	case groupScope:
 		m.cursor = m.scopeIdx
@@ -214,6 +224,8 @@ func (m installModalModel) onEnter() (tea.Model, tea.Cmd) {
 	case groupScope:
 		m.scopeIdx = m.cursor
 		return m.nextGroup(1), nil
+	case groupOptions:
+		return m.nextGroup(1), nil
 	case groupAction:
 		m.actionIdx = m.cursor
 		return m.commit()
@@ -244,6 +256,7 @@ func (m installModalModel) commit() (tea.Model, tea.Cmd) {
 			Platforms: plats,
 			Scope:     scope,
 			Global:    global,
+			Force:     m.force,
 			Confirmed: true,
 		}
 	}
@@ -257,6 +270,8 @@ func (m installModalModel) groupLen() int {
 		return len(m.adapters)
 	case groupScope:
 		return len(m.scopes)
+	case groupOptions:
+		return 1
 	case groupAction:
 		return len(m.actions)
 	}
@@ -292,6 +307,8 @@ func (m installModalModel) groupLabel() string {
 		return "platforms"
 	case groupScope:
 		return "scope"
+	case groupOptions:
+		return "options"
 	case groupAction:
 		return "action"
 	}
@@ -349,6 +366,8 @@ func (m installModalModel) renderLeftStacked(width int) string {
 		sb.WriteString("  " + th.Detail.Render(
 			"profile default is \"adapter default\" — pick a concrete scope for this install") + "\n")
 	}
+	sb.WriteString("\n")
+	sb.WriteString(m.renderGroup(groupOptions, "OPTIONS", m.optionRows(), width))
 	sb.WriteString("\n")
 	sb.WriteString(m.renderGroup(groupAction, "ACTION", m.actionRows(), width))
 
@@ -511,6 +530,30 @@ func (m installModalModel) scopeRows() []string {
 	return rows
 }
 
+// optionRows renders the force toggle. The consequence is spelled out in the
+// row itself rather than a footnote: this is the one option here that can
+// delete something the user cannot get back.
+func (m installModalModel) optionRows() []string {
+	th := m.theme
+	box := "[ ]"
+	if m.force {
+		box = "[✓]"
+	}
+	label := "force reinstall  " + th.RowDim.Render("(discards preserved files)")
+	if m.force {
+		label = "force reinstall  " + th.Warn.Render("(discards preserved files — you'll confirm)")
+	}
+	if m.group == groupOptions {
+		return []string{th.Bullet.Render("▸") + " " + th.RowSelected.Render(box+" force reinstall") + "  " +
+			th.Warn.Render("(discards preserved files)")}
+	}
+	marker := th.RowDim.Render(box)
+	if m.force {
+		marker = th.Warn.Render(box)
+	}
+	return []string{"  " + marker + " " + th.RowUnselected.Render(label)}
+}
+
 func (m installModalModel) actionRows() []string {
 	th := m.theme
 	rows := make([]string, 0, len(m.actions))
@@ -537,6 +580,11 @@ func (m installModalModel) hints() []KeyHint {
 		)
 	case groupScope:
 		base = append(base, KeyHint{Keys: "↵", Label: "next"})
+	case groupOptions:
+		base = append(base,
+			KeyHint{Keys: "space", Label: "toggle"},
+			KeyHint{Keys: "↵", Label: "next"},
+		)
 	case groupAction:
 		base = append(base, KeyHint{Keys: "↵", Label: "confirm"})
 	}

--- a/cli/internal/tui/install_modal_test.go
+++ b/cli/internal/tui/install_modal_test.go
@@ -88,11 +88,44 @@ func TestInstallModal_EnterAdvancesFromScope(t *testing.T) {
 	m.cursor = 2
 	out, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	m = out.(installModalModel)
-	if m.group != groupAction {
-		t.Errorf("enter should advance to action; got %v", m.group)
+	if m.group != groupOptions {
+		t.Errorf("enter should advance to options; got %v", m.group)
 	}
 	if m.scopeIdx != 2 {
 		t.Errorf("scopeIdx = %d, want 2", m.scopeIdx)
+	}
+	out, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if m = out.(installModalModel); m.group != groupAction {
+		t.Errorf("enter should advance from options to action; got %v", m.group)
+	}
+}
+
+// The force toggle is the TUI's counterpart to `install --force`. It must
+// default off and reach the caller, which is what makes the two surfaces
+// capable of the same thing.
+func TestInstallModal_ForceToggleDefaultsOffAndCommits(t *testing.T) {
+	m := newTestModal(map[string]bool{"claude-code": true}, map[string]bool{"claude-code": true})
+	if m.force {
+		t.Fatal("force must default off")
+	}
+
+	m.group = groupAction
+	out, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if got := out.(installModalModel).result; got.Force {
+		t.Error("untouched modal must not request force")
+	}
+
+	m = newTestModal(map[string]bool{"claude-code": true}, map[string]bool{"claude-code": true})
+	m.group = groupOptions
+	out, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{' '}})
+	m = out.(installModalModel)
+	if !m.force {
+		t.Fatal("space should toggle force on")
+	}
+	m.group = groupAction
+	out, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if got := out.(installModalModel).result; !got.Force || !got.Confirmed {
+		t.Errorf("force toggle did not reach the result: %+v", got)
 	}
 }
 

--- a/cli/internal/tui/profile.go
+++ b/cli/internal/tui/profile.go
@@ -763,9 +763,13 @@ func (m profileModel) hints() []KeyHint {
 // InstallModalResult is what the install platform picker returns. The modal
 // implementation lives in install_modal.go (hand-rolled bubbletea model).
 type InstallModalResult struct {
-	Platforms   []string
-	Scope       string
-	Global      bool
+	Platforms []string
+	Scope     string
+	Global    bool
+	// Force mirrors `install --force`: reinstall from the registry even if the
+	// target is current, discarding user-owned preserved files. Off unless the
+	// user toggles it, and the caller still asks for confirmation.
+	Force       bool
 	Confirmed   bool
 	EditProfile bool
 }

--- a/docs/using_humblskills/preserving_user_content.md
+++ b/docs/using_humblskills/preserving_user_content.md
@@ -15,6 +15,15 @@ Entries are **paths relative to the skill directory**. A trailing **`/`** means 
 
 Fresh installs always seed everything from the registry. `preserve` applies when **replacing** an existing install. `humblskills uninstall` removes platform symlinks and removes the canonical store when no remaining platform target references it.
 
+## What can and cannot overwrite these files
+
+Every platform target is a symlink into **one canonical store**, so the store is the only copy of your preserved files. Two rules protect it:
+
+- **Adding a platform never rewrites the store.** `install <skill> --platform <new>` on a skill you already have (or `update --platforms`) adds a symlink and a manifest entry. When the store already holds the registry's current revision, nothing is fetched and no file is touched — the outcome is reported as `linked`, not `installed`.
+- **Only an explicit request overwrites them.** `--force` (on `install`, `update` or `sync`), or an `uninstall` followed by a fresh install. Both now print the exact paths at risk and require confirmation; non-interactive runs must pass `--yes` rather than having consent assumed.
+
+An update with real drift refreshes everything *except* your preserved paths, per the table above.
+
 ### Example `SKILL.md` frontmatter
 
 ```yaml

--- a/docs/using_humblskills/updating.md
+++ b/docs/using_humblskills/updating.md
@@ -42,6 +42,46 @@ To throw your local changes away and take exactly what the registry ships:
 humblskills update --force <skill>
 ```
 
+`--force` is the one update mode that destroys content, so it now **lists the
+user-owned files it would overwrite and asks you to confirm**. In a pipe, in CI,
+or with `--json` there is nobody to ask, so it stops instead of guessing:
+
+```console
+$ humblskills update --force smart-commit --json
+humblskills: update --force: overwrites user-owned files: smart-commit
+(references/log.md, references/decisions.md) — re-run with --yes to confirm
+```
+
+The same gate covers `install --force`, `sync --force`, `sync --prune` and
+`uninstall`. In the TUI, `f` on the update list and the **force reinstall**
+toggle in the install modal reach the same behaviour, so neither surface can do
+something the other can't.
+
+## Adding a platform to skills you already have
+
+Installed a new agent (Codex, say) and want your existing skills on it too? Add
+it to your profile's `default_platforms`, then:
+
+```sh
+humblskills update --platforms          # add missing platforms + apply any drift
+humblskills update --check --platforms  # preview, change nothing
+```
+
+Every platform target is a symlink into one canonical store, so covering a new
+platform is a symlink plus a manifest entry. When the skill is already current
+nothing is downloaded and **no file in the store is touched** — the summary says
+`linked` rather than `installed` to make that explicit:
+
+```console
+$ humblskills update --check --platforms
+1 skill to act on:
+  smart-commit  link only  (+codex, no content change)
+```
+
+If a skill *is* drifted, the refresh and the new platform happen in one pass, so
+you don't need two commands. Skills that declare a `platforms` allow-list are
+only offered the platforms they support.
+
 ## When a skill gets renamed
 
 Skills occasionally get renamed upstream (for example, the `use-*` family was

--- a/registry.json
+++ b/registry.json
@@ -1,10 +1,10 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-07-30T22:25:16Z",
+  "generated_at": "2026-08-03T21:48:18Z",
   "source": {
     "repo": "github.com/jjfantini/humblSKILLS",
-    "ref": "feat/update-follows-renames",
-    "sha": "14b51f91f3b4626d40927a6de6ec8d69dc86f5df"
+    "ref": "fix/install-platform-add-preserve",
+    "sha": "dc97ce6d5e32b6e6bab92610da041d4dc919586f"
   },
   "skills": [
     {


### PR DESCRIPTION
## The incident

Installing an **already-installed** skill for a **new** platform (`install <skill> --platform codex` on a skill installed under `claude-code`) overwrote the shared canonical store with freshly fetched registry content, silently destroying every file the skill declares under `metadata.preserve` — the LLM-maintained memory files (`log.md`, `decisions.md`, `patterns.md`) that are the entire point of a smart skill.

No `--force` was passed. Nothing warned. A user lost `references/log.md` with no backup, and the registry `version` hadn't even changed — only the upstream commit had, so it looked like a no-op.

## Root cause

`installOne` inferred its preserve source only from a manifest entry matching *the adapter currently being installed*. Adding `codex` finds no such entry, and nothing exists yet at the new platform's path, so the preserve step was skipped — even though every platform shares **one** canonical store that was sitting there populated with the user's data.

## What changed

**1. `fix(install)` — the data loss**
- Fall back to the canonical store itself as the preserve source when no per-adapter entry matches.
- Skip the fetch *and* the store rewrite entirely when the store already holds the registry's current revision. Adding a platform becomes a symlink + manifest row: no network, no writes over live user data. New `linked` outcome so nothing reports it as a content change.
- Store currency is judged from manifest evidence, **not** by hashing — a store with preserved edits legitimately differs from `dir_sha` and would refetch forever.
- Sibling manifest rows are refreshed after a real store refresh (they symlink to the same directory, so `list` was reporting a version no longer on disk).

**2. `feat(install)` — destructive actions are explicit, on both surfaces**

| Path | Before | After |
|---|---|---|
| `install/update/sync --force` | no prompt at all | lists the exact paths it overwrites, asks |
| `uninstall --json` | deleted on an implied yes | non-interactive requires `--yes` |
| `sync --prune` | counted skills | names the files |
| `--force` from the TUI | unreachable | modal OPTIONS toggle + `f` on update list |

One gate for all of them. `--yes` is consent; a TTY gets a prompt defaulting to No; non-interactive without `--yes` errors and names both the files and the flag. Nothing at risk means no prompt.

**3. `feat(update)` — `--platforms` backfill**

Add a platform to your profile's `default_platforms`, then `humblskills update --platforms` puts every installed skill on it — symlink only, no refetch when the skill is current. Link-only plans avoid upgrade language everywhere (no ↑, no `1.0.0 → 1.0.0`, "no content change" badge). Drift + new platform fold into one `Execute` call.

Also fixes `update --check` printing only its count line — the per-skill rows used verbose-only `Detail`, so the list `--check` exists to show was invisible without `-v`.

## Verification

Both regression tests fail without the fix — one on the data loss, one because the cached tarball is deleted first to prove no fetch happens:

```
--- FAIL: TestInstall_AddPlatform_KeepsPreservedContentWithoutFetching
    adding a platform must not fetch: fetch https://codeload.github.com/... HTTP 404
--- FAIL: TestInstall_AddPlatformWithDrift_UpdatesStoreAndPreserves
    preserved file lost across the drifted platform add:
     got "seed-v2\n"
    want "seed\n[SESSION] hard-won context\n"
```

End-to-end against the in-repo registry, reproducing the original incident (md5 before/after identical):

```console
$ humblskills install smart-commit --platform codex --global --yes
✓ linked smart-commit → ~/.agents/skills/smart-commit [codex/user] (no content change)

$ humblskills update --check --platforms
1 skill to act on:
  smart-skill  link only  (+codex, no content change)

$ humblskills install smart-commit --force --platform claude-code --global
humblskills: install --force: overwrites user-owned files: smart-commit
(references/raw/, references/wiki/, references/decisions.md, references/log.md,
references/patterns.md) — re-run with --yes to confirm
```

`make vet`, `make test`, `make registry-check` all clean.

## Behaviour changes worth calling out

- `uninstall` / `--force` / `sync --prune` in a pipe, CI or with `--json` now **require `--yes`** instead of proceeding.
- Adding a platform to an installed skill no longer makes a network request.
- Engine tests were writing into the real `~/Library/Application Support` and reading each other's leftovers; each test now gets an isolated store root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)