### PR TITLE
docs(agents): require merge commits, never squash

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,22 @@ line, and skips *all* workflow runs for that push. A commit body explaining the 
 entire branch here — no failing check, no queued run, nothing to notice. Write it unbracketed (`skip-ci`)
 when you need to refer to it in prose.
 
+### Merge PRs with `--merge`. Never `--squash`, never `--rebase`.
+Two independent things break on a squash, both silently:
+
+1. **release-please reads the individual commit messages on `main`.** A squash collapses the whole PR into
+   its title, so a branch carrying `fix:` plus two `feat:` commits ships as a patch and loses both feature
+   changelog entries. A merge commit preserved all four and correctly produced the 2.43.0 minor bump.
+2. **`registry.json` pins `source.sha` to the commit where skill content last changed, and `install`
+   fetches the skill tarball at exactly that SHA.** Under a merge commit that SHA stays reachable forever.
+   A squash replaces it with a new commit and orphans the original, so the recorded SHA becomes
+   unreachable and installs of those skills start failing — long after the PR is forgotten.
+
+```sh
+gh pr merge <n> --merge      # correct
+gh pr merge <n> --squash     # breaks both of the above
+```
+
 ### A conflicted PR gets no CI at all
 GitHub cannot build the merge ref for a PR with conflicts, so it dispatches **no** `pull_request` workflows.
 The PR shows no checks rather than failing ones, and with nothing gating `main` it stays merge-able by hand.


### PR DESCRIPTION
The merge-vs-squash rule was never written down in `AGENTS.md`. It now has two independent reasons, either of which is sufficient, and both fail silently:

1. **release-please reads individual commit messages on `main`.** A squash collapses a multi-commit PR into its title, so a branch carrying `fix:` plus two `feat:` commits ships as a patch and loses both changelog entries.
2. **`registry.json` pins `source.sha` to the commit where skill content last changed, and `install` fetches the skill tarball at that SHA.** A merge commit keeps it reachable; a squash orphans it, so installs of those skills start 404ing long after the PR is forgotten.

Reason 2 is new as of the registry determinism fix in v2.45.0 — it was the caveat raised on that change.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)