### PR TITLE
fix(registry): keep the current registry reachable when naming the first one

### DIFF
--- a/cli/cmd/humblskills/registry.go
+++ b/cli/cmd/humblskills/registry.go
@@ -11,6 +11,7 @@ import (
 	"golang.org/x/term"
 
 	"github.com/jjfantini/humblSKILLS/cli/v2/internal/profile"
+	"github.com/jjfantini/humblSKILLS/cli/v2/internal/registry"
 	"github.com/jjfantini/humblSKILLS/cli/v2/internal/secrets"
 	"github.com/jjfantini/humblSKILLS/cli/v2/internal/textutil"
 	"github.com/jjfantini/humblSKILLS/cli/v2/internal/tui"
@@ -112,38 +113,78 @@ func newRegistryRemoveCmd(app *App) *cobra.Command {
 	}
 }
 
-// addRegistry validates and persists a named registry. Shared by the direct
-// and interactive add paths.
-func addRegistry(app *App, name, url string) (string, string, error) {
+// addRegistry validates and persists a named registry. Shared by the direct,
+// interactive, and skillset-bootstrap add paths. The third return value is the
+// name of a companion registry seeded alongside it, or "" when none was needed
+// — see seedEffectiveRegistry.
+func addRegistry(app *App, name, url string) (string, string, string, error) {
 	name = strings.TrimSpace(name)
 	// Expand shorthands (owner/repo, github.com URLs) into a raw registry.json URL.
 	url = normalizeRegistryURL(strings.TrimSpace(url))
 	if name == "" {
-		return "", "", fmt.Errorf("registry name must not be empty")
+		return "", "", "", fmt.Errorf("registry name must not be empty")
 	}
 	if !isPlausibleRegistry(url) {
-		return "", "", fmt.Errorf("invalid registry URL %q — expected an http(s):// URL, a file:// URL, or a filesystem path", url)
+		return "", "", "", fmt.Errorf("invalid registry URL %q — expected an http(s):// URL, a file:// URL, or a filesystem path", url)
 	}
 	p, err := profile.Load(app.Config.ProfilePath)
 	if err != nil {
-		return "", "", err
+		return "", "", "", err
 	}
+	seeded := seedEffectiveRegistry(p, name)
 	p.SetRegistry(name, url)
 	if err := profile.Save(app.Config.ProfilePath, p); err != nil {
-		return "", "", err
+		return "", "", "", err
 	}
-	return name, url, nil
+	return name, url, seeded, nil
+}
+
+// seedEffectiveRegistry keeps the registry that was already in effect reachable
+// once the profile names its first one.
+//
+// resolvedRegistries() returns ONLY the named set as soon as it is non-empty, so
+// without this a first `registry add work …` silently drops the registry the user
+// was actually using — the hosted default, or a `profile set registry` URL — and
+// every skill it carried: search stops listing them and install reports them as
+// "not found in any configured registry". Seeding it as a named entry makes the
+// two modes continuous instead of a silent cutover.
+//
+// Returns the name it seeded, or "" when nothing needed seeding.
+func seedEffectiveRegistry(p *profile.Profile, adding string) string {
+	if len(p.Registries) > 0 {
+		return "" // already multi-registry: nothing is implicit any more
+	}
+	// Persisted state only. A transient --registry/HUMBLSKILLS_REGISTRY on this
+	// very invocation is not something to write into the profile.
+	name, url := "public", registry.DefaultURL
+	if p.Registry != "" {
+		name, url = "default", p.Registry
+	}
+	if name == adding {
+		return "" // the caller is naming that same registry itself
+	}
+	p.SetRegistry(name, url)
+	return name
 }
 
 func runRegistryAdd(app *App, name, url string) error {
-	name, url, err := addRegistry(app, name, url)
+	name, url, seeded, err := addRegistry(app, name, url)
 	if err != nil {
 		return err
 	}
 	if app.Config.JSON {
-		return app.UI.JSON(map[string]string{"name": name, "url": url})
+		out := map[string]string{"name": name, "url": url}
+		if seeded != "" {
+			out["seeded"] = seeded
+		}
+		return app.UI.JSON(out)
 	}
 	app.UI.Success("added registry %q → %s", name, url)
+	if seeded != "" {
+		// Info, not Detail: this writes a profile entry the user didn't ask for,
+		// and Detail is invisible without -v.
+		app.UI.Info("also kept %q, the registry you were already using — naming a registry replaces the default rather than adding to it", seeded)
+	}
 	app.UI.Detail("store its token (if private) with: humblskills registry login --name %s", name)
 	return nil
 }
@@ -157,11 +198,16 @@ func runRegistryAddInteractive(app *App) error {
 	if err != nil {
 		return err
 	}
-	name, url, err = addRegistry(app, name, url)
+	name, url, seeded, err := addRegistry(app, name, url)
 	if err != nil {
 		return err
 	}
 	app.UI.Success("added registry %q → %s", name, url)
+	if seeded != "" {
+		// Info, not Detail: this writes a profile entry the user didn't ask for,
+		// and Detail is invisible without -v.
+		app.UI.Info("also kept %q, the registry you were already using — naming a registry replaces the default rather than adding to it", seeded)
+	}
 
 	store, err := app.Prompt.Confirm("Store an auth token for this registry now? (private registries only)", false)
 	if err != nil {

--- a/cli/cmd/humblskills/registry_test.go
+++ b/cli/cmd/humblskills/registry_test.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/jjfantini/humblSKILLS/cli/v2/internal/profile"
+	"github.com/jjfantini/humblSKILLS/cli/v2/internal/registry"
 	"github.com/jjfantini/humblSKILLS/cli/v2/internal/testutil"
 )
 
@@ -43,4 +45,105 @@ func TestRegistryRefresh_FileURLReportsFileOrigin(t *testing.T) {
 	if out.Skills != 1 {
 		t.Errorf("skills = %d", out.Skills)
 	}
+}
+
+// Naming the first registry must not silently drop the registry that was already
+// in effect: resolvedRegistries() returns ONLY the named set once it is non-empty,
+// so `registry add work …` on a fresh profile used to hide every public skill.
+func TestRegistryAdd_SeedsPreviouslyEffectiveRegistry(t *testing.T) {
+	t.Run("fresh profile keeps the hosted default as public", func(t *testing.T) {
+		s := testutil.NewSandbox(t)
+
+		res := runCLIWithStdoutCapture(t,
+			"registry", "add", "work", "https://example.com/work/registry.json",
+			"--profile", s.ProfilePath,
+			"--cache-dir", s.CacheDir,
+			"--json",
+		)
+		if res.RunErr != nil {
+			t.Fatalf("run: %v\n%s", res.RunErr, res.Err)
+		}
+
+		p, err := profile.Load(s.ProfilePath)
+		if err != nil {
+			t.Fatalf("load profile: %v", err)
+		}
+		got := map[string]string{}
+		for _, r := range p.Registries {
+			got[r.Name] = r.URL
+		}
+		if len(got) != 2 {
+			t.Fatalf("registries = %v, want work + public", got)
+		}
+		if got["work"] != "https://example.com/work/registry.json" {
+			t.Errorf("work = %q", got["work"])
+		}
+		if got["public"] != registry.DefaultURL {
+			t.Errorf("public = %q, want %q", got["public"], registry.DefaultURL)
+		}
+		if idx := strings.Index(res.Out, "{"); idx >= 0 {
+			var out struct{ Seeded string }
+			if err := json.Unmarshal([]byte(res.Out[idx:]), &out); err == nil && out.Seeded != "public" {
+				t.Errorf("json seeded = %q, want public", out.Seeded)
+			}
+		}
+	})
+
+	t.Run("a custom profile registry is kept under default", func(t *testing.T) {
+		s := testutil.NewSandbox(t)
+		if res := runCLI(t, "profile", "set", "registry", "https://example.com/mine/registry.json",
+			"--profile", s.ProfilePath, "--cache-dir", s.CacheDir); res.RunErr != nil {
+			t.Fatalf("profile set: %v\n%s", res.RunErr, res.Err)
+		}
+
+		if res := runCLI(t, "registry", "add", "work", "https://example.com/work/registry.json",
+			"--profile", s.ProfilePath, "--cache-dir", s.CacheDir); res.RunErr != nil {
+			t.Fatalf("registry add: %v\n%s", res.RunErr, res.Err)
+		}
+
+		p, err := profile.Load(s.ProfilePath)
+		if err != nil {
+			t.Fatalf("load profile: %v", err)
+		}
+		got := map[string]string{}
+		for _, r := range p.Registries {
+			got[r.Name] = r.URL
+		}
+		if got["default"] != "https://example.com/mine/registry.json" {
+			t.Errorf("default = %q, want the profile's own registry URL (got %v)", got["default"], got)
+		}
+	})
+
+	t.Run("second add seeds nothing further", func(t *testing.T) {
+		s := testutil.NewSandbox(t)
+		for _, name := range []string{"work", "extra"} {
+			if res := runCLI(t, "registry", "add", name, "https://example.com/"+name+"/registry.json",
+				"--profile", s.ProfilePath, "--cache-dir", s.CacheDir); res.RunErr != nil {
+				t.Fatalf("add %s: %v\n%s", name, res.RunErr, res.Err)
+			}
+		}
+		p, err := profile.Load(s.ProfilePath)
+		if err != nil {
+			t.Fatalf("load profile: %v", err)
+		}
+		// work + extra + one seeded public, and nothing more.
+		if len(p.Registries) != 3 {
+			t.Errorf("registries = %d, want 3 (work, extra, public): %+v", len(p.Registries), p.Registries)
+		}
+	})
+
+	t.Run("naming public itself seeds nothing", func(t *testing.T) {
+		s := testutil.NewSandbox(t)
+		if res := runCLI(t, "registry", "add", "public", registry.DefaultURL,
+			"--profile", s.ProfilePath, "--cache-dir", s.CacheDir); res.RunErr != nil {
+			t.Fatalf("add: %v\n%s", res.RunErr, res.Err)
+		}
+		p, err := profile.Load(s.ProfilePath)
+		if err != nil {
+			t.Fatalf("load profile: %v", err)
+		}
+		if len(p.Registries) != 1 {
+			t.Errorf("registries = %d, want 1: %+v", len(p.Registries), p.Registries)
+		}
+	})
 }

--- a/cli/cmd/humblskills/skillset.go
+++ b/cli/cmd/humblskills/skillset.go
@@ -354,12 +354,15 @@ func bootstrapSkillsetRegistries(app *App, set *skillset.Set) {
 			ensureRegistryReadable(app, r.Name)
 			continue
 		}
-		name, url, err := addRegistry(app, r.Name, r.URL)
+		name, url, seeded, err := addRegistry(app, r.Name, r.URL)
 		if err != nil {
 			app.UI.Warn("skillset registry %q: %v", r.Name, err)
 			continue
 		}
 		app.UI.Success("added registry %s → %s", name, url)
+		if seeded != "" {
+			app.UI.Info("also kept %q, the registry you were already using", seeded)
+		}
 		ensureRegistryReadable(app, name)
 	}
 }


### PR DESCRIPTION
Found while auditing the docs for #233. The docs were wrong, but so is the behavior they were describing.

## The bug

`resolvedRegistries()` (`cli/cmd/humblskills/registries.go:84`) returns **only** the profile's named registries once that list is non-empty. It falls back to `--registry` / `HUMBLSKILLS_REGISTRY` / `profile set registry` / hosted default **only when it is empty**. There is no merge between the two modes.

So the very first `humblskills registry add work my-company/our-skills` silently removed the registry the user was actually using:

```
$ humblskills search --profile <fresh>          # before: full public catalog
$ humblskills registry add work https://…/registry.json
$ humblskills search --profile <fresh> --json
{ "results": null }
$ humblskills install smart-commit --profile <fresh>
humblskills: skill "smart-commit" not found in any configured registry
```

Nothing warned, and the profile looked correct — the registry they added was right there.

`sync` reached the same cliff without anyone typing `registry add`: `bootstrapSkillsetRegistries` (`skillset.go:340`) adds whatever registries a skillset names, so a teammate with no named registries who synced a skillset carrying one private registry lost the public catalog as a side effect of installing from a file. `export` encodes the assumption in a comment — *"every CLI already has the default"* (`skillset.go:127`) — which is exactly what stops being true the moment anything is named.

## The fix

`seedEffectiveRegistry` carries the previously-effective registry forward as a named entry the first time the profile names one:

- hosted default → seeded as `public`
- a `profile set registry` URL → seeded as `default`, so custom single-registry setups are preserved rather than silently replaced by the public one

It seeds only from **persisted** state (a transient `--registry` on the same invocation is not something to write into a profile), and skips when the caller is naming that same registry itself.

Applied in `addRegistry`, the one choke point all three add paths route through — direct, interactive, and skillset bootstrap — so none of them can regress separately.

```
$ humblskills registry add work https://example.com/work/registry.json
✓ added registry "work" → https://example.com/work/registry.json
also kept "public", the registry you were already using — naming a registry replaces the default rather than adding to it
```

Reported with `Info` rather than `Detail` because it writes an entry the user didn't ask for and `Detail` is invisible without `-v` (`internal/ui/ui.go:116`). `--json` callers get a `"seeded"` key.

## Verification

- New test asserts all four cases: fresh profile seeds `public`, a custom `profile set registry` is kept under `default`, a second add seeds nothing further, and naming `public` yourself seeds nothing.
- **Confirmed the test fails without the fix** — `registries = map[work:https://example.com/work/registry.json], want work + public`.
- `go build`, `go vet`, and the full `go test -race -count=1 ./...` suite are green; no existing test depended on the old semantics.

Touches only `cli/cmd/**`, so it won't trigger a `registry.json` regeneration conflict with an open release PR.

## Docs follow-up

#233 documents the current (pre-fix) behavior, which is correct for anyone on 2.45.0 and should merge as-is. Once this ships, the "add `public` explicitly" guidance becomes belt-and-braces rather than required — worth a follow-up pass phrased so it stays true on both old and new builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)