### PR TITLE
docs(registries): reconcile with the seeding fix in #234

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,18 +148,17 @@ humblskills search
 Register several registries and `search`/`browse` show them **together, grouped by
 registry** (each skill tagged with its source). Each registry keeps its own token.
 
-> **Naming any registry replaces the default — it is not a fallback.** As soon as one named
-> registry exists in your profile, the CLI uses **exactly** that set for every command: the
-> hosted public default is no longer consulted, and `--registry`/`HUMBLSKILLS_REGISTRY` are
-> ignored. So adding only a private registry **silently hides every public skill** — `search`
-> stops listing them and `install` reports them as not found. Add `public` explicitly (first
-> line below) if you want both, and confirm with `humblskills registry list`.
+> **Naming a registry replaces the default — but the CLI keeps the old one for you.** As soon
+> as one named registry exists in your profile, the CLI uses **exactly** that set for every
+> command: the hosted public default is no longer consulted, and `--registry`/`HUMBLSKILLS_REGISTRY`
+> are ignored. Because that replaces rather than adds, the **first** `registry add` seeds whatever
+> you were already using — `public`, or `default` pointing at your `profile set registry` URL —
+> and tells you it did. Private-only is still available: `humblskills registry remove public`.
 
 ```sh
 # Shorthand: pass owner/repo (or a github.com URL) — it expands to the raw
 # registry.json URL. owner/repo@branch selects a branch.
-humblskills registry add public    jjfantini/humblSKILLS   # keep the public one available
-humblskills registry add happyrobot happyrobot-ai/happySKILLS
+humblskills registry add happyrobot jenningsfantini-happyrobot/happySKILLS   # public is seeded automatically
 humblskills registry add                       # no args → prompts for name, URL, and (optional) token
 humblskills registry login --name happyrobot   # token for the private one; verifies it can read the registry
 humblskills registry list                      # show configured registries + token state

--- a/docs/getting_started/installation-agent/SKILL.md
+++ b/docs/getting_started/installation-agent/SKILL.md
@@ -93,13 +93,13 @@ Claude Desktop and claude.ai can't read skills from disk. Restrict with
 
 Naming **any** registry makes the CLI use **only** its named set — the hosted public
 default stops being consulted, and `--registry` / `HUMBLSKILLS_REGISTRY` /
-`profile set registry` are ignored. So adding just a private registry silently hides
-every public skill (`search` omits them, `install` reports them as not found). Add
-`public` too unless private-only is what you want:
+`profile set registry` are ignored. Because that replaces rather than adds, the **first**
+`registry add` seeds whatever was already in effect (`public`, or `default` for a
+`profile set registry` URL) and reports it. So you do not need to add `public` yourself;
+for private-only, run `humblskills registry remove public` afterwards.
 
 ```sh
-humblskills registry add public https://raw.githubusercontent.com/jjfantini/humblSKILLS/main/registry.json
-humblskills registry add work my-company/our-skills   # owner/repo shorthand works
+humblskills registry add work my-company/our-skills   # owner/repo shorthand; seeds public
 humblskills registry login --name work                # token → OS keychain (or pipe it on stdin)
 humblskills registry list                             # confirm what you ended up with
 humblskills install <skill> --from work               # if a name exists in several registries

--- a/docs/using_humblskills/registries.md
+++ b/docs/using_humblskills/registries.md
@@ -27,7 +27,7 @@ Tokens are stored in your **OS keychain** (macOS Keychain, Windows Credential
 Manager, Linux Secret Service), not in a config file. They never appear in
 `humblskills profile show`.
 
-!!! warning "Naming any registry replaces the default — it is not a fallback"
+!!! note "Naming a registry replaces the default — but the CLI keeps the old one for you"
     The CLI runs in one of two modes, and there is **no fallback between them**:
 
     - **No named registries** → single-registry mode, using
@@ -36,16 +36,21 @@ Manager, Linux Secret Service), not in a config file. They never appear in
       The hosted public default is no longer consulted, and `--registry` /
       `HUMBLSKILLS_REGISTRY` are **ignored**.
 
-    So `humblskills registry add work my-company/our-skills` on its own **silently hides every
-    public skill** — `search` stops listing them and `install` reports them as not found. If you
-    want both, add both:
+    Because naming a registry *replaces* rather than adds, the first
+    `humblskills registry add` would otherwise drop whatever you were already using. It doesn't:
+    the CLI seeds that registry alongside the one you named, and says so.
 
-    ```sh
-    humblskills registry add public jjfantini/humblSKILLS
-    humblskills registry add work   my-company/our-skills
+    ```console
+    $ humblskills registry add work my-company/our-skills
+    ✓ added registry work → https://raw.githubusercontent.com/my-company/our-skills/main/registry.json
+    also kept "public", the registry you were already using — naming a registry replaces the
+    default rather than adding to it
     ```
 
-    Check what you actually have with `humblskills registry list`.
+    Seeding happens only on the **first** named registry, since after that nothing is implicit
+    any more. It seeds `public` (the hosted default), or `default` pointing at your
+    `profile set registry` URL if you had set one. Want private-only? Remove the seeded entry
+    with `humblskills registry remove public`. Check what you have with `humblskills registry list`.
 
 ## Add a second registry
 
@@ -54,15 +59,14 @@ the `owner/repo` shorthand — the CLI expands that into the raw `registry.json`
 URL for you.
 
 ```sh
-humblskills registry add public     jjfantini/humblSKILLS               # add this too — see the warning above
 humblskills registry add work       my-company/our-skills
 humblskills registry add work       my-company/our-skills@develop   # pick a branch
 humblskills registry add                                            # no args → prompts you
 ```
 
-**Add `public` explicitly** the first time you name a registry. As soon as one named
-registry exists, the built-in public default stops being consulted — naming only your
-private registry is what makes public skills vanish.
+You don't need to add `public` yourself — the first `registry add` seeds whatever you were
+already using, so the public catalog stays reachable (see the note above). Adding it
+explicitly is harmless if you prefer to be exact about it.
 
 Run `humblskills registry add` with no arguments and it asks for the name, the
 URL, and (optionally) a token — handy if you'd rather not remember the flags.

--- a/docs/using_humblskills/sharing_skillsets.md
+++ b/docs/using_humblskills/sharing_skillsets.md
@@ -42,27 +42,29 @@ On `sync`, for each listed registry the CLI:
    [`registry login`](registries.md#private-registries-add-a-token).
 
 A **single** unreachable registry is not fatal: `sync` warns, continues, and reports
-that registry's skills as not-found. But if **every** configured registry fails to
-load, `sync` aborts and installs nothing — which is exactly what a skillset naming
-only a private registry does on a machine that has no token for it yet. Listing
-`public` alongside it (below) also keeps `sync` alive in that case.
+that registry's skills as not-found. But if **every** configured registry fails to load,
+`sync` aborts and installs nothing. Seeding makes that much harder to hit — a machine
+syncing a skillset that names only a private registry still ends up with the public one
+alongside it — but it is still reachable if every registry in play is unreadable.
 
 When a skill name exists in more than one registry, `sync` prefers the order the
 skillset lists them in, on the grounds that the file's author knows where their
 skills live.
 
-!!! warning "List `public` in your skillset if the team also uses public skills"
-    `export` only records **named** registries, on the assumption that every CLI already
-    has the public default. That assumption breaks on the receiving machine: adding a named
-    registry means the CLI uses **only** its named set, so the hosted public default stops
-    being consulted (see
+!!! note "Your teammate keeps their public catalog automatically"
+    `export` only records **named** registries, on the assumption that every CLI already has
+    the public default. That assumption stops holding the moment anything is named, because
+    naming a registry replaces the default rather than adding to it (see
     [Registries](registries.md#the-mental-model)).
 
-    Concretely — a teammate with **no** named registries who syncs a skillset carrying only
-    a private `work` registry ends up with exactly one named registry, and every public
-    skill silently disappears from their `search` and `install`.
+    `sync` bootstraps skillset registries through the same path as `registry add`, so the
+    first one it adds seeds whatever the receiving machine was already using. A teammate with
+    no named registries who syncs a skillset carrying only a private `work` registry ends up
+    with **both** `work` and `public`, and sees `also kept "public", the registry you were
+    already using` in the output.
 
-    Fix it in the skillset by listing both:
+    You can still list `public` explicitly if you want the skillset to be self-describing
+    rather than relying on that:
 
     ```json
     "registries": [


### PR DESCRIPTION
#234 fixed the behaviour, but no documentation was updated alongside it. `main` currently ships four pages telling users to work around a bug that no longer exists, and to perform a step the CLI now does itself.

## Verified, not inferred

```console
$ humblskills registry add work https://…/registry.json --profile <fresh>
✓ added registry "work" → https://…/registry.json
also kept "public", the registry you were already using — naming a registry replaces
the default rather than adding to it
```

Resulting profile contains **both** `public` and `work`. Both entry points seed: `registry add` calls `seedEffectiveRegistry` directly, and `sync` reaches it via `bootstrapSkillsetRegistries` → `addRegistry`.

## What stays

The mode semantics are unchanged and still worth stating: naming a registry **replaces** the default rather than adding to it, and `--registry` / `HUMBLSKILLS_REGISTRY` are ignored once anything is named. The CLI's own new message says exactly that.

## What goes

| Page | Stale claim |
|---|---|
| `docs/using_humblskills/registries.md` | "silently hides every public skill… if you want both, add both" |
| `README.md` | same, plus "Add `public` explicitly" |
| `docs/using_humblskills/sharing_skillsets.md` | "List `public` in your skillset… every public skill silently disappears" |
| `docs/getting_started/installation-agent/SKILL.md` | "Add `public` too unless private-only is what you want" |

The last one matters most — it's the **agent-facing** install doc, so an agent following it would add a registry the CLI had already seeded.

Also narrows the sharing-skillsets claim about `sync` aborting when every registry fails: still true, but seeding makes it much harder to reach.

Also corrects the private registry example owner to `jenningsfantini-happyrobot/happySKILLS`. Note that repo is private, so the example 404s for public readers — say the word and I'll switch it to the `my-company/our-skills` placeholder used elsewhere.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)