### PR TITLE
docs: carry the registry-resolution warning into README and skillsets

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,9 +131,11 @@ humblskills registry logout         # remove the stored token
 (`echo "$TOK" | humblskills registry login`), and falls back to a `0600` file if no
 keychain is available.
 
-**Or ad-hoc / CI**, via flags or env vars (highest precedence, in this order:
-`--token` → `HUMBLSKILLS_TOKEN` → keychain → file; and `--registry` → `HUMBLSKILLS_REGISTRY`
-→ profile → hosted default):
+**Or ad-hoc / CI**, via flags or env vars. Token precedence: `--token` → `HUMBLSKILLS_TOKEN`
+→ keychain → file. Registry precedence **in single-registry mode only** (no named registries
+configured): `--registry` → `HUMBLSKILLS_REGISTRY` → `profile set registry` → hosted default.
+Once you configure named registries, `--registry` and `HUMBLSKILLS_REGISTRY` are ignored — see
+[Multiple registries](#multiple-registries-at-once) below.
 
 ```sh
 export HUMBLSKILLS_REGISTRY=https://raw.githubusercontent.com/<owner>/<repo>/main/registry.json
@@ -146,10 +148,17 @@ humblskills search
 Register several registries and `search`/`browse` show them **together, grouped by
 registry** (each skill tagged with its source). Each registry keeps its own token.
 
+> **Naming any registry replaces the default — it is not a fallback.** As soon as one named
+> registry exists in your profile, the CLI uses **exactly** that set for every command: the
+> hosted public default is no longer consulted, and `--registry`/`HUMBLSKILLS_REGISTRY` are
+> ignored. So adding only a private registry **silently hides every public skill** — `search`
+> stops listing them and `install` reports them as not found. Add `public` explicitly (first
+> line below) if you want both, and confirm with `humblskills registry list`.
+
 ```sh
 # Shorthand: pass owner/repo (or a github.com URL) — it expands to the raw
 # registry.json URL. owner/repo@branch selects a branch.
-humblskills registry add public    jjfantini/humblSKILLS
+humblskills registry add public    jjfantini/humblSKILLS   # keep the public one available
 humblskills registry add happyrobot happyrobot-ai/happySKILLS
 humblskills registry add                       # no args → prompts for name, URL, and (optional) token
 humblskills registry login --name happyrobot   # token for the private one; verifies it can read the registry

--- a/docs/using_humblskills/sharing_skillsets.md
+++ b/docs/using_humblskills/sharing_skillsets.md
@@ -44,10 +44,31 @@ On `sync`, for each listed registry the CLI:
 None of this is fatal: if a registry stays unreachable, `sync` continues and
 reports the skills it couldn't find as warnings.
 
-Skills from the public default registry contribute nothing here — every install
-of the CLI already has it. When a skill name exists in more than one registry,
-`sync` prefers the order the skillset lists them in, on the grounds that the
-file's author knows where their skills live.
+When a skill name exists in more than one registry, `sync` prefers the order the
+skillset lists them in, on the grounds that the file's author knows where their
+skills live.
+
+!!! warning "List `public` in your skillset if the team also uses public skills"
+    `export` only records **named** registries, on the assumption that every CLI already
+    has the public default. That assumption breaks on the receiving machine: adding a named
+    registry means the CLI uses **only** its named set, so the hosted public default stops
+    being consulted (see
+    [Registries](registries.md#the-mental-model)).
+
+    Concretely — a teammate with **no** named registries who syncs a skillset carrying only
+    a private `work` registry ends up with exactly one named registry, and every public
+    skill silently disappears from their `search` and `install`.
+
+    Fix it in the skillset by listing both:
+
+    ```json
+    "registries": [
+      { "name": "public", "url": "https://raw.githubusercontent.com/jjfantini/humblSKILLS/main/registry.json" },
+      { "name": "work",   "url": "https://raw.githubusercontent.com/my-company/our-skills/main/registry.json" }
+    ]
+    ```
+
+    After syncing, `humblskills registry list` shows what you actually ended up with.
 
 ## Create a skillset
 


### PR DESCRIPTION
Companion edits to #231, recovered from the same uncommitted working tree and landed against the same verified behaviour (`resolvedRegistries()` returns exactly the named set when one exists).

- **README** described a single registry precedence chain, which reads as though `--registry` always wins. It's ignored once a named registry exists.
- **Sharing skillsets** had a sharper version of the same trap: `export` only records *named* registries, assuming every CLI already has the public default. That assumption inverts on the receiving machine — importing a skillset naming only a private registry leaves the teammate with exactly one named registry, which is what makes every public skill vanish from `search` and `install`.

`mkdocs build --strict` in CI validates the new cross-reference into `registries.md#the-mental-model`.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)