### PR TITLE
fix(tui): scroll long lists instead of pushing the header off screen

### DIFF
--- a/cli/internal/tui/chrome.go
+++ b/cli/internal/tui/chrome.go
@@ -101,10 +101,10 @@ func DashedRule(theme *ui.Theme, width int) string {
 	return theme.RuleLine.Render(strings.Repeat("╌", width))
 }
 
-// Frame composes header + body + footer into one renderable string, padding
-// the body to bodyHeight rows so the footer sits at a predictable y.
+// Frame composes header + body + footer into one renderable string, fitting
+// the body to exactly bodyHeight rows so the footer sits at a predictable y.
 func Frame(header, body, footer string, bodyHeight int) string {
-	body = padToHeight(body, bodyHeight)
+	body = fitToHeight(body, bodyHeight)
 	return header + "\n\n" + body + "\n" + footer
 }
 
@@ -121,15 +121,48 @@ func padBetween(left, right string, width int) string {
 	return left + strings.Repeat(" ", gap) + right
 }
 
-func padToHeight(s string, h int) string {
+// fitToHeight forces s to exactly h rows: short bodies get blank rows appended
+// so the footer lands at a fixed y, and over-tall bodies get their overflow
+// dropped.
+//
+// The truncation half is load-bearing, not defensive. Every screen here renders
+// into an alt-screen whose height is fixed, so a body even one row too tall
+// makes the terminal scroll the whole frame up — the header disappears off the
+// top and nothing can bring it back, because the frame is re-rendered from
+// scratch each tick with the same overflow. Screens that own more content than
+// fits must window it themselves (a viewport, or Model's left-pane window);
+// this clamp only guarantees the chrome survives when one doesn't.
+func fitToHeight(s string, h int) string {
 	if h <= 0 {
 		return s
 	}
 	lines := lipgloss.Height(s)
-	if lines >= h {
+	if lines == h {
 		return s
 	}
-	return s + strings.Repeat("\n", h-lines)
+	if lines < h {
+		return s + strings.Repeat("\n", h-lines)
+	}
+	return strings.Join(strings.Split(s, "\n")[:h], "\n")
+}
+
+// fitToWidth forces s to exactly w display cells, padding short strings with
+// spaces and truncating long ones with an ellipsis. ANSI-aware on both sides:
+// lipgloss.Width ignores escape sequences when measuring, and ansi.Truncate
+// keeps them intact so a clipped row can't leak its styling into the rest of
+// the line.
+func fitToWidth(s string, w int) string {
+	if w < 1 {
+		return ""
+	}
+	switch sw := lipgloss.Width(s); {
+	case sw == w:
+		return s
+	case sw < w:
+		return s + strings.Repeat(" ", w-sw)
+	default:
+		return ansi.Truncate(s, w, "…")
+	}
 }
 
 func max(a, b int) int {

--- a/cli/internal/tui/dashboard.go
+++ b/cli/internal/tui/dashboard.go
@@ -383,9 +383,11 @@ func (m dashboardModel) View() string {
 		gridView += "\n  " + th.Crumb.Render("no command matches "+fmt.Sprintf("%q", m.query))
 	}
 
-	// Pad the grid view to exactly gridHeight() lines so the footer sits at
-	// a predictable row regardless of content size.
-	gridView = padToHeight(gridView, m.gridHeight())
+	// Fit the grid view to exactly gridHeight() lines so the footer sits at
+	// a predictable row regardless of content size. The no-match line above is
+	// appended after the viewport already filled its budget, so this has to
+	// clamp as well as pad or that one extra row scrolls the header away.
+	gridView = fitToHeight(gridView, m.gridHeight())
 
 	return header + "\n\n" + search + "\n\n" + gridView + "\n" + footer
 }

--- a/cli/internal/tui/listdetail.go
+++ b/cli/internal/tui/listdetail.go
@@ -158,7 +158,20 @@ type Model struct {
 	actions   map[string]ActionSpec // keyed by ActionSpec.Key
 	done      bool
 	collapsed map[string]bool // CollapseKey → collapsed; missing = expanded
+	// listOff is the index of the first item row the left pane draws and
+	// listRows how many rows fit below its title. The left pane builds a plain
+	// string rather than owning a viewport, so without this window renderLeft
+	// emitted every item: a list taller than the terminal overflowed the frame,
+	// the alt-screen scrolled the header off the top, and no key brought it
+	// back. listOff is never assigned from the outside — scrollCursorIntoView
+	// derives it from the cursor, so "where the list is scrolled to" has a
+	// single owner and can't drift from the highlighted row.
+	listOff  int
+	listRows int
 }
+
+// wheelStep is how many list rows one mouse-wheel notch travels.
+const wheelStep = 3
 
 // NewListDetail builds a Model ready for Run.
 func NewListDetail(cfg Config) Model {
@@ -227,6 +240,78 @@ func (m Model) prevSelectable(from int) int {
 	return -1
 }
 
+// moveCursor steps the cursor n navigable rows (negative = up), stopping dead at
+// either end, then re-syncs the detail pane and the scroll window. Every cursor
+// movement goes through here — ↑/↓ and the mouse wheel — so there is exactly one
+// place that has to remember to scroll the new row into view.
+func (m *Model) moveCursor(n int) {
+	if n == 0 {
+		return
+	}
+	up := n < 0
+	if up {
+		n = -n
+	}
+	for i := 0; i < n; i++ {
+		next := m.nextSelectable(m.cursor)
+		if up {
+			next = m.prevSelectable(m.cursor)
+		}
+		if next < 0 {
+			break
+		}
+		m.cursor = next
+	}
+	m.scrollCursorIntoView()
+	m.refreshPreview()
+}
+
+// scrollCursorIntoView slides listOff the minimum distance needed to keep the
+// cursor row inside the visible window, so the list scrolls one row at a time at
+// the edges instead of jumping the selection to the middle. Call after anything
+// that moves the cursor, changes which items are visible, or resizes the pane.
+func (m *Model) scrollCursorIntoView() {
+	// listRows is 0 until the first WindowSizeMsg, and a list that already fits
+	// never scrolls; both mean "draw from the top".
+	if m.listRows < 1 || len(m.items) <= m.listRows {
+		m.listOff = 0
+		return
+	}
+	if maxOff := len(m.items) - m.listRows; m.listOff > maxOff {
+		m.listOff = maxOff
+	}
+	if m.listOff < 0 {
+		m.listOff = 0
+	}
+	if m.cursor < m.listOff {
+		m.listOff = m.cursor
+	}
+	if m.cursor >= m.listOff+m.listRows {
+		m.listOff = m.cursor - m.listRows + 1
+	}
+}
+
+// listWindow is the [start, end) span of m.items the left pane renders. It
+// re-clamps rather than trusting listOff because View runs on a value copy that
+// may not have seen a resize yet.
+func (m Model) listWindow() (start, end int) {
+	if m.listRows < 1 || len(m.items) <= m.listRows {
+		return 0, len(m.items)
+	}
+	start = m.listOff
+	if maxOff := len(m.items) - m.listRows; start > maxOff {
+		start = maxOff
+	}
+	if start < 0 {
+		start = 0
+	}
+	end = start + m.listRows
+	if end > len(m.items) {
+		end = len(m.items)
+	}
+	return start, end
+}
+
 // Selected returns the terminal state after the model exits.
 func (m Model) Selected() Result { return m.result }
 
@@ -241,12 +326,19 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case tea.MouseMsg:
-		// Forward wheel events to the detail viewport only when the cursor
-		// is over the right pane. The left pane's list has its own ↑/↓
-		// handling so a trackpad scroll over the list shouldn't also scroll
-		// the detail body.
+		// The pane under the pointer owns the wheel, so a trackpad flick over
+		// the list doesn't also scroll the detail body. Over the left pane a
+		// notch moves the cursor by wheelStep rows — same path as holding ↑/↓,
+		// which keeps the highlight, the detail pane and the scroll window in
+		// lockstep instead of letting the list scroll away from its selection.
 		leftW, _ := m.paneWidths()
 		if msg.X < leftW {
+			switch msg.Button {
+			case tea.MouseButtonWheelUp:
+				m.moveCursor(-wheelStep)
+			case tea.MouseButtonWheelDown:
+				m.moveCursor(wheelStep)
+			}
 			return m, nil
 		}
 		var cmd tea.Cmd
@@ -306,16 +398,10 @@ func (m Model) updateNav(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.done = true
 		return m, tea.Quit
 	case key.Matches(msg, m.keys.Up):
-		if n := m.prevSelectable(m.cursor); n >= 0 {
-			m.cursor = n
-			m.refreshPreview()
-		}
+		m.moveCursor(-1)
 		return m, nil
 	case key.Matches(msg, m.keys.Down):
-		if n := m.nextSelectable(m.cursor); n >= 0 {
-			m.cursor = n
-			m.refreshPreview()
-		}
+		m.moveCursor(1)
 		return m, nil
 	case key.Matches(msg, m.keys.Filter):
 		if m.cfg.Items != nil {
@@ -368,6 +454,10 @@ func (m Model) updateNav(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			focusKey := key
 			m.rebuildVisible()
 			m.cursor = m.indexOfCollapseKey(focusKey)
+			// Collapsing removes rows above the cursor and expanding adds rows
+			// below it; either way the window has to re-centre on the header the
+			// user just toggled.
+			m.scrollCursorIntoView()
 			m.refreshPreview()
 			return m, nil
 		}
@@ -428,6 +518,13 @@ func (m *Model) resize() {
 	// a 1-cell gutter before the actual detail content.
 	m.preview.Width = rightW - 2
 	m.preview.Height = bodyH - 2 // title row + blank row under the title
+	// The left pane spends its budget the same way: title row, blank row, then
+	// item rows. Same subtraction keeps the two panes row-synced.
+	m.listRows = bodyH - 2
+	if m.listRows < 1 {
+		m.listRows = 1
+	}
+	m.scrollCursorIntoView()
 }
 
 func (m Model) paneWidths() (left, right int) {
@@ -502,6 +599,9 @@ func (m *Model) applyFilter() {
 	} else if m.cursor >= len(m.items) || isNavSkip(m.items[m.cursor]) {
 		m.cursor = m.firstSelectable()
 	}
+	// Typing into the filter shrinks the list under the window, so the offset
+	// has to come back down with it or the pane renders past the last match.
+	m.scrollCursorIntoView()
 }
 
 // rebuildVisible rebuilds m.items from cfg.Items applying the active filter
@@ -626,12 +726,21 @@ func (m Model) renderLeft(width int) string {
 		return s + strings.Repeat(" ", width-w)
 	}
 
+	start, end := m.listWindow()
+
 	var title string
 	if m.filtOn {
 		m.filter.Width = width - 2
 		title = "  " + m.filter.View()
 	} else {
 		title = "  " + th.SectionTitle.Render(spacedUpper(m.cfg.LeftTitle))
+		// Right-anchor the overflow affordance on the title row, mirroring the
+		// detail pane's indicator. Skipped while filtering — the title row is
+		// the text input then, and the match count in the footer already says
+		// how much the list holds.
+		if ind := m.listScrollIndicator(th, start, end); ind != "" {
+			title = padBetween(title, ind, width-1)
+		}
 	}
 
 	if len(m.items) == 0 {
@@ -642,7 +751,8 @@ func (m Model) renderLeft(width int) string {
 	var sb strings.Builder
 	sb.WriteString(pad(title))
 	sb.WriteString("\n\n")
-	for i, it := range m.items {
+	for i := start; i < end; i++ {
+		it := m.items[i]
 		selected := i == m.cursor
 		var row string
 		if c, ok := it.(CollapsibleItem); ok && c.IsCollapsible() {
@@ -650,11 +760,15 @@ func (m Model) renderLeft(width int) string {
 		} else {
 			row = it.Row(th, width-2, selected)
 		}
-		// Pad the row body (minus the leading bar/gutter) to width-2.
-		rowW := lipgloss.Width(row)
-		if rowW < width-2 {
-			row += strings.Repeat(" ", width-2-rowW)
-		}
+		// Fit the row body (minus the leading bar/gutter) to exactly width-2.
+		// Truncating matters as much as padding: Item.Row is free to return a
+		// row wider than the pane (skillItem does, for a long name plus its
+		// version), and lipgloss.JoinHorizontal sizes the left block to its
+		// widest line. Pad-only meant one long row shoved the divider — and the
+		// whole detail pane — right by however far it overhung, so with the
+		// scroll window in play the divider jittered as rows entered and left
+		// the view. Clamping here fixes it for every Item type at once.
+		row = fitToWidth(row, width-2)
 		var line string
 		if selected {
 			// Transparent highlight: just a magenta ▌ bar + magenta-bold
@@ -666,11 +780,35 @@ func (m Model) renderLeft(width int) string {
 			line = "  " + row
 		}
 		sb.WriteString(line)
-		if i < len(m.items)-1 {
+		if i < end-1 {
 			sb.WriteString("\n")
 		}
 	}
 	return sb.String()
+}
+
+// listScrollIndicator is the left pane's counterpart to scrollIndicator: hollow
+// arrows at the ends, filled when rows are hidden that way, plus how far through
+// the list the window sits. Empty string when everything already fits.
+func (m Model) listScrollIndicator(th *ui.Theme, start, end int) string {
+	if start <= 0 && end >= len(m.items) {
+		return ""
+	}
+	up, down := "△", "▽"
+	if start > 0 {
+		up = "▲"
+	}
+	if end < len(m.items) {
+		down = "▼"
+	}
+	// Percent of the way scrolled, not percent of rows seen: hidden is the
+	// number of scroll positions available, so the first row reads 0% and the
+	// last reads 100% — matching viewport.ScrollPercent on the detail side.
+	pct := 100
+	if hidden := len(m.items) - m.listRows; hidden > 0 {
+		pct = int(float64(start)/float64(hidden)*100 + 0.5)
+	}
+	return th.Meta.Render(fmt.Sprintf("%s%s %d%%", up, down, pct))
 }
 
 func (m Model) renderRight(width int) string {
@@ -807,6 +945,7 @@ func (m Model) renderHelp() string {
 	nav := helpGroup{title: "NAVIGATE", rows: []helpRow{
 		{"↑ / k", "move up"},
 		{"↓ / j", "move down"},
+		{"wheel", "scroll the list (pointer over the left pane)"},
 		{"enter", "toggle section (on category/role headers)"},
 	}}
 	if m.cfg.Items != nil {
@@ -820,7 +959,13 @@ func (m Model) renderHelp() string {
 		{"home / end", "jump to top / bottom"},
 	}}
 
-	groups := []helpGroup{nav, scroll}
+	// Column split: movement concerns on the left, what-you-can-do on the right.
+	// Stacked in one column the sheet runs past 20 rows once a caller supplies a
+	// few Actions, which overflows a stock 24-row terminal — and an overflowing
+	// body now loses its tail to Frame's clamp instead of shoving the header off
+	// screen. Two columns roughly halve the height and keep it all readable.
+	leftCol := []helpGroup{nav, scroll}
+	rightCol := make([]helpGroup, 0, 2)
 
 	if len(m.cfg.Actions) > 0 {
 		rows := make([]helpRow, 0, len(m.cfg.Actions))
@@ -832,21 +977,27 @@ func (m Model) renderHelp() string {
 			}
 			rows = append(rows, helpRow{keys, a.Label})
 		}
-		groups = append(groups, helpGroup{title: "ACTIONS", rows: rows})
+		rightCol = append(rightCol, helpGroup{title: "ACTIONS", rows: rows})
 	}
 
 	backKey := textutil.FirstNonEmpty(m.cfg.BackKey, "q")
 	backLabel := textutil.FirstNonEmpty(m.cfg.BackLabel, "quit")
-	groups = append(groups, helpGroup{title: "GENERAL", rows: []helpRow{
+	// esc always goes back, so a caller that already bound BackKey to esc would
+	// otherwise render "esc / esc".
+	backKeys := backKey + " / esc"
+	if backKey == "esc" {
+		backKeys = "esc"
+	}
+	rightCol = append(rightCol, helpGroup{title: "GENERAL", rows: []helpRow{
 		{"?", "toggle this help"},
-		{backKey + " / esc", backLabel},
+		{backKeys, backLabel},
 		{"ctrl+c", "quit"},
 	}})
 
 	// Align the key column to the widest key across every group so the labels
 	// form a clean second column.
 	keyW := 0
-	for _, g := range groups {
+	for _, g := range append(append([]helpGroup{}, leftCol...), rightCol...) {
 		for _, r := range g.rows {
 			if w := lipgloss.Width(r.keys); w > keyW {
 				keyW = w
@@ -854,16 +1005,29 @@ func (m Model) renderHelp() string {
 		}
 	}
 
-	var sb strings.Builder
-	sb.WriteString("  " + th.SectionTitle.Render(spacedUpper("Keybindings")) + "\n")
-	for _, g := range groups {
-		sb.WriteString("\n  " + th.Meta.Render(g.title) + "\n")
-		for _, r := range g.rows {
-			keyCol := r.keys + strings.Repeat(" ", keyW-lipgloss.Width(r.keys))
-			sb.WriteString("    " + th.Brand.Render(keyCol) + "  " + th.Detail.Render(r.label) + "\n")
+	renderCol := func(groups []helpGroup) string {
+		var sb strings.Builder
+		for i, g := range groups {
+			if i > 0 {
+				sb.WriteString("\n")
+			}
+			sb.WriteString(th.Meta.Render(g.title) + "\n")
+			for _, r := range g.rows {
+				keyCol := r.keys + strings.Repeat(" ", keyW-lipgloss.Width(r.keys))
+				sb.WriteString("  " + th.Brand.Render(keyCol) + "  " + th.Detail.Render(r.label) + "\n")
+			}
 		}
+		return strings.TrimRight(sb.String(), "\n")
 	}
-	return strings.TrimRight(sb.String(), "\n")
+
+	// JoinHorizontal pads each block to its own widest line, so the gutter style
+	// is all that separates the columns.
+	gutter := lipgloss.NewStyle().PaddingRight(4)
+	cols := lipgloss.JoinHorizontal(lipgloss.Top,
+		gutter.Render(renderCol(leftCol)),
+		renderCol(rightCol),
+	)
+	return "  " + th.SectionTitle.Render(spacedUpper("Keybindings")) + "\n\n" + indentBlock(cols, 2)
 }
 
 // RunListDetail runs the model on an alt-screen and returns the user's choice.

--- a/cli/internal/tui/listdetail_test.go
+++ b/cli/internal/tui/listdetail_test.go
@@ -1,10 +1,12 @@
 package tui
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 
 	"github.com/jjfantini/humblSKILLS/cli/v2/internal/ui"
 )
@@ -295,5 +297,164 @@ func TestModel_EmptyItemsShowsEmptyMsg(t *testing.T) {
 	v := m.View()
 	if !strings.Contains(v, "empty") {
 		t.Errorf("empty msg missing:\n%s", v)
+	}
+}
+
+// --- left-pane scroll window --------------------------------------------------
+
+func manyItems(n int) []Item {
+	out := make([]Item, 0, n)
+	for i := 0; i < n; i++ {
+		name := fmt.Sprintf("item-%02d", i)
+		out = append(out, testItem{name: name, filter: name})
+	}
+	return out
+}
+
+// The regression this whole window exists for: a list taller than the terminal
+// used to render every row, so the frame overflowed the alt-screen and the
+// header scrolled off the top with no way back.
+func TestModel_LongListNeverOutgrowsTheScreen(t *testing.T) {
+	m := newTestListDetail(manyItems(200), nil)
+	m.width, m.height = 80, 24
+	m.resize()
+
+	for _, step := range []int{0, 50, 199} {
+		m.moveCursor(step)
+		v := m.View()
+		if got := lipgloss.Height(v); got > m.height {
+			t.Fatalf("frame is %d rows tall, terminal is %d (cursor %d)", got, m.height, m.cursor)
+		}
+		if !strings.Contains(v, "humblskills") {
+			t.Fatalf("header scrolled out of the frame at cursor %d:\n%s", m.cursor, v)
+		}
+	}
+}
+
+// Scrolling has to actually reveal rows that were off-screen, and drop the ones
+// it scrolled past — otherwise the window is decorative.
+func TestModel_ScrollingRevealsOffscreenRows(t *testing.T) {
+	m := newTestListDetail(manyItems(200), nil)
+	m.width, m.height = 80, 24
+	m.resize()
+
+	if v := m.View(); !strings.Contains(v, "item-00") {
+		t.Fatalf("first row should be visible at rest:\n%s", v)
+	}
+	m.moveCursor(199) // walk to the end
+	v := m.View()
+	if !strings.Contains(v, "item-199") {
+		t.Errorf("last row should be visible once scrolled to the bottom:\n%s", v)
+	}
+	if strings.Contains(v, "item-00") {
+		t.Errorf("first row should have scrolled out of the window:\n%s", v)
+	}
+	if !strings.Contains(v, "▲") {
+		t.Errorf("expected an up-arrow indicator once rows are hidden above:\n%s", v)
+	}
+}
+
+// The cursor must stay inside the window at all times: a highlight the user
+// can't see is worse than no highlight.
+func TestModel_CursorStaysInsideWindow(t *testing.T) {
+	m := newTestListDetail(manyItems(60), nil)
+	m.width, m.height = 80, 24
+	m.resize()
+
+	for i := 0; i < 59; i++ {
+		m.moveCursor(1)
+		start, end := m.listWindow()
+		if m.cursor < start || m.cursor >= end {
+			t.Fatalf("cursor %d outside window [%d,%d)", m.cursor, start, end)
+		}
+	}
+	for i := 0; i < 59; i++ {
+		m.moveCursor(-1)
+		start, end := m.listWindow()
+		if m.cursor < start || m.cursor >= end {
+			t.Fatalf("cursor %d outside window [%d,%d) scrolling back up", m.cursor, start, end)
+		}
+	}
+	if m.cursor != 0 || m.listOff != 0 {
+		t.Errorf("expected to land back at the top, cursor=%d off=%d", m.cursor, m.listOff)
+	}
+}
+
+func TestModel_WheelOverLeftPaneScrollsList(t *testing.T) {
+	m := newTestListDetail(manyItems(60), nil)
+	m.width, m.height = 80, 24
+	m.resize()
+
+	out, _ := m.Update(tea.MouseMsg{X: 1, Y: 5, Button: tea.MouseButtonWheelDown, Action: tea.MouseActionPress})
+	mm := out.(Model)
+	if mm.cursor != wheelStep {
+		t.Errorf("wheel down should advance %d rows, cursor = %d", wheelStep, mm.cursor)
+	}
+	out, _ = mm.Update(tea.MouseMsg{X: 1, Y: 5, Button: tea.MouseButtonWheelUp, Action: tea.MouseActionPress})
+	if mm = out.(Model); mm.cursor != 0 {
+		t.Errorf("wheel up should return to the top, cursor = %d", mm.cursor)
+	}
+}
+
+// Shrinking the terminal must not leave the window pointing past the last row.
+func TestModel_ResizeKeepsCursorVisible(t *testing.T) {
+	m := newTestListDetail(manyItems(60), nil)
+	m.width, m.height = 80, 40
+	m.resize()
+	m.moveCursor(45)
+
+	m.height = 12 // sudden shrink
+	m.resize()
+	start, end := m.listWindow()
+	if m.cursor < start || m.cursor >= end {
+		t.Errorf("cursor %d outside window [%d,%d) after shrink", m.cursor, start, end)
+	}
+	if got := lipgloss.Height(m.View()); got > m.height {
+		t.Errorf("frame is %d rows, terminal is %d after shrink", got, m.height)
+	}
+}
+
+// Filtering down to a short list has to release the offset, or the pane renders
+// past the end of the matches.
+func TestModel_FilterResetsScrollOffset(t *testing.T) {
+	m := newTestListDetail(manyItems(60), nil)
+	m.width, m.height = 80, 24
+	m.resize()
+	m.moveCursor(50)
+	if m.listOff == 0 {
+		t.Fatal("precondition: expected a non-zero offset before filtering")
+	}
+
+	m.filtOn = true
+	m.filter.SetValue("item-07")
+	m.applyFilter()
+	if m.listOff != 0 {
+		t.Errorf("offset should reset when the filtered list fits, got %d", m.listOff)
+	}
+	if v := m.View(); !strings.Contains(v, "item-07") {
+		t.Errorf("the single match should be visible:\n%s", v)
+	}
+}
+
+// The help sheet is a static body with no viewport of its own, so it has to fit
+// the frame outright — Frame's clamp would otherwise silently eat its last rows.
+func TestModel_HelpOverlayFitsAStockTerminal(t *testing.T) {
+	m := newTestListDetail(manyItems(200), []ActionSpec{
+		{Key: "i", Label: "install", Action: "install"},
+		{Key: "u", Label: "update", Action: "update"},
+		{Key: "x", Label: "remove", Action: "remove"},
+	})
+	m.width, m.height = 80, 24
+	m.resize()
+	m.helpOn = true
+
+	v := m.View()
+	if got := lipgloss.Height(v); got > m.height {
+		t.Errorf("help frame is %d rows, terminal is %d", got, m.height)
+	}
+	for _, want := range []string{"KEYBINDINGS", "NAVIGATE", "SCROLL DETAIL", "ACTIONS", "GENERAL", "toggle this help"} {
+		if !strings.Contains(v, want) {
+			t.Errorf("help sheet lost %q:\n%s", want, v)
+		}
 	}
 }

--- a/cli/internal/tui/tui_test.go
+++ b/cli/internal/tui/tui_test.go
@@ -162,17 +162,26 @@ func TestPadBetween_NoRoom(t *testing.T) {
 	}
 }
 
-func TestPadToHeight_AddsLines(t *testing.T) {
-	got := padToHeight("line1\nline2", 5)
+func TestFitToHeight_AddsLines(t *testing.T) {
+	got := fitToHeight("line1\nline2", 5)
 	if strings.Count(got, "\n") < 4 {
 		t.Errorf("expected 5 rows, got: %q", got)
 	}
 }
 
-func TestPadToHeight_NoOpWhenTallEnough(t *testing.T) {
-	got := padToHeight("a\nb\nc", 2)
+func TestFitToHeight_ExactHeightIsUnchanged(t *testing.T) {
+	got := fitToHeight("a\nb\nc", 3)
 	if got != "a\nb\nc" {
 		t.Errorf("got %q", got)
+	}
+}
+
+// A body taller than its budget must lose the overflow: in an alt-screen an
+// over-tall frame scrolls the header off the top for good.
+func TestFitToHeight_TruncatesOverflow(t *testing.T) {
+	got := fitToHeight("a\nb\nc\nd", 2)
+	if got != "a\nb" {
+		t.Errorf("got %q, want %q", got, "a\nb")
 	}
 }
 


### PR DESCRIPTION
## The bug

The two-pane browser rendered **every** item in the left pane, so any list taller than the terminal produced a frame taller than the alt-screen. The terminal scrolled the whole frame up: the header vanished off the top, and no key brought it back — `humblskills install` against a full registry was stuck showing its tail.

Reported with a screenshot of exactly that: no header, list clipped, nothing scrollable.

## Root causes (2)

Both fixed at the one place every caller routes through, not per-screen:

1. **`renderLeft` had no window.** It now draws only `[listOff, listOff+listRows)`. `scrollCursorIntoView` slides the offset the *minimum* distance to keep the cursor visible, so the list scrolls a row at a time at the edges instead of jumping the selection to the middle. All cursor movement funnels through `moveCursor`, so `↑/↓` and the new wheel binding stay in lockstep with the detail pane and can't forget to scroll.
2. **`Frame` never clamped its body.** `padToHeight` → `fitToHeight`, which truncates as well as pads. Screens own their own windowing, but a body one row too tall silently cost the header — the chrome is now guaranteed regardless. Also covers the dashboard, where the no-match line is appended *after* the viewport already filled its budget.

## Fell out of the above

- **Divider jitter.** `Item.Row` may return a row wider than the pane (`skillItem` does, for a long name + version) and `JoinHorizontal` sizes the left block to its widest line — so one long row shoved the divider and the whole detail pane sideways. Harmless when every row was always rendered; with a scroll window the divider *jittered as rows scrolled in and out*. `fitToWidth` clamps each row instead of only padding it, fixing every `Item` type at once.
- **Help sheet overflow.** Already ~20 rows in one column, which overflows a 24-row terminal once a caller supplies a few Actions — previously by eating the header, now by losing its own tail to the new clamp. Split into two columns (movement left, actions/general right).
- `esc / esc` in the help sheet when a caller already bound `BackKey: "esc"`.

## Also

Scroll indicator on the `SKILLS` title row, mirroring the detail pane's (`▲▼ 45%`), so hidden rows are a visible state rather than something you discover by pressing keys. Wheel binding documented in the `?` sheet.

## Verification

`go vet ./...` and `go test -race -count=1 ./...` green in `cli`.

Seven new tests covering the behaviours that were broken — frame never exceeds the terminal at any cursor position, scrolling actually reveals off-screen rows and drops passed ones, cursor stays inside the window across a full down-and-back walk, wheel moves the cursor, shrinking the terminal keeps the cursor visible, filtering releases the offset, help sheet fits 24 rows. `fitToHeight`'s truncation is pinned by its own test (the old `padToHeight` test asserted the no-op that *was* the bug).

Driven against the real binary through a pty at 24 rows on the actual registry: header and footer both present, frame exactly 24 rows, divider stable while scrolling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)