### PR TITLE
feat(install): install several skills in one go

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ Use explicit subcommands below for scripts, CI, or non-TTY environments.
 humblskills doctor                    # verify the environment
 humblskills search                    # browse the registry (--category=, --role=)
 humblskills install smart-skill
+humblskills install smart-skill smart-commit   # several at once, one shared dep resolution
+humblskills install                   # picker: space picks several, enter installs them all
 humblskills list
 humblskills update                    # pick which drifted skills to upgrade
 humblskills update --all --yes        # non-interactive bulk upgrade

--- a/cli/cmd/humblskills/browse_skills.go
+++ b/cli/cmd/humblskills/browse_skills.go
@@ -517,15 +517,18 @@ func distinctRegistries(skills []skillItem) int {
 }
 
 // runSkillBrowser opens the shared two-pane picker over skills and routes the
-// user's choice through the right subcommand. Returns (skill, action) where
+// user's choice through the right subcommand. Returns (skills, action) where
 // action is one of "install", "update", "uninstall", or "" (user quit).
+//
+// The returned slice is every skill the action applies to: one name normally,
+// several when the mode enables multi-select and the user ticked rows with space.
 //
 // Pressing `p` opens the profile editor inline and re-enters the picker so
 // every surface that uses this browser gets the same footer shortcut.
-func runSkillBrowser(app *App, section string, skills []skillItem, mode skillsBrowseMode, emptyMsg string, fromDashboard bool) (string, string, error) {
+func runSkillBrowser(app *App, section string, skills []skillItem, mode skillsBrowseMode, emptyMsg string, fromDashboard bool) ([]string, string, error) {
 	if len(skills) == 0 {
 		app.UI.Info(emptyMsg)
-		return "", "", nil
+		return nil, "", nil
 	}
 
 	var actions []tui.ActionSpec
@@ -600,6 +603,11 @@ func runSkillBrowser(app *App, section string, skills []skillItem, mode skillsBr
 			RightTitle: "DETAIL",
 			Actions:    actions,
 			EmptyMsg:   emptyMsg,
+			// Ticking several rows only makes sense where the action is additive.
+			// modeInstalledOnly's verbs are update and uninstall, and a mis-aimed
+			// batch uninstall deletes work — that one stays deliberately one at a
+			// time.
+			MultiSelect: mode == modeSearch,
 		}
 		if fromDashboard {
 			cfg.BackKey = "esc"
@@ -607,22 +615,29 @@ func runSkillBrowser(app *App, section string, skills []skillItem, mode skillsBr
 		}
 		res, err := tui.RunListDetail(cfg)
 		if err != nil {
-			return "", "", err
+			return nil, "", err
 		}
-		if res.Quit || res.Item == nil {
-			return "", "", nil
+		if res.Quit || len(res.Items) == 0 {
+			return nil, "", nil
 		}
 		if res.Action == "profile" {
 			if err := runProfileEditor(app); err != nil {
-				return "", "", err
+				return nil, "", err
 			}
 			continue
 		}
-		it, ok := res.Item.(skillItem)
-		if !ok {
-			return "", "", nil
+		// Section headers can't be ticked and aren't returned, but a caller could
+		// still hand us a non-skill Item, so filter rather than assert.
+		names := make([]string, 0, len(res.Items))
+		for _, item := range res.Items {
+			if it, ok := item.(skillItem); ok {
+				names = append(names, it.s.Name)
+			}
 		}
-		return it.s.Name, res.Action, nil
+		if len(names) == 0 {
+			return nil, "", nil
+		}
+		return names, res.Action, nil
 	}
 }
 

--- a/cli/cmd/humblskills/install.go
+++ b/cli/cmd/humblskills/install.go
@@ -30,19 +30,17 @@ type installFlags struct {
 func newInstallCmd(app *App) *cobra.Command {
 	var f installFlags
 	cmd := &cobra.Command{
-		Use:   "install [skill]",
-		Short: "Install a skill (and its deps) onto every detected platform",
-		Long: "install <skill> installs a named skill. With no arg, it opens " +
-			"an interactive, filterable picker listing every skill in the registry.",
-		Args: cobra.MaximumNArgs(1),
+		Use:   "install [skill...]",
+		Short: "Install one or more skills (and their deps) onto every detected platform",
+		Long: "install <skill>... installs the named skills, sharing one dependency " +
+			"resolution and one platform prompt across all of them. With no arg, it " +
+			"opens an interactive, filterable picker listing every skill in the " +
+			"registry, where space picks several to install at once.",
+		Args: cobra.ArbitraryArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			skill := ""
-			if len(args) == 1 {
-				skill = args[0]
-			}
 			f.platformsSet = cmd.Flags().Changed("platform")
 			f.scopeSet = cmd.Flags().Changed("scope")
-			return runInstall(app, skill, f, false)
+			return runInstall(app, args, f, false)
 		},
 	}
 	cmd.Flags().StringSliceVar(&f.platforms, "platform", nil, "restrict install to these adapters (default: profile default, else all detected)")
@@ -50,11 +48,21 @@ func newInstallCmd(app *App) *cobra.Command {
 	cmd.Flags().BoolVar(&f.force, "force", false, "reinstall even if already up-to-date")
 	cmd.Flags().BoolVar(&f.global, "global", false, "alias for --scope global: install once into ~/.humblskills and symlink to the selected platforms")
 	cmd.Flags().StringVar(&f.from, "from", "", "registry to install from when a skill name exists in more than one")
+	// Completion stays available for every positional now that the command takes
+	// several, minus the names already typed on the line.
 	cmd.ValidArgsFunction = func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		if len(args) != 0 {
-			return nil, cobra.ShellCompDirectiveNoFileComp
+		taken := make(map[string]bool, len(args))
+		for _, a := range args {
+			taken[a] = true
 		}
-		return app.completeSkillNames(toComplete), cobra.ShellCompDirectiveNoFileComp
+		all := app.completeSkillNames(toComplete)
+		out := make([]string, 0, len(all))
+		for _, name := range all {
+			if !taken[name] {
+				out = append(out, name)
+			}
+		}
+		return out, cobra.ShellCompDirectiveNoFileComp
 	}
 	_ = cmd.RegisterFlagCompletionFunc("from", func(_ *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return app.completeRegistryNames(toComplete), cobra.ShellCompDirectiveNoFileComp
@@ -62,7 +70,15 @@ func newInstallCmd(app *App) *cobra.Command {
 	return cmd
 }
 
-func runInstall(app *App, skill string, f installFlags, fromDashboard bool) error {
+// runInstall installs every named skill. Passing no names opens the picker,
+// where the user can pick several.
+//
+// The batch is not N independent installs: the whole set shares one dependency
+// resolution, one platform/scope prompt, one --force confirmation and one
+// progress screen. Skills are grouped by owning registry because a registry
+// carries its own document and token, so each group is a separate engine run —
+// but all of them happen inside the one progress screen.
+func runInstall(app *App, skills []string, f installFlags, fromDashboard bool) error {
 	useTUI := tui.ShouldUseTUI(app.Config.JSON, app.Config.Quiet, app.Config.Yes)
 
 	type preload struct {
@@ -91,8 +107,9 @@ func runInstall(app *App, skill string, f installFlags, fromDashboard bool) erro
 	}
 	adapterList, loaded, reg := pre.adapters, pre.loaded, pre.merged
 
-	if skill == "" {
-		skill, err = pickSkill(app, reg, fromDashboard)
+	skills = dedupeNames(skills)
+	if len(skills) == 0 {
+		skills, err = pickSkills(app, reg, fromDashboard)
 		if err != nil {
 			if fromDashboard && err.Error() == "no skill selected" {
 				return nil
@@ -100,45 +117,18 @@ func runInstall(app *App, skill string, f installFlags, fromDashboard bool) erro
 			return err
 		}
 	}
+	if len(skills) == 0 {
+		return fmt.Errorf("no skill selected")
+	}
 
-	// Resolve which registry holds the chosen skill so we plan and fetch against
-	// that registry's document (Source) and token. When several registries list
-	// the same name, honor --from, else prompt (TUI), else ask for --from.
-	matches := allRegistriesForSkill(loaded, skill)
-	var target registrySkills
-	switch {
-	case len(matches) == 0:
-		return fmt.Errorf("skill %q not found in any configured registry", skill)
-	case len(matches) == 1:
-		target = matches[0]
-	default:
-		picked := ""
-		if f.from != "" {
-			picked = f.from
-		} else if useTUI {
-			opts := make([]ui.SelectOption, 0, len(matches))
-			for _, m := range matches {
-				opts = append(opts, ui.SelectOption{Label: m.Name + "  —  " + m.URL, Value: m.Name})
-			}
-			sel, err := app.Prompt.Select(fmt.Sprintf("%q is in %d registries — install from?", skill, len(matches)), "", opts)
-			if err != nil {
-				return err
-			}
-			picked = sel
-		} else {
-			return fmt.Errorf("skill %q exists in multiple registries (%s) — choose one with --from <registry>", skill, registryNames(matches))
-		}
-		found := false
-		for _, m := range matches {
-			if m.Name == picked {
-				target = m
-				found = true
-				break
-			}
-		}
-		if !found {
-			return fmt.Errorf("skill %q is not in registry %q (available in: %s)", skill, picked, registryNames(matches))
-		}
+	// Resolve which registry holds each chosen skill so we plan and fetch against
+	// that registry's document (Source) and token, then group the batch by
+	// registry. Resolution happens for every name up front, before anything is
+	// written: an unknown or ambiguous name in a batch of five should fail with
+	// nothing installed rather than leaving a partial result behind.
+	groups, err := groupSkillsByRegistry(app, loaded, skills, f.from, useTUI)
+	if err != nil {
+		return err
 	}
 
 	p, err := profile.Load(app.Config.ProfilePath)
@@ -156,7 +146,9 @@ func runInstall(app *App, skill string, f installFlags, fromDashboard bool) erro
 	force := f.force
 	useTUIForModal := !explicitFlags && useTUI
 	if useTUIForModal {
-		res, ok, err := promptInstallTargets(app, adapterList, skill)
+		// One modal for the whole batch — the platform/scope answer is a property
+		// of this install run, not of each skill in it.
+		res, ok, err := promptInstallTargets(app, adapterList, batchLabel(skills))
 		if err != nil {
 			return err
 		}
@@ -188,17 +180,27 @@ func runInstall(app *App, skill string, f installFlags, fromDashboard bool) erro
 		return fmt.Errorf("no platforms selected — run 'humblskills doctor' to see what's detected")
 	}
 
-	plan, err := install.Plan(target.Reg, skill)
-	if err != nil {
-		return err
+	// One plan per registry group. PlanAll shares dependency resolution across
+	// every root in the group, so a dep two picked skills have in common is
+	// fetched and placed once.
+	plans := make([][]install.Step, len(groups))
+	for i, g := range groups {
+		plan, err := install.PlanAll(g.target.Reg, g.skills)
+		if err != nil {
+			return err
+		}
+		plans[i] = plan
 	}
 
 	// --force is what bypasses the preserve list, so it's the one install flag
-	// that can destroy user data. Name the files first and make the user agree.
+	// that can destroy user data. Name the files first and make the user agree —
+	// once for the batch, listing every skill it will overwrite.
 	if force {
-		names := make([]string, 0, len(plan))
-		for _, s := range plan {
-			names = append(names, s.Skill.Name)
+		var names []string
+		for _, plan := range plans {
+			for _, s := range plan {
+				names = append(names, s.Skill.Name)
+			}
 		}
 		if err := confirmForce(app, "install --force", names); err != nil {
 			if errors.Is(err, errCancelled) {
@@ -209,32 +211,44 @@ func runInstall(app *App, skill string, f installFlags, fromDashboard bool) erro
 		}
 	}
 
-	engine := app.installEngineForToken(target.Token)
-
 	if !useTUI {
 		app.UI.Detail("plan:")
-		for _, s := range plan {
-			tag := "root"
-			if s.IsDep {
-				tag = "dep"
+		for i, g := range groups {
+			if len(groups) > 1 {
+				app.UI.Detail("  from %s:", g.target.Name)
 			}
-			app.UI.Detail("  %s %s@%s", tag, s.Skill.Name, s.Skill.Version)
+			for _, s := range plans[i] {
+				tag := "root"
+				if s.IsDep {
+					tag = "dep"
+				}
+				app.UI.Detail("  %s %s@%s", tag, s.Skill.Name, s.Skill.Version)
+			}
 		}
 	}
 
 	var res install.Result
 	run := func(sink install.EventSink) error {
-		r, err := engine.Execute(target.Reg, plan, install.ExecuteOpts{
-			Adapters:     adapterList,
-			Platforms:    selected,
-			Scope:        scope,
-			Force:        force,
-			Global:       global,
-			OnEvent:      sink,
-			RegistryName: target.Name,
-		})
-		res = r
-		return err
+		// Sequential, and it aborts on the first failing group: a later group
+		// depends on nothing the earlier ones did, but continuing past a real
+		// error (bad token, network gone) would just pile up the same failure.
+		for i, g := range groups {
+			r, err := app.installEngineForToken(g.target.Token).Execute(g.target.Reg, plans[i], install.ExecuteOpts{
+				Adapters:     adapterList,
+				Platforms:    selected,
+				Scope:        scope,
+				Force:        force,
+				Global:       global,
+				OnEvent:      sink,
+				RegistryName: g.target.Name,
+			})
+			res.Results = append(res.Results, r.Results...)
+			res.Warnings = append(res.Warnings, r.Warnings...)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
 	}
 
 	if useTUI {
@@ -412,15 +426,16 @@ func promptInstallTargets(app *App, adapterList []adapters.Adapter, skill string
 	}
 }
 
-// pickSkill opens the shared two-pane skill browser over the registry and
-// returns the chosen skill's name. Matches the search surface 1:1 so the user
-// can't tell them apart — a zero-arg install IS a searchable picker.
-func pickSkill(app *App, reg *registry.Registry, fromDashboard bool) (string, error) {
+// pickSkills opens the shared two-pane skill browser over the registry and
+// returns the chosen skills' names — several of them when the user ticked rows
+// with space. Matches the search surface 1:1 so the user can't tell them apart —
+// a zero-arg install IS a searchable picker.
+func pickSkills(app *App, reg *registry.Registry, fromDashboard bool) ([]string, error) {
 	if len(reg.Skills) == 0 {
-		return "", fmt.Errorf("registry is empty")
+		return nil, fmt.Errorf("registry is empty")
 	}
 	if !tui.ShouldUseTUI(app.Config.JSON, app.Config.Quiet, app.Config.Yes) {
-		return "", fmt.Errorf("skill name required — usage: humblskills install <skill>")
+		return nil, fmt.Errorf("skill name required — usage: humblskills install <skill>...")
 	}
 
 	skills := append([]registry.Skill(nil), reg.Skills...)
@@ -438,12 +453,104 @@ func pickSkill(app *App, reg *registry.Registry, fromDashboard bool) (string, er
 	})
 	items := buildSkillItems(skills, m, app.resolvedGroupByCategory())
 
-	skill, action, err := runSkillBrowser(app, "Install", items, modeSearch, "registry is empty", fromDashboard)
+	picked, action, err := runSkillBrowser(app, "Install", items, modeSearch, "registry is empty", fromDashboard)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	if action != "install" || skill == "" {
-		return "", fmt.Errorf("no skill selected")
+	if action != "install" || len(picked) == 0 {
+		return nil, fmt.Errorf("no skill selected")
 	}
-	return skill, nil
+	return picked, nil
+}
+
+// dedupeNames drops blanks and repeats while preserving the caller's order, so
+// `install a b a` plans `a` once and the plan reads in the order asked for.
+func dedupeNames(names []string) []string {
+	out := make([]string, 0, len(names))
+	seen := make(map[string]bool, len(names))
+	for _, n := range names {
+		if n == "" || seen[n] {
+			continue
+		}
+		seen[n] = true
+		out = append(out, n)
+	}
+	return out
+}
+
+// batchLabel names the install for the platform modal's title: the skill itself
+// when there's one, otherwise a count, since listing eight names would blow out
+// the modal header.
+func batchLabel(skills []string) string {
+	if len(skills) == 1 {
+		return skills[0]
+	}
+	return fmt.Sprintf("%d skills", len(skills))
+}
+
+// installGroup is one registry's share of a batch install: the registry to plan
+// and fetch against, plus the requested root skills that live in it.
+type installGroup struct {
+	target registrySkills
+	skills []string
+}
+
+// groupSkillsByRegistry resolves every name to its owning registry and buckets
+// the batch accordingly, preserving first-appearance order for both the groups
+// and the skills inside them so a run is reproducible.
+//
+// Ambiguity (a name in several registries) is resolved exactly as it was for a
+// single skill: --from wins, else prompt in a TUI, else an error telling the
+// user to pass --from. --from applies to the whole batch, and is only consulted
+// for names that are actually ambiguous — so it can't drag an unambiguous skill
+// to the wrong registry.
+func groupSkillsByRegistry(app *App, loaded []registrySkills, skills []string, from string, useTUI bool) ([]installGroup, error) {
+	var groups []installGroup
+	index := map[string]int{} // registry name → position in groups
+	for _, skill := range skills {
+		matches := allRegistriesForSkill(loaded, skill)
+		var target registrySkills
+		switch {
+		case len(matches) == 0:
+			return nil, fmt.Errorf("skill %q not found in any configured registry", skill)
+		case len(matches) == 1:
+			target = matches[0]
+		default:
+			picked := ""
+			if from != "" {
+				picked = from
+			} else if useTUI {
+				opts := make([]ui.SelectOption, 0, len(matches))
+				for _, m := range matches {
+					opts = append(opts, ui.SelectOption{Label: m.Name + "  —  " + m.URL, Value: m.Name})
+				}
+				sel, err := app.Prompt.Select(fmt.Sprintf("%q is in %d registries — install from?", skill, len(matches)), "", opts)
+				if err != nil {
+					return nil, err
+				}
+				picked = sel
+			} else {
+				return nil, fmt.Errorf("skill %q exists in multiple registries (%s) — choose one with --from <registry>", skill, registryNames(matches))
+			}
+			found := false
+			for _, m := range matches {
+				if m.Name == picked {
+					target = m
+					found = true
+					break
+				}
+			}
+			if !found {
+				return nil, fmt.Errorf("skill %q is not in registry %q (available in: %s)", skill, picked, registryNames(matches))
+			}
+		}
+
+		if i, ok := index[target.Name]; ok {
+			groups[i].skills = append(groups[i].skills, skill)
+			continue
+		}
+		index[target.Name] = len(groups)
+		groups = append(groups, installGroup{target: target, skills: []string{skill}})
+	}
+	return groups, nil
 }

--- a/cli/cmd/humblskills/install_test.go
+++ b/cli/cmd/humblskills/install_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/jjfantini/humblSKILLS/cli/v2/internal/manifest"
 	"github.com/jjfantini/humblSKILLS/cli/v2/internal/profile"
+	"github.com/jjfantini/humblSKILLS/cli/v2/internal/registry"
 	"github.com/jjfantini/humblSKILLS/cli/v2/internal/testutil"
 )
 
@@ -744,5 +745,132 @@ func TestSelectPlatforms_RequestedSubset(t *testing.T) {
 		if inst.Platform == "claude-code" {
 			t.Errorf("claude-code installed despite --platform cursor: %+v", inst)
 		}
+	}
+}
+
+// --- batch install (multiple skills) -----------------------------------------
+
+func TestDedupeNames(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []string
+		want string
+	}{
+		{"preserves order", []string{"c", "a", "b"}, "c,a,b"},
+		{"drops repeats keeping the first", []string{"a", "b", "a"}, "a,b"},
+		{"drops blanks", []string{"", "a", ""}, "a"},
+		{"empty stays empty", nil, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := strings.Join(dedupeNames(tc.in), ","); got != tc.want {
+				t.Errorf("dedupeNames(%v) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestBatchLabel(t *testing.T) {
+	if got := batchLabel([]string{"solo"}); got != "solo" {
+		t.Errorf("single skill should name itself, got %q", got)
+	}
+	if got := batchLabel([]string{"a", "b", "c"}); got != "3 skills" {
+		t.Errorf("batch should be counted, got %q", got)
+	}
+}
+
+// loadedFixture builds two registries with an overlapping skill name so the
+// grouping tests can exercise both the unambiguous and ambiguous paths.
+func loadedFixture() []registrySkills {
+	pub := registry.Registry{Skills: []registry.Skill{
+		{Name: "alpha", Version: "1.0.0", Registry: "public"},
+		{Name: "shared", Version: "1.0.0", Registry: "public"},
+	}}
+	priv := registry.Registry{Skills: []registry.Skill{
+		{Name: "beta", Version: "1.0.0", Registry: "work"},
+		{Name: "shared", Version: "2.0.0", Registry: "work"},
+	}}
+	return []registrySkills{
+		{Name: "public", URL: "https://pub", Reg: &pub, Skills: pub.Skills},
+		{Name: "work", URL: "https://work", Reg: &priv, Skills: priv.Skills},
+	}
+}
+
+// A batch spanning registries must split into one group per registry, since each
+// carries its own token and document — but keep first-appearance order so the
+// run is reproducible.
+func TestGroupSkillsByRegistry_SplitsAndPreservesOrder(t *testing.T) {
+	groups, err := groupSkillsByRegistry(nil, loadedFixture(), []string{"beta", "alpha"}, "", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(groups) != 2 {
+		t.Fatalf("expected 2 groups, got %d", len(groups))
+	}
+	if groups[0].target.Name != "work" || groups[1].target.Name != "public" {
+		t.Errorf("groups should follow first-appearance order, got %q then %q",
+			groups[0].target.Name, groups[1].target.Name)
+	}
+}
+
+func TestGroupSkillsByRegistry_SameRegistrySharesOneGroup(t *testing.T) {
+	groups, err := groupSkillsByRegistry(nil, loadedFixture(), []string{"alpha", "shared"}, "public", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(groups) != 1 {
+		t.Fatalf("expected 1 group, got %d", len(groups))
+	}
+	if got := strings.Join(groups[0].skills, ","); got != "alpha,shared" {
+		t.Errorf("group skills = %q, want %q", got, "alpha,shared")
+	}
+}
+
+// An unknown name must fail before anything is installed, so the whole batch
+// errors rather than silently installing the names that did resolve.
+func TestGroupSkillsByRegistry_UnknownNameFailsBatch(t *testing.T) {
+	_, err := groupSkillsByRegistry(nil, loadedFixture(), []string{"alpha", "ghost"}, "", false)
+	if err == nil {
+		t.Fatal("expected an error for an unknown skill")
+	}
+	if !strings.Contains(err.Error(), "ghost") {
+		t.Errorf("error should name the offending skill: %v", err)
+	}
+}
+
+// Without a TTY there's nobody to prompt, so an ambiguous name must say how to
+// resolve it rather than guessing a registry.
+func TestGroupSkillsByRegistry_AmbiguousNameNeedsFrom(t *testing.T) {
+	_, err := groupSkillsByRegistry(nil, loadedFixture(), []string{"shared"}, "", false)
+	if err == nil {
+		t.Fatal("expected an error for an ambiguous skill")
+	}
+	if !strings.Contains(err.Error(), "--from") {
+		t.Errorf("error should point at --from: %v", err)
+	}
+}
+
+// --from resolves ambiguity for the batch, and must not drag an unambiguous
+// skill into a registry that doesn't have it.
+func TestGroupSkillsByRegistry_FromOnlyAppliesToAmbiguous(t *testing.T) {
+	groups, err := groupSkillsByRegistry(nil, loadedFixture(), []string{"shared", "alpha"}, "work", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(groups) != 2 {
+		t.Fatalf("expected 2 groups (work for shared, public for alpha), got %d", len(groups))
+	}
+	if groups[0].target.Name != "work" || groups[0].skills[0] != "shared" {
+		t.Errorf("shared should resolve to work via --from, got %+v", groups[0])
+	}
+	if groups[1].target.Name != "public" || groups[1].skills[0] != "alpha" {
+		t.Errorf("alpha is only in public and should stay there, got %+v", groups[1])
+	}
+}
+
+func TestGroupSkillsByRegistry_FromNamingAWrongRegistryErrors(t *testing.T) {
+	_, err := groupSkillsByRegistry(nil, loadedFixture(), []string{"shared"}, "nope", false)
+	if err == nil {
+		t.Fatal("expected an error when --from names a registry without the skill")
 	}
 }

--- a/cli/cmd/humblskills/list.go
+++ b/cli/cmd/humblskills/list.go
@@ -229,15 +229,19 @@ func runListTUI(app *App, m *manifest.Manifest, fromDashboard bool) error {
 
 	items := buildSkillItems(skills, m, app.resolvedGroupByCategory())
 
-	skill, action, err := runSkillBrowser(app, "Installed", items, modeInstalledOnly, "no skills installed", fromDashboard)
+	// modeInstalledOnly is single-select, so this always yields at most one name.
+	picked, action, err := runSkillBrowser(app, "Installed", items, modeInstalledOnly, "no skills installed", fromDashboard)
 	if err != nil {
 		return err
 	}
+	if len(picked) == 0 {
+		return nil
+	}
 	switch action {
 	case "update":
-		return runUpdate(app, []string{skill}, updateFlags{})
+		return runUpdate(app, picked, updateFlags{})
 	case "uninstall":
-		return runUninstall(app, skill)
+		return runUninstall(app, picked[0])
 	}
 	return nil
 }

--- a/cli/cmd/humblskills/search.go
+++ b/cli/cmd/humblskills/search.go
@@ -124,7 +124,8 @@ func matches(s registry.Skill, q string) bool {
 }
 
 // runSearchTUI opens the shared skill browser over hits and, if the user picks
-// one, hands the skill to runInstall so one TUI flows into the next.
+// any, hands them to runInstall so one TUI flows into the next. Search is
+// multi-select, so this can carry a whole batch through.
 func runSearchTUI(app *App, hits []registry.Skill, fromDashboard bool) error {
 	m, err := manifest.Load(app.Config.ManifestPath)
 	if err != nil {
@@ -132,14 +133,14 @@ func runSearchTUI(app *App, hits []registry.Skill, fromDashboard bool) error {
 	}
 	items := buildSkillItems(hits, m, app.resolvedGroupByCategory())
 
-	skill, action, err := runSkillBrowser(app, "Search", items, modeSearch, "no skills match", fromDashboard)
+	picked, action, err := runSkillBrowser(app, "Search", items, modeSearch, "no skills match", fromDashboard)
 	if err != nil {
 		return err
 	}
-	if action != "install" || skill == "" {
+	if action != "install" || len(picked) == 0 {
 		return nil
 	}
-	return runInstall(app, skill, installFlags{}, fromDashboard)
+	return runInstall(app, picked, installFlags{}, fromDashboard)
 }
 
 // renderSearchResults returns a multi-line, themed string listing every hit.

--- a/cli/cmd/humblskills/start.go
+++ b/cli/cmd/humblskills/start.go
@@ -155,7 +155,7 @@ func crumbLabel(cmd string) string {
 func dispatchDashboardCommand(app *App, cmd string) error {
 	switch cmd {
 	case "install":
-		return runInstall(app, "", installFlags{}, true)
+		return runInstall(app, nil, installFlags{}, true)
 	case "list":
 		return runList(app, true)
 	case "update":

--- a/cli/cmd/humblskills/uninstall.go
+++ b/cli/cmd/humblskills/uninstall.go
@@ -62,14 +62,16 @@ func runUninstallPicker(app *App, fromDashboard bool) error {
 	}
 	items := buildSkillItems(skills, m, app.resolvedGroupByCategory())
 
-	skill, action, err := runSkillBrowser(app, "Uninstall", items, modeInstalledOnly, "no skills installed", fromDashboard)
+	// modeInstalledOnly is single-select on purpose — see runSkillBrowser — so
+	// this yields at most one name.
+	picked, action, err := runSkillBrowser(app, "Uninstall", items, modeInstalledOnly, "no skills installed", fromDashboard)
 	if err != nil {
 		return err
 	}
-	if action != "uninstall" || skill == "" {
+	if action != "uninstall" || len(picked) == 0 {
 		return nil
 	}
-	return runUninstall(app, skill)
+	return runUninstall(app, picked[0])
 }
 
 // runUninstall performs the confirm → engine → print flow for a named skill.

--- a/cli/internal/install/planner.go
+++ b/cli/internal/install/planner.go
@@ -23,22 +23,48 @@ type Step struct {
 // with dependencies first and the root itself last. Missing or unsatisfiable
 // deps surface as errors.
 func Plan(reg *registry.Registry, root string) ([]Step, error) {
+	return PlanAll(reg, []string{root})
+}
+
+// PlanAll is Plan for several roots at once: one topo-sorted plan covering
+// every root and its transitive deps, deps before dependents.
+//
+// Walking all roots into a single graph is what makes a batch install correct
+// rather than just convenient. Planning each root separately and concatenating
+// would fetch a shared dep once per root that needs it, and could order a dep
+// after a dependent that a later root pulled in — one graph plus one topo sort
+// gives each skill exactly one Step in a globally valid order.
+//
+// IsDep marks a skill that no caller asked for by name: a root stays a root
+// even when another root also depends on it.
+func PlanAll(reg *registry.Registry, roots []string) ([]Step, error) {
 	if reg == nil {
 		return nil, fmt.Errorf("plan: nil registry")
+	}
+	if len(roots) == 0 {
+		return nil, nil
 	}
 
 	index := make(map[string]registry.Skill, len(reg.Skills))
 	for _, s := range reg.Skills {
 		index[s.Name] = s
 	}
-	if _, ok := index[root]; !ok {
-		return nil, fmt.Errorf("skill %q not in registry", root)
-	}
 
+	isRoot := make(map[string]bool, len(roots))
 	g := resolver.New()
 	visited := make(map[string]bool)
-	if err := walk(root, index, g, visited); err != nil {
-		return nil, err
+	for _, root := range roots {
+		if _, ok := index[root]; !ok {
+			return nil, fmt.Errorf("skill %q not in registry", root)
+		}
+		// A name repeated by the caller is not an error, just already handled.
+		if isRoot[root] {
+			continue
+		}
+		isRoot[root] = true
+		if err := walk(root, index, g, visited); err != nil {
+			return nil, err
+		}
 	}
 
 	order, err := g.TopoSort()
@@ -49,7 +75,7 @@ func Plan(reg *registry.Registry, root string) ([]Step, error) {
 	out := make([]Step, 0, len(order))
 	for _, name := range order {
 		s := index[name]
-		out = append(out, Step{Skill: s, IsDep: name != root})
+		out = append(out, Step{Skill: s, IsDep: !isRoot[name]})
 	}
 	return out, nil
 }

--- a/cli/internal/install/planner_test.go
+++ b/cli/internal/install/planner_test.go
@@ -78,3 +78,115 @@ func TestPlan_UnknownRoot(t *testing.T) {
 		t.Fatal("expected error")
 	}
 }
+
+// --- PlanAll (batch install) --------------------------------------------------
+
+func planNames(steps []Step) []string {
+	out := make([]string, 0, len(steps))
+	for _, s := range steps {
+		out = append(out, s.Skill.Name)
+	}
+	return out
+}
+
+// A dep shared by two roots must be planned once, or it gets fetched and placed
+// once per root that wants it.
+func TestPlanAll_SharedDepAppearsOnce(t *testing.T) {
+	r := reg(
+		registry.Skill{Name: "common", Version: "1.0.0"},
+		registry.Skill{Name: "a", Version: "1.0.0", Requires: []string{"common"}},
+		registry.Skill{Name: "b", Version: "1.0.0", Requires: []string{"common"}},
+	)
+	steps, err := PlanAll(r, []string{"a", "b"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := planNames(steps)
+	if len(got) != 3 {
+		t.Fatalf("expected 3 steps (a, b, and common once), got %v", got)
+	}
+	n := 0
+	for _, name := range got {
+		if name == "common" {
+			n++
+		}
+	}
+	if n != 1 {
+		t.Errorf("shared dep planned %d times, want 1: %v", n, got)
+	}
+}
+
+// Deps must precede the skills that need them across the whole batch, not just
+// within one root's own subtree.
+func TestPlanAll_DepsOrderedBeforeDependents(t *testing.T) {
+	r := reg(
+		registry.Skill{Name: "base", Version: "1.0.0"},
+		registry.Skill{Name: "mid", Version: "1.0.0", Requires: []string{"base"}},
+		registry.Skill{Name: "leaf", Version: "1.0.0", Requires: []string{"mid"}},
+		registry.Skill{Name: "solo", Version: "1.0.0"},
+	)
+	steps, err := PlanAll(r, []string{"leaf", "solo"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	names := planNames(steps)
+	pos := map[string]int{}
+	for i, name := range names {
+		pos[name] = i
+	}
+	if pos["base"] > pos["mid"] || pos["mid"] > pos["leaf"] {
+		t.Errorf("dep order violated: %v", names)
+	}
+	if _, ok := pos["solo"]; !ok {
+		t.Errorf("second root missing from plan: %v", names)
+	}
+}
+
+// IsDep drives the "root"/"dep" labelling, and must follow what the caller asked
+// for by name: a root stays a root even when another root also depends on it.
+func TestPlanAll_RootStaysRootWhenAlsoADep(t *testing.T) {
+	r := reg(
+		registry.Skill{Name: "base", Version: "1.0.0"},
+		registry.Skill{Name: "top", Version: "1.0.0", Requires: []string{"base"}},
+	)
+	steps, err := PlanAll(r, []string{"top", "base"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, s := range steps {
+		if s.IsDep {
+			t.Errorf("%q marked as a dep, but both names were requested", s.Skill.Name)
+		}
+	}
+}
+
+func TestPlanAll_RepeatedRootIsNotAnError(t *testing.T) {
+	r := reg(registry.Skill{Name: "a", Version: "1.0.0"})
+	steps, err := PlanAll(r, []string{"a", "a"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := planNames(steps); len(got) != 1 {
+		t.Errorf("expected 1 step, got %v", got)
+	}
+}
+
+// An unknown name fails the whole batch: a partially installed batch is worse
+// than an unstarted one, so resolution happens before any work.
+func TestPlanAll_UnknownRootFailsWholeBatch(t *testing.T) {
+	r := reg(registry.Skill{Name: "a", Version: "1.0.0"})
+	if _, err := PlanAll(r, []string{"a", "nope"}); err == nil {
+		t.Fatal("expected an error for an unknown root")
+	}
+}
+
+func TestPlanAll_NoRootsIsEmpty(t *testing.T) {
+	r := reg(registry.Skill{Name: "a", Version: "1.0.0"})
+	steps, err := PlanAll(r, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(steps) != 0 {
+		t.Errorf("expected an empty plan, got %v", planNames(steps))
+	}
+}

--- a/cli/internal/tui/listdetail.go
+++ b/cli/internal/tui/listdetail.go
@@ -133,6 +133,13 @@ type Config struct {
 	BackLabel string
 	// BackKey overrides the quit-hint key. Default is "q".
 	BackKey string
+	// MultiSelect lets space tick several rows so one action applies to all of
+	// them, surfaced as Result.Items. Off by default, and off is exactly the
+	// old behaviour: no checkbox column, no space binding, Result.Items holding
+	// just the cursor row. Leave it off for destructive actions — ticking five
+	// rows and hitting a key is a much cheaper mistake to make than five
+	// separate confirmations.
+	MultiSelect bool
 }
 
 // Result is what the caller inspects after the model returns.
@@ -140,6 +147,11 @@ type Result struct {
 	Action string // "" if user quit
 	Item   Item   // nil if Items was empty or user quit
 	Quit   bool
+	// Items is what the action applies to, in list order: every ticked row
+	// under MultiSelect, or just Item when nothing is ticked. Always the
+	// authoritative selection — callers should read this rather than Item, which
+	// stays the cursor row for callers that only ever handle one.
+	Items []Item
 }
 
 // Model is the shared two-pane bubbletea model.
@@ -168,7 +180,16 @@ type Model struct {
 	// single owner and can't drift from the highlighted row.
 	listOff  int
 	listRows int
+	// checked holds the ticked rows by Item.Key(), so a tick survives the list
+	// being rebuilt by a filter keystroke or a section collapse — the indices
+	// move, the keys don't. Only populated when cfg.MultiSelect is on.
+	checked map[string]bool
 }
+
+// checkboxWidth is the cell cost of the multi-select checkbox column ("✓ ").
+// Reserved on every row, ticked or not, so ticking one can't shift the text
+// beside it.
+const checkboxWidth = 2
 
 // wheelStep is how many list rows one mouse-wheel notch travels.
 const wheelStep = 3
@@ -199,6 +220,7 @@ func NewListDetail(cfg Config) Model {
 
 	m := Model{
 		cfg:       cfg,
+		checked:   map[string]bool{},
 		preview:   vp,
 		filter:    filt,
 		keys:      DefaultKeys(),
@@ -264,6 +286,53 @@ func (m *Model) moveCursor(n int) {
 	}
 	m.scrollCursorIntoView()
 	m.refreshPreview()
+}
+
+// toggleChecked ticks or unticks the row under the cursor. Section headers and
+// dividers are never tickable: they aren't installable things, and Result.Items
+// promises only real items.
+func (m *Model) toggleChecked() {
+	if len(m.items) == 0 || m.cursor >= len(m.items) {
+		return
+	}
+	it := m.items[m.cursor]
+	if isHeader(it) || isCollapsible(it) {
+		return
+	}
+	if m.checked == nil {
+		m.checked = map[string]bool{}
+	}
+	k := it.Key()
+	if m.checked[k] {
+		// Delete rather than store false so len(m.checked) is the tick count and
+		// callers can't see a "checked: false" ghost.
+		delete(m.checked, k)
+		return
+	}
+	m.checked[k] = true
+}
+
+// checkedItems returns the ticked rows in list order. Order comes from
+// cfg.Items, not from the order they were ticked, so the resulting install plan
+// is deterministic and matches what the user sees top to bottom.
+//
+// It reads cfg.Items rather than the visible items so a tick made before
+// filtering or collapsing still counts — hiding a row is not unticking it.
+func (m Model) checkedItems() []Item {
+	if len(m.checked) == 0 {
+		return nil
+	}
+	out := make([]Item, 0, len(m.checked))
+	seen := make(map[string]bool, len(m.checked))
+	for _, it := range m.cfg.Items {
+		k := it.Key()
+		if !m.checked[k] || seen[k] {
+			continue
+		}
+		seen[k] = true
+		out = append(out, it)
+	}
+	return out
 }
 
 // scrollCursorIntoView slides listOff the minimum distance needed to keep the
@@ -412,6 +481,9 @@ func (m Model) updateNav(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case key.Matches(msg, m.keys.Help):
 		m.helpOn = true
 		return m, nil
+	case m.cfg.MultiSelect && msg.String() == " ":
+		m.toggleChecked()
+		return m, nil
 	}
 
 	// Detail-pane scroll. List navigation owns up/down, so scrolling uses a
@@ -488,7 +560,15 @@ func (m Model) exitWith(action string) (tea.Model, tea.Cmd) {
 	if isHeader(it) || isCollapsible(it) {
 		it = nil
 	}
-	m.result = Result{Action: action, Item: it}
+	// Ticked rows win over the cursor row, so "tick three, press i" installs the
+	// three and not whatever the cursor drifted onto. With nothing ticked Items
+	// is just the cursor row, which is what makes MultiSelect: false and "on but
+	// unused" behave identically.
+	items := m.checkedItems()
+	if len(items) == 0 && it != nil {
+		items = []Item{it}
+	}
+	m.result = Result{Action: action, Item: it, Items: items}
 	m.done = true
 	return m, tea.Quit
 }
@@ -570,6 +650,13 @@ func (m Model) measureLeftWidth() int {
 		// before `│` and the divider column gets a sliver of breathing room.
 		gutter = 3
 	)
+	// The checkbox column eats into the same budget as the rows, so it has to be
+	// added here too — otherwise turning MultiSelect on silently truncates every
+	// row by two cells instead of widening the pane to fit the boxes.
+	box := 0
+	if m.cfg.MultiSelect {
+		box = checkboxWidth
+	}
 	widest := minW
 	if w := lipgloss.Width(th.SectionTitle.Render(spacedUpper(m.cfg.LeftTitle))) + gutter; w > widest {
 		widest = w
@@ -581,12 +668,12 @@ func (m Model) measureLeftWidth() int {
 		} else {
 			natural = fallback
 		}
-		if w := natural + gutter; w > widest {
+		if w := natural + gutter + box; w > widest {
 			widest = w
 		}
 	}
-	if widest > maxW {
-		widest = maxW
+	if widest > maxW+box {
+		widest = maxW + box
 	}
 	return widest
 }
@@ -686,9 +773,17 @@ func (m Model) View() string {
 	default:
 		body = m.renderBody(leftW, rightW)
 		focused := ""
-		if m.cfg.FocusedLabel != nil {
+		switch {
+		// A tick count outranks the focused-item label: once rows are ticked,
+		// what the action will apply to is the selection, not the cursor, and the
+		// footer should say so.
+		case len(m.checked) > 0:
+			n := len(m.checked)
+			focused = th.Meta.Render("selected: ") +
+				th.Brand.Render(fmt.Sprintf("%d item%s", n, textutil.Plural(n)))
+		case m.cfg.FocusedLabel != nil:
 			focused = m.cfg.FocusedLabel(m.items, m.cursor)
-		} else if len(m.items) > 0 {
+		case len(m.items) > 0:
 			// "focused:" stays muted; the value (item key) renders in the
 			// magenta brand colour to match the design.
 			focused = th.Meta.Render("focused: ") + th.Brand.Render(m.items[m.cursor].Key())
@@ -748,6 +843,16 @@ func (m Model) renderLeft(width int) string {
 		return pad(title) + "\n\n" + pad(empty)
 	}
 
+	// The checkbox lives in the model, not in Item.Row: one implementation gives
+	// every Item type the affordance with a single consistently-aligned column,
+	// where a Row-level checkbox would need each of the ~10 Item types to agree
+	// on the same glyph and spacing.
+	box := 0
+	if m.cfg.MultiSelect {
+		box = checkboxWidth
+	}
+	bodyW := width - 2 - box
+
 	var sb strings.Builder
 	sb.WriteString(pad(title))
 	sb.WriteString("\n\n")
@@ -756,11 +861,11 @@ func (m Model) renderLeft(width int) string {
 		selected := i == m.cursor
 		var row string
 		if c, ok := it.(CollapsibleItem); ok && c.IsCollapsible() {
-			row = c.RowCollapsed(th, width-2, selected, m.collapsed[c.CollapseKey()])
+			row = c.RowCollapsed(th, bodyW, selected, m.collapsed[c.CollapseKey()])
 		} else {
-			row = it.Row(th, width-2, selected)
+			row = it.Row(th, bodyW, selected)
 		}
-		// Fit the row body (minus the leading bar/gutter) to exactly width-2.
+		// Fit the row body (minus the leading bar/gutter) to exactly bodyW.
 		// Truncating matters as much as padding: Item.Row is free to return a
 		// row wider than the pane (skillItem does, for a long name plus its
 		// version), and lipgloss.JoinHorizontal sizes the left block to its
@@ -768,16 +873,16 @@ func (m Model) renderLeft(width int) string {
 		// whole detail pane — right by however far it overhung, so with the
 		// scroll window in play the divider jittered as rows entered and left
 		// the view. Clamping here fixes it for every Item type at once.
-		row = fitToWidth(row, width-2)
+		row = fitToWidth(row, bodyW)
 		var line string
 		if selected {
 			// Transparent highlight: just a magenta ▌ bar + magenta-bold
 			// name (styled by the Item itself). No background fill so the
 			// row stays legible on both dark and light terminal themes.
 			bar := th.Bullet.Render("▌")
-			line = bar + " " + row
+			line = bar + " " + m.checkbox(th, it) + row
 		} else {
-			line = "  " + row
+			line = "  " + m.checkbox(th, it) + row
 		}
 		sb.WriteString(line)
 		if i < end-1 {
@@ -785,6 +890,22 @@ func (m Model) renderLeft(width int) string {
 		}
 	}
 	return sb.String()
+}
+
+// checkbox renders the multi-select column for one row: a magenta ✓ when
+// ticked, blanks otherwise. Returns "" when multi-select is off so single-select
+// lists keep their exact previous layout.
+//
+// Untickable rows (section headers) still get the blank column rather than
+// skipping it, so a header's text stays aligned with the item text beneath it.
+func (m Model) checkbox(th *ui.Theme, it Item) string {
+	if !m.cfg.MultiSelect {
+		return ""
+	}
+	if m.checked[it.Key()] && !isHeader(it) && !isCollapsible(it) {
+		return th.Bullet.Render("✓") + " "
+	}
+	return strings.Repeat(" ", checkboxWidth)
 }
 
 // listScrollIndicator is the left pane's counterpart to scrollIndicator: hollow
@@ -891,11 +1012,22 @@ func (m Model) hints() []KeyHint {
 	if m.cfg.Items != nil {
 		hints = append(hints, KeyHint{Keys: "/", Label: "filter"})
 	}
-	hints = append(hints, KeyHint{Keys: "⇞⇟", Label: "scroll"})
+	// The hint row already fills an 80-column footer exactly, so adding "space
+	// pick" has to buy its space from somewhere or the whole row gets truncated
+	// with an ellipsis. Detail-pane paging is the cheapest thing to drop: it's
+	// the one hint whose keys most users never reach for, and ? still lists it.
+	if !m.cfg.MultiSelect {
+		hints = append(hints, KeyHint{Keys: "⇞⇟", Label: "scroll"})
+	}
 
 	onSection := len(m.items) > 0 && m.cursor < len(m.items) && isCollapsible(m.items[m.cursor])
 	if onSection {
 		hints = append(hints, KeyHint{Keys: "enter", Label: "toggle"})
+	}
+	// Space is only advertised on rows it actually does something to, so a
+	// section header doesn't offer a tick that gets ignored.
+	if m.cfg.MultiSelect && !onSection {
+		hints = append(hints, KeyHint{Keys: "space", Label: "pick"})
 	}
 
 	// Deduplicate enter when it's absorbed by the first action.
@@ -950,6 +1082,9 @@ func (m Model) renderHelp() string {
 	}}
 	if m.cfg.Items != nil {
 		nav.rows = append(nav.rows, helpRow{"/", "filter list"})
+	}
+	if m.cfg.MultiSelect {
+		nav.rows = append(nav.rows, helpRow{"space", "pick / unpick this row (action applies to all picked)"})
 	}
 
 	scroll := helpGroup{title: "SCROLL DETAIL", rows: []helpRow{

--- a/cli/internal/tui/listdetail_test.go
+++ b/cli/internal/tui/listdetail_test.go
@@ -458,3 +458,199 @@ func TestModel_HelpOverlayFitsAStockTerminal(t *testing.T) {
 		}
 	}
 }
+
+// --- multi-select -------------------------------------------------------------
+
+func newMultiListDetail(items []Item) Model {
+	m := NewListDetail(Config{
+		Theme:       ui.DefaultTheme(),
+		Section:     "Test",
+		Version:     "v1",
+		Items:       items,
+		LeftTitle:   "LEFT",
+		RightTitle:  "DETAIL",
+		Actions:     []ActionSpec{{Key: "i", Label: "install", Action: "install"}},
+		EmptyMsg:    "empty",
+		MultiSelect: true,
+	})
+	m.width, m.height = 80, 24
+	m.resize()
+	return m
+}
+
+func space() tea.KeyMsg { return tea.KeyMsg{Type: tea.KeySpace, Runes: []rune{' '}} }
+
+func TestModel_SpaceTogglesSelection(t *testing.T) {
+	m := newMultiListDetail(manyItems(5))
+
+	out, _ := m.Update(space())
+	mm := out.(Model)
+	if len(mm.checked) != 1 || !mm.checked["item-00"] {
+		t.Fatalf("space should tick the cursor row, checked = %v", mm.checked)
+	}
+	if v := mm.View(); !strings.Contains(v, "✓") {
+		t.Errorf("a ticked row should render a check mark:\n%s", v)
+	}
+
+	// Space again unticks, and leaves no ghost entry behind.
+	out, _ = mm.Update(space())
+	if mm = out.(Model); len(mm.checked) != 0 {
+		t.Errorf("space should untick, checked = %v", mm.checked)
+	}
+	if v := mm.View(); strings.Contains(v, "✓") {
+		t.Errorf("no check mark should remain:\n%s", v)
+	}
+}
+
+// The action must apply to every ticked row, in list order — not to the cursor
+// row, which is where the user happened to stop.
+func TestModel_ActionAppliesToAllTicked(t *testing.T) {
+	m := newMultiListDetail(manyItems(6))
+
+	// Tick rows 0, 2 and 3, leaving the cursor on 3.
+	out, _ := m.Update(space())
+	mm := out.(Model)
+	mm.moveCursor(2)
+	out, _ = mm.Update(space())
+	mm = out.(Model)
+	mm.moveCursor(1)
+	out, _ = mm.Update(space())
+	mm = out.(Model)
+
+	out, _ = mm.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("i")})
+	res := out.(Model).Selected()
+	if res.Action != "install" {
+		t.Fatalf("action = %q", res.Action)
+	}
+	got := make([]string, 0, len(res.Items))
+	for _, it := range res.Items {
+		got = append(got, it.Key())
+	}
+	want := []string{"item-00", "item-02", "item-03"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("Items = %v, want %v (list order)", got, want)
+	}
+}
+
+// Nothing ticked has to behave exactly like the old single-select model, since
+// that's every existing caller's path.
+func TestModel_NothingTickedFallsBackToCursorRow(t *testing.T) {
+	m := newMultiListDetail(manyItems(4))
+	m.moveCursor(2)
+
+	out, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	res := out.(Model).Selected()
+	if len(res.Items) != 1 || res.Items[0].Key() != "item-02" {
+		t.Fatalf("expected just the cursor row, got %v", res.Items)
+	}
+	if res.Item == nil || res.Item.Key() != "item-02" {
+		t.Errorf("Item should stay the cursor row, got %v", res.Item)
+	}
+}
+
+// Single-select lists must not grow a space binding or a checkbox column.
+func TestModel_SingleSelectIgnoresSpace(t *testing.T) {
+	m := newTestListDetail(manyItems(4), []ActionSpec{{Key: "i", Label: "install", Action: "install"}})
+	m.width, m.height = 80, 24
+	m.resize()
+
+	out, _ := m.Update(space())
+	mm := out.(Model)
+	if len(mm.checked) != 0 {
+		t.Errorf("space should do nothing without MultiSelect, checked = %v", mm.checked)
+	}
+	if v := mm.View(); strings.Contains(v, "✓") || strings.Contains(v, "pick") {
+		t.Errorf("single-select view should show no checkbox or pick hint:\n%s", v)
+	}
+}
+
+// A tick must survive the list being rebuilt underneath it — the row indices
+// move when a filter narrows the list, the keys don't.
+func TestModel_SelectionSurvivesFilter(t *testing.T) {
+	m := newMultiListDetail(manyItems(30))
+	m.moveCursor(7) // item-07
+	out, _ := m.Update(space())
+	mm := out.(Model)
+
+	mm.filtOn = true
+	mm.filter.SetValue("item-2")
+	mm.applyFilter()
+	if !mm.checked["item-07"] {
+		t.Error("filtering should not untick a hidden row")
+	}
+
+	// Enter closes the filter — while it's focused, letters type into it rather
+	// than firing actions, so the action key has to come after.
+	out, _ = mm.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	mm = out.(Model)
+
+	// And the hidden tick still comes back in the result.
+	out, _ = mm.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("i")})
+	res := out.(Model).Selected()
+	found := false
+	for _, it := range res.Items {
+		if it.Key() == "item-07" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("ticked-but-filtered-out row missing from Items: %v", res.Items)
+	}
+}
+
+// Section headers aren't installable, so they must not be tickable.
+func TestModel_HeadersAreNotTickable(t *testing.T) {
+	m := newMultiListDetail([]Item{
+		testHeader{k: "group"},
+		testItem{name: "a", filter: "a"},
+	})
+	m.cursor = 0 // sit on the header explicitly
+
+	out, _ := m.Update(space())
+	if mm := out.(Model); len(mm.checked) != 0 {
+		t.Errorf("a header should not be tickable, checked = %v", mm.checked)
+	}
+}
+
+// Ticking must not shift the text beside it, or the list twitches as you pick.
+func TestModel_CheckboxColumnDoesNotShiftRows(t *testing.T) {
+	m := newMultiListDetail(manyItems(5))
+	before := lipgloss.Width(strings.Split(m.View(), "\n")[4])
+
+	out, _ := m.Update(space())
+	mm := out.(Model)
+	if after := lipgloss.Width(strings.Split(mm.View(), "\n")[4]); after != before {
+		t.Errorf("row width changed on tick: %d -> %d", before, after)
+	}
+}
+
+// The count is the footer's only piece of unrecoverable state (every hint is
+// also in ?), so it has to show wherever there's room for it.
+func TestModel_FooterReportsSelectionCount(t *testing.T) {
+	m := newMultiListDetail(manyItems(5))
+	m.width = 100
+	m.resize()
+
+	out, _ := m.Update(space())
+	if v := out.(Model).View(); !strings.Contains(v, "selected: ") || !strings.Contains(v, "1 item") {
+		t.Errorf("footer should report the selection count:\n%s", v)
+	}
+}
+
+// An 80-column terminal is the common case, and the hint row filled it exactly
+// before "space pick" existed — so the multi-select footer has to stay inside it
+// rather than degrading to an ellipsis.
+func TestModel_MultiSelectFooterFitsEightyColumns(t *testing.T) {
+	m := newMultiListDetail(manyItems(5))
+	out, _ := m.Update(space())
+	mm := out.(Model)
+
+	for _, line := range strings.Split(mm.View(), "\n") {
+		if lipgloss.Width(line) > mm.width {
+			t.Fatalf("line exceeds %d columns (%d): %q", mm.width, lipgloss.Width(line), line)
+		}
+	}
+	if v := mm.View(); strings.Contains(v, "…") {
+		t.Errorf("footer should fit rather than truncate at 80 columns:\n%s", v)
+	}
+}

--- a/cli/internal/tui/progress.go
+++ b/cli/internal/tui/progress.go
@@ -325,7 +325,12 @@ func (m ProgressModel) renderItemsList() string {
 func (m *ProgressModel) applyEvent(ev install.Event) {
 	switch ev.Phase {
 	case install.PhaseRunStart:
-		m.total = ev.Total
+		// Accumulate rather than assign: one screen can span several engine
+		// runs (a batch install whose skills come from different registries
+		// executes once per registry, since each has its own token and
+		// document). Assigning would reset the denominator on the second
+		// run_start and show "3/8" of a batch as "3/2".
+		m.total += ev.Total
 	case install.PhaseTargetStart:
 		it := m.upsert(ev)
 		m.current = it

--- a/cli/internal/tui/progress_test.go
+++ b/cli/internal/tui/progress_test.go
@@ -386,3 +386,17 @@ func TestProgressEntry_Key(t *testing.T) {
 		t.Error("different scopes should differ")
 	}
 }
+
+// A batch install whose skills span registries runs the engine once per
+// registry, so the screen sees several run_start events and the totals have to
+// add up rather than the last one replacing the first.
+func TestProgressModel_TotalsAccumulateAcrossRuns(t *testing.T) {
+	m := NewProgressModel(ui.DefaultTheme(), "install", nil, nil, 0)
+
+	m.applyEvent(install.Event{Phase: install.PhaseRunStart, Total: 3})
+	m.applyEvent(install.Event{Phase: install.PhaseRunStart, Total: 5})
+
+	if m.total != 8 {
+		t.Errorf("total = %d, want 8 (3 + 5 across two engine runs)", m.total)
+	}
+}

--- a/docs/getting_started/quickstart.md
+++ b/docs/getting_started/quickstart.md
@@ -42,11 +42,19 @@ Or read the full [skill catalog](../skills.md).
 
 ```sh
 humblskills install smart-commit
+humblskills install smart-commit smart-skill     # several at once
 humblskills install                              # no name → pick from a list
 humblskills install smart-commit --yes           # skip the confirmation
 humblskills install smart-commit --platform claude-code
 humblskills install smart-commit --scope project # this repo only
 ```
+
+Installing several at once is not a loop over single installs: the whole batch
+shares one dependency resolution (so a dep two skills both need is fetched once),
+one platform/scope prompt, and one progress screen. In the picker, **space** ticks
+a row — the footer counts what you've picked — and **enter** (or `i`) installs
+everything ticked. Naming a skill that isn't in any registry fails the batch
+before anything is written, so you never end up half-installed.
 
 By default a skill installs once into `~/.humblskills/skills/<skill>` and is
 linked into every agent platform found on your machine. See


### PR DESCRIPTION
Promotes `develop` to `main`. One feature, already green and merged via #240.

`humblskills install a b c` takes any number of names, and the picker gains space-to-tick multi-select (✓ per row, count in the footer, enter installs the lot). A batch shares one dependency resolution, one platform prompt and one progress screen; unknown names fail before anything is written.

Full detail in #240.

Merge commit, not squash — release-please needs the `feat:` commit on main for the minor bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)