### PR TITLE
docs: correct registry, token, and upgrade behavior against the source

### DIFF
--- a/docs/getting_started/installation-agent/SKILL.md
+++ b/docs/getting_started/installation-agent/SKILL.md
@@ -33,7 +33,7 @@ Optional:
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/jjfantini/humblSKILLS/main/scripts/install.sh | INSTALL_DIR=$HOME/.local/bin sh
-curl -fsSL https://raw.githubusercontent.com/jjfantini/humblSKILLS/main/scripts/install.sh | VERSION=0.1.0 sh
+curl -fsSL https://raw.githubusercontent.com/jjfantini/humblSKILLS/main/scripts/install.sh | VERSION=2.45.0 sh
 ```
 
 ### Go
@@ -56,7 +56,7 @@ humblskills doctor
 
 ```sh
 humblskills upgrade            # self-update; --dry-run to check only
-brew upgrade humblskills       # use this instead for Homebrew installs
+brew upgrade humblskills       # equivalent; on brew installs `upgrade` runs this for you
 ```
 
 `upgrade` updates the CLI binary; `update` updates installed skills.
@@ -91,15 +91,24 @@ Claude Desktop and claude.ai can't read skills from disk. Restrict with
 
 ### Private / additional registries
 
+Naming **any** registry makes the CLI use **only** its named set — the hosted public
+default stops being consulted, and `--registry` / `HUMBLSKILLS_REGISTRY` /
+`profile set registry` are ignored. So adding just a private registry silently hides
+every public skill (`search` omits them, `install` reports them as not found). Add
+`public` too unless private-only is what you want:
+
 ```sh
+humblskills registry add public https://raw.githubusercontent.com/jjfantini/humblSKILLS/main/registry.json
 humblskills registry add work my-company/our-skills   # owner/repo shorthand works
 humblskills registry login --name work                # token → OS keychain (or pipe it on stdin)
-humblskills registry list
+humblskills registry list                             # confirm what you ended up with
 humblskills install <skill> --from work               # if a name exists in several registries
 ```
 
-Non-interactive alternative: `HUMBLSKILLS_REGISTRY` + `HUMBLSKILLS_TOKEN`, or the
-global `--registry` / `--token` flags.
+Tokens for named registries come from the keychain (`registry login --name`), with
+`HUMBLSKILLS_TOKEN` as a shared fallback. The global `--token` and `--registry` flags
+and `HUMBLSKILLS_REGISTRY` apply **only** when no registry is named. Details:
+[Registries](https://jjfantini.github.io/humblSKILLS/using_humblskills/registries/#the-mental-model).
 
 ### Team skillsets
 

--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -41,7 +41,7 @@ curl -fsSL https://raw.githubusercontent.com/jjfantini/humblSKILLS/main/scripts/
 Pin a version (example: `0.1.0`):
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/jjfantini/humblSKILLS/main/scripts/install.sh | VERSION=0.1.0 sh
+curl -fsSL https://raw.githubusercontent.com/jjfantini/humblSKILLS/main/scripts/install.sh | VERSION=2.45.0 sh
 ```
 
 ## Go
@@ -80,8 +80,10 @@ humblskills upgrade              # self-update: download, verify, swap the binar
 humblskills upgrade --dry-run    # just show the version you'd move to
 ```
 
-Homebrew installs are upgraded through Homebrew instead, so its bookkeeping stays
-correct — `upgrade` will tell you so:
+On a Homebrew-managed install, `upgrade` detects that, asks for confirmation, and
+runs `brew update && brew upgrade humblskills` for you, so Homebrew's own Cellar
+bookkeeping stays correct. It only asks you to run brew yourself if `brew` isn't on
+`PATH`. You can of course still do it directly:
 
 ```sh
 brew upgrade humblskills
@@ -98,7 +100,9 @@ Tab-complete skill names, registry names, and flag values:
 humblskills completion zsh --help    # also: bash, fish, powershell
 ```
 
-Each shell's `--help` prints the exact line to add to your shell config.
+Each shell's `--help` prints the exact setup steps for that shell — for zsh and bash
+that's a one-time command to run (writing the completion file), not a line to paste
+into your shell config.
 
 ## Next
 

--- a/docs/getting_started/quickstart.md
+++ b/docs/getting_started/quickstart.md
@@ -144,7 +144,7 @@ humblskills completion zsh --help    # also: bash, fish, powershell
 | `uninstall` | Remove a skill |
 | `migrate` | Adopt hand-installed skills into humblskills |
 | `registry` | Add / list / rename / remove registries, login, refresh |
-| `profile` | Defaults: platforms, scope, registry, TUI options |
+| `profile` | Defaults: platforms, scope, registry (single-registry setups only), TUI options |
 | `init` / `export` / `sync` | Share a skillset with a team |
 | `export desktop` | Write Claude Desktop / claude.ai upload zips |
 | `eval` | Benchmark a skill across arms |

--- a/docs/using_humblskills/platforms.md
+++ b/docs/using_humblskills/platforms.md
@@ -43,7 +43,11 @@ into it. That means one copy on disk, one place to update.
 |-------|---------------------|
 | `global` (the default) | `~/.humblskills/skills/<skill-id>` |
 | `user` | `$XDG_DATA_HOME/humblskills/skills/<skill-id>` |
-| `project` | `<current repo>/.humblskills/skills/<skill-id>` |
+| `project` | `<current directory>/.humblskills/skills/<skill-id>` |
+| `adapter-default` | Whatever each platform adapter defines as its own default location |
+
+`project` scope resolves against your **working directory**, not the repository root —
+running it from a subdirectory creates a second store nested there.
 
 ```sh
 humblskills install smart-commit                    # global (default)

--- a/docs/using_humblskills/registries.md
+++ b/docs/using_humblskills/registries.md
@@ -105,9 +105,16 @@ humblskills registry login --name work --token "$GITHUB_TOKEN"  # flag
 ```
 
 !!! note "Where the token is looked up"
-    Highest precedence first: `--token` → `HUMBLSKILLS_TOKEN` → OS keychain →
-    a `0600` fallback file (used only when no keychain is available). Tokens are
-    ignored for `file://` registries and for the public default.
+    For a **named** registry, highest precedence first: that registry's **own** stored
+    token (`registry login --name <n>`) → `HUMBLSKILLS_TOKEN` → the default stored token.
+    A single default token can therefore cover several registries that have none of their
+    own — which is what `registry list` means by `token: inherited default`.
+
+    The global **`--token` flag is not consulted for named registries** — it only applies
+    in single-registry mode, where the chain is `--token` → `HUMBLSKILLS_TOKEN` → stored
+    token. "Stored" means the OS keychain, or a `0600` file when no keychain is available.
+
+    Tokens are ignored for `file://` registries and for the public default.
 
 ## Installing when a name exists in two registries
 
@@ -181,8 +188,8 @@ humblskills search
     registries configured, use `--from <name>` to pick among them, or
     `humblskills registry remove` / a separate `--profile <path>` for a throwaway config.
 
-Token lookup is independent of that, highest precedence first: `--token` →
-`HUMBLSKILLS_TOKEN` → OS keychain → `0600` fallback file.
+Token lookup is a separate chain, and it also differs by mode — see
+[Where the token is looked up](#private-registries-add-a-token) above.
 
 ## Tab completion
 

--- a/docs/using_humblskills/sharing_skillsets.md
+++ b/docs/using_humblskills/sharing_skillsets.md
@@ -41,8 +41,11 @@ On `sync`, for each listed registry the CLI:
    through creating and storing one — the same path as
    [`registry login`](registries.md#private-registries-add-a-token).
 
-None of this is fatal: if a registry stays unreachable, `sync` continues and
-reports the skills it couldn't find as warnings.
+A **single** unreachable registry is not fatal: `sync` warns, continues, and reports
+that registry's skills as not-found. But if **every** configured registry fails to
+load, `sync` aborts and installs nothing — which is exactly what a skillset naming
+only a private registry does on a machine that has no token for it yet. Listing
+`public` alongside it (below) also keeps `sync` alive in that case.
 
 When a skill name exists in more than one registry, `sync` prefers the order the
 skillset lists them in, on the grounds that the file's author knows where their
@@ -101,11 +104,11 @@ By default `sync` only **adds** skills. Pass `--prune` to also **remove** any lo
 humblskills sync --prune
 ```
 
-Pruning is destructive, so it asks for confirmation (skip with `--yes`, or run with `--json` for a machine-readable summary instead of a prompt).
+Pruning is destructive, so it asks for confirmation. Pass `--yes` to consent up front. In a pipe, in CI, or with `--json` there is nobody to ask, so it **stops with an error** naming what it would delete rather than proceeding — the same gate as `update --force`.
 
 ### Platforms and scope
 
-`export`, `init`, and `sync` follow the same platform/scope rules as `install`: explicit `--platform`/`--scope`/`--global` flags win, otherwise your [profile](../getting_started/quickstart.md) defaults apply.
+`sync` follows the same platform/scope rules as `install`: explicit `--platform`/`--scope`/`--global` flags win, otherwise your [profile](../getting_started/quickstart.md) defaults apply. `init` and `export` only write the skillset file, so they take no platform or scope flags.
 
 ## Related topics
 

--- a/docs/using_humblskills/updating.md
+++ b/docs/using_humblskills/updating.md
@@ -120,8 +120,10 @@ humblskills upgrade --dry-run    # just report the version you'd move to
 The upgrade checks GitHub releases, verifies the checksum, and replaces the
 running binary in place.
 
-If you installed via Homebrew, `upgrade` tells you to use Homebrew instead, so
-Homebrew's own bookkeeping stays correct:
+If you installed via Homebrew, `upgrade` detects that and delegates: it confirms with
+you, then runs `brew update && brew upgrade humblskills` itself, so Homebrew's own
+bookkeeping stays correct. It falls back to telling you to run brew by hand only when
+`brew` isn't on `PATH`. Doing it directly works too:
 
 ```sh
 brew upgrade humblskills


### PR DESCRIPTION
Audited the published docs against the v2.43.0 CLI ahead of onboarding someone onto a private registry. Seven files carried claims the code contradicts. Every finding below was verified against source or empirically — none are taken on trust.

## The one that matters most

`docs/getting_started/installation-agent/SKILL.md` is what `installation.md` tells users to point their agent at, and it is read **standalone** — it never inherits the warnings on the registries page. It recommended:

```sh
humblskills registry add work my-company/our-skills
```

with no mention that naming any registry makes `resolvedRegistries()` (`cli/cmd/humblskills/registries.go:84`) return **only** the named set, so the hosted public default stops being consulted. Proven in a sandboxed profile:

- `search` → `{"results": null}`
- `install smart-commit` → `skill "smart-commit" not found in any configured registry`

It then offered `HUMBLSKILLS_REGISTRY` / `--registry` as a "non-interactive alternative" immediately below, which is false — both are ignored once a registry is named (verified: `search --registry file:///nonexistent/registry.json` still succeeds).

## Token precedence

`--token` reaches only the single-registry path (`registries.go:93`). A named registry resolves its **own** stored token → `HUMBLSKILLS_TOKEN` → the default stored token (`secrets.go:267-276`) — that last fallback is what `registry list` prints as `token: inherited default`.

## `upgrade` on Homebrew installs

Three files claimed `upgrade` tells you to use Homebrew yourself. It doesn't: `applyHomebrewUpgrade` (`upgrade.go:170`) confirms, then runs `brew update && brew upgrade humblskills` itself, deferring to the user only on `ErrBrewNotFound`.

## Skillset docs

- Claimed an unreachable registry always degrades to warnings. `runSync` (`skillset.go:221`) **aborts when no registry loads** — exactly what a skillset naming only a private registry does on a machine with no token yet. Zero skills install.
- `--prune --json` **errors out** rather than printing a summary (`confirm.go:35` treats `--json` as "nobody to ask").
- `init` and `export` take no platform/scope flags (only `sync` registers them; confirmed via `--help`).

## Smaller corrections

- `project` scope resolves against `os.Getwd()`, not the repo root (`store.go:32`) — a subdirectory creates a nested store.
- `adapter-default` was missing from the scope table despite `install --help` advertising it.
- `VERSION=0.1.0` read as though 0.1.0 were current (44 minor versions stale).
- zsh/bash completion `--help` prints a command to run once, not a config line to paste.

## Verification

- `mkdocs build --strict` passes.
- Nested table inside the new admonition confirmed rendering in the built HTML.
- All cross-reference anchors resolve.
- The published `SKILL.md` copy generated by the mkdocs hook carries the corrected registry section.

Docs-only, so this touches neither `cli/internal/**` nor `skills/**` and won't trigger a `registry.json` regeneration conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)