### PR TITLE
fix(smart-handoff): correct Codex skill path to ~/.agents/skills

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1,10 +1,10 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-08-04T02:11:56Z",
+  "generated_at": "2026-08-04T02:12:12Z",
   "source": {
     "repo": "github.com/jjfantini/humblSKILLS",
-    "ref": "main",
-    "sha": "7ecf16a1f78e225f41dea1071466addccfe6321c"
+    "ref": "fix/handoff-codex-agents-path",
+    "sha": "9929bb3f481874dedc41622a756b59d29a142f3f"
   },
   "skills": [
     {
@@ -621,7 +621,7 @@
         "references/patterns.md"
       ],
       "path": "skills/smart-handoff",
-      "dir_sha": "67302ae36ddbf838d789e76b08b74d2f893b893e5b52c1600a0c385c44b49d84"
+      "dir_sha": "7768b2b02cbeb8b3f65135116277319e199fbb633d0c746a95201b672701910e"
     },
     {
       "name": "smart-humanize-text",

--- a/registry.json
+++ b/registry.json
@@ -1,10 +1,10 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-08-04T02:12:12Z",
+  "generated_at": "2026-08-04T02:31:15Z",
   "source": {
     "repo": "github.com/jjfantini/humblSKILLS",
     "ref": "fix/handoff-codex-agents-path",
-    "sha": "9929bb3f481874dedc41622a756b59d29a142f3f"
+    "sha": "196dbc8bc824d5b6f7ec39d0027bab570256cf56"
   },
   "skills": [
     {

--- a/skills/smart-handoff/references/log.md
+++ b/skills/smart-handoff/references/log.md
@@ -30,3 +30,5 @@ Entry shape:
     EXAMPLE stays safe-listed)
 
 [LINT 2026-08-03] 6 wiki, 0 raw. Hard: 0, Soft: 6. Regenerated _index.md.
+
+[LINT 2026-08-03] 6 wiki, 0 raw. Hard: 0, Soft: 6. Regenerated _index.md.

--- a/skills/smart-handoff/references/wiki/handoff/targets/harness-tailoring.md
+++ b/skills/smart-handoff/references/wiki/handoff/targets/harness-tailoring.md
@@ -26,12 +26,29 @@ asking twice.
 |--------|-------------|-------|--------|-----------------|
 | Instruction file | `CLAUDE.md` | `AGENTS.md` | `.cursor/rules`, `.cursorrules` | "the repo's agent instruction file" |
 | Skill invocation | `/smart-commit` or "use the smart-commit skill" | prose: "follow the smart-commit skill at `<path>`" | prose + `@`-file references | prose only |
-| Skill install path | `~/.claude/skills/` | `~/.codex/skills/` (varies) | `~/.cursor/skills/` | `humblskills install <name>` and let the CLI resolve it |
+| Skill install path | `~/.claude/skills/` | `~/.agents/skills/` (**not** `~/.codex/`) | `~/.cursor/skills/` | `humblskills install <name>` and let the CLI resolve it |
 | Sub-agents / tasks | available | plain execution | plain execution | do not assume |
 | Tool naming | Read / Edit / Bash | shell-first | editor-first | describe the action, not the tool |
 
 Name the instruction file the target actually reads, and check it exists —
 `preflight.sh` prints an `instruction-files` block.
+
+The SKILL.md format itself is identical across all three (the humblskills
+adapters are `transform: passthrough`), so a suggested skill is portable. Only
+the *path* and the *way you reference it* change.
+
+## Claude Desktop and claude.ai Are the Exception
+
+They cannot read skills off the filesystem — skills arrive as an account-level
+zip upload. An `humblskills install` line is useless to them. When the target
+is Claude Desktop or claude.ai, write the install column as:
+
+```markdown
+| `smart-commit` | step 3 | `humblskills export desktop smart-commit`, then upload the zip in Settings → Capabilities → Skills |
+```
+
+Also drop every filesystem path from Next Steps — that agent has no shell and
+no repo.
 
 ## Write Actions, Not Tool Calls
 
@@ -51,7 +68,7 @@ which tool does it.
 1. Add the retry guard at `src/auth.ts:88` — wrap `fetchToken()` so a 429
    retries once after honouring `Retry-After`.
 2. Commit it following the smart-commit skill
-   (`~/.codex/skills/smart-commit/SKILL.md`, install:
+   (`~/.agents/skills/smart-commit/SKILL.md`, install:
    `humblskills install smart-commit`) — one atomic conventional commit.
 ```
 


### PR DESCRIPTION
## What

Three corrections to `skills/smart-handoff/references/wiki/handoff/targets/harness-tailoring.md`, plus a `registry.json` regen for the changed `dir_sha`.

## The bug

The concept pointed Codex targets at `~/.codex/skills/` — in both the comparison table and the worked example. `cli/internal/adapters/codex.yaml` is authoritative:

```yaml
detect:
  any_of:
    - path_exists: ~/.codex
    - path_exists: ~/.agents
    - path_exists: .agents
install_targets:
  user: ~/.agents/skills
  project: .agents/skills
```

It **detects** `~/.codex` but **installs to** `~/.agents/skills`. So a handoff doc tailored to Codex told the receiving agent to read a `SKILL.md` at a path where nothing is installed — the suggested skill gets silently skipped, which is the exact failure the Suggested Skills section exists to prevent.

## Also added

- **Claude Desktop / claude.ai exception.** They cannot read skills off the filesystem at all (`claude-desktop.yaml` writes a zip; `docs/using_humblskills/platforms.md` confirms the upload flow). An `humblskills install` line is dead there, so the concept now specifies `humblskills export desktop <skill>` + the Settings → Capabilities → Skills upload, and says to drop filesystem paths from Next Steps for that target.
- **Format-portability note.** All three filesystem adapters are `transform: passthrough`, so SKILL.md is identical everywhere — only the path and the reference style change. Worth stating so nobody rewrites a skill per harness.

## Verification

- `bash scripts/lint.sh` → 0 hard findings (6 soft: synthesis-only concepts, expected)
- `bash tests/run.sh` → 22 passed, 0 failed
- `make registry` → 21 skills, `registry.json` staged in the same commit so the self-heal workflow has nothing to regenerate on `main`