### PR TITLE
fix(registry): rewrite a source.sha that predates a listed skill

### DIFF
--- a/.github/workflows/registry.yml
+++ b/.github/workflows/registry.yml
@@ -20,6 +20,15 @@ name: Registry
 # source.ref/sha were rewritten on every run, so the early exit was unreachable
 # and this workflow would push on every trigger, forever. If build-registry ever
 # goes back to writing unconditionally, this becomes an infinite push loop.
+#
+# There is exactly one sanctioned exception, and this job is what applies it: a
+# source.sha that predates a skill registry.json already lists. `make registry`
+# reads the working tree but stamps source.sha from HEAD, so the commit that
+# first adds a skill records a SHA that cannot contain it, and install then
+# fails with "no files found under skills/<name> in tarball". build-registry
+# rewrites in that case only, and only when the new SHA actually resolves every
+# skill — so it converges after one push rather than looping. See
+# sourceSHAVerdict in cli/cmd/build-registry/main.go.
 
 on:
   push:
@@ -61,6 +70,13 @@ jobs:
           # A GITHUB_TOKEN push does not trigger workflows, so CI would never
           # run on the auto-fix commit.
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          # Full history, not the default depth-1. Two steps here need commits
+          # other than the tip: build-registry resolves the *recorded*
+          # source.sha to check it contains every skill (on a shallow clone
+          # that object is absent, git errors, and the check silently declines
+          # to fire), and the push-retry below does `git reset --hard HEAD~1`,
+          # which has no parent to reach at depth 1.
+          fetch-depth: 0
       - uses: actions/setup-go@v5
         with:
           go-version: "1.23"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,6 +87,26 @@ gh pr merge <n> --merge      # correct
 gh pr merge <n> --squash     # breaks both of the above
 ```
 
+### `registry.json`'s `source.sha` must contain every skill it lists
+`install` fetches each skill's tarball at `source.sha`, so a SHA that predates a listed skill produces
+`extract: no files found under "skills/<name>" in tarball` — the skill is discoverable and uninstallable.
+`make registry` reads the working tree but stamps `source.sha` from git HEAD, so **the run that first adds a
+skill always records a SHA that cannot contain it**. That is expected locally; the Registry workflow repairs
+it on the next push, once the skill is committed.
+
+Do not "fix" this by making `semanticDiff` compare the `source` block — that comparison is zeroed on purpose,
+and reinstating it makes the workflow push on every trigger forever. The repair lives in `sourceSHAVerdict`
+(`cli/cmd/build-registry/main.go`), which bypasses the "already in sync" exit only when the recorded SHA is
+provably broken **and** the replacement provably fixes it, so it converges after one write. It needs real
+history, which is why the workflow checks out with `fetch-depth: 0`.
+
+If you ever need to repair it by hand:
+
+```sh
+go -C cli run ./cmd/build-registry --skills-dir=$PWD/skills --out=$PWD/registry.json --ref=main --sha=<sha>
+git cat-file -e <sha>:skills/<name>/SKILL.md   # verify before pushing
+```
+
 ### A conflicted PR gets no CI at all
 GitHub cannot build the merge ref for a PR with conflicts, so it dispatches **no** `pull_request` workflows.
 The PR shows no checks rather than failing ones, and with nothing gating `main` it stays merge-able by hand.

--- a/cli/cmd/build-registry/main.go
+++ b/cli/cmd/build-registry/main.go
@@ -176,10 +176,20 @@ func run(skillsDir, outFile, repo, ref, sha string, check bool) error {
 	// "already in sync" reachable. semanticDiff is the same comparison
 	// --check uses. If the existing file is unreadable or malformed, fall
 	// through and write.
+	//
+	// The one exception is a source.sha that predates a skill the file already
+	// lists — see sourceSHAVerdict. Ignoring the source block is what made the
+	// early exit safe, and also what made that particular corruption permanent.
 	if existing, rerr := os.ReadFile(outFile); rerr == nil {
 		if diff, derr := semanticDiff(existing, out); derr == nil && !diff {
-			fmt.Printf("%s already up to date (%d skills)\n", outFile, len(skills))
-			return nil
+			rewrite, note := sourceSHAVerdict(existing, sha, skills)
+			if note != "" {
+				fmt.Fprintln(os.Stderr, "build-registry:", note)
+			}
+			if !rewrite {
+				fmt.Printf("%s already up to date (%d skills)\n", outFile, len(skills))
+				return nil
+			}
 		}
 	}
 
@@ -273,6 +283,122 @@ func semanticDiff(a, b []byte) (bool, error) {
 	ra.GeneratedAt, rb.GeneratedAt = "", ""
 	ra.Source, rb.Source = registry.Source{}, registry.Source{}
 	return !reflect.DeepEqual(ra, rb), nil
+}
+
+// gitPathsAt reports which of paths exist in the tree at sha, as a set. One
+// `git ls-tree` call answers for every path at once; entries that do not exist
+// are simply absent from the output. An error means git could not answer at
+// all (not a repository, unknown or pruned object, shallow clone that never
+// fetched that commit) and must never be read as "the paths are missing".
+//
+// Package-level so tests can substitute a fake without building a repository.
+var gitPathsAt = gitLsTree
+
+func gitLsTree(sha string, paths []string) (map[string]bool, error) {
+	// --full-tree is load-bearing: without it ls-tree resolves pathspecs
+	// relative to the process CWD, and the Makefile runs this binary via
+	// `go -C cli run ...`, so every "skills/x" would be looked up as
+	// "cli/skills/x" and report as missing. The skill paths recorded in the
+	// registry are repo-root-relative, so the lookup must be too.
+	args := make([]string, 0, len(paths)+6)
+	args = append(args, "ls-tree", "--full-tree", "--name-only", "-z", sha, "--")
+	args = append(args, paths...)
+
+	cmd := exec.Command("git", args...)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("git ls-tree %s: %w: %s", sha, err, strings.TrimSpace(stderr.String()))
+	}
+
+	present := make(map[string]bool, len(paths))
+	for _, name := range strings.Split(string(out), "\x00") {
+		if name != "" {
+			present[name] = true
+		}
+	}
+	return present, nil
+}
+
+// missingSkillAt returns the first skill path absent from the tree at sha, or
+// "" when every one of them is present.
+func missingSkillAt(sha string, skills []registry.Skill) (string, error) {
+	paths := make([]string, 0, len(skills))
+	for _, s := range skills {
+		paths = append(paths, s.Path)
+	}
+	present, err := gitPathsAt(sha, paths)
+	if err != nil {
+		return "", err
+	}
+	for _, p := range paths {
+		if !present[p] {
+			return p, nil
+		}
+	}
+	return "", nil
+}
+
+// sourceSHAVerdict decides whether a registry.json that is otherwise in sync
+// must still be rewritten because its recorded source.sha predates a skill it
+// lists.
+//
+// This is the one hole semanticDiff leaves open. `make registry` reads the
+// working tree but stamps source.sha from git HEAD, so the run that first adds
+// a skill necessarily records a commit that does not contain it. install
+// fetches each skill's tarball at exactly that SHA, so the skill is listed and
+// then fails with "no files found under skills/<name> in tarball". Because
+// semanticDiff zeroes the whole source block, every later rebuild reports
+// "already in sync" and the broken SHA is never replaced. It bites only the
+// release that introduces a skill — for skills that already existed the frozen
+// SHA still contains them, which is why it went unnoticed until v2.47.0.
+//
+// rewrite is true only when the recorded SHA is provably broken AND newSHA
+// provably fixes it. That conjunction is what keeps this convergent: the write
+// records a SHA containing every skill, so the next run takes the early exit
+// and the Registry workflow pushes exactly once. Rewriting whenever the
+// recorded SHA merely looked suspect would push on every trigger, forever —
+// the failure mode the early exit exists to prevent.
+//
+// note is advisory text for the operator; it is printed whether or not the
+// file is rewritten, so the unfixable case cannot fail silently.
+func sourceSHAVerdict(existing []byte, newSHA string, skills []registry.Skill) (rewrite bool, note string) {
+	var reg registry.Registry
+	if err := json.Unmarshal(existing, &reg); err != nil {
+		return false, ""
+	}
+	oldSHA := reg.Source.SHA
+	if oldSHA == "" || newSHA == "" || oldSHA == newSHA {
+		return false, ""
+	}
+
+	missing, err := missingSkillAt(oldSHA, skills)
+	if err != nil {
+		// Git cannot answer. Staying silent is deliberate: building outside a
+		// repository (tests, a vendored tarball) is normal and must not warn.
+		return false, ""
+	}
+	if missing == "" {
+		return false, ""
+	}
+
+	if stillMissing, err := missingSkillAt(newSHA, skills); err != nil || stillMissing != "" {
+		return false, fmt.Sprintf(
+			"source.sha %s does not contain %s, and %s does not either — registry.json lists a skill that cannot be installed. Commit the skill, then re-run `make registry`.",
+			shortSHA(oldSHA), missing, shortSHA(newSHA))
+	}
+
+	return true, fmt.Sprintf(
+		"source.sha %s predates %s; rewriting with %s",
+		shortSHA(oldSHA), missing, shortSHA(newSHA))
+}
+
+func shortSHA(sha string) string {
+	if len(sha) > 12 {
+		return sha[:12]
+	}
+	return sha
 }
 
 func writeAtomic(path string, data []byte) error {

--- a/cli/cmd/build-registry/main_test.go
+++ b/cli/cmd/build-registry/main_test.go
@@ -3,7 +3,9 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -382,5 +384,302 @@ func TestRun_UnknownRole_Rejected(t *testing.T) {
 	err := run(skillsDir, filepath.Join(root, "registry.json"), "r", "main", "sha", false)
 	if err == nil || !strings.Contains(err.Error(), `unknown role "astronaut"`) {
 		t.Fatalf("expected unknown-role validation error, got %v", err)
+	}
+}
+
+// --- source.sha staleness -------------------------------------------------
+//
+// Regression cover for the v2.47.0 bug: a registry.json whose source.sha
+// predates a skill it lists installs as `no files found under skills/<name>
+// in tarball`, and semanticDiff (which zeroes the source block) made that
+// state permanent.
+
+// fakeTree substitutes gitPathsAt with an in-memory sha -> paths map for the
+// duration of a test. A sha absent from the map behaves like an object git
+// cannot resolve, which is the "do not draw conclusions" case.
+func fakeTree(t *testing.T, trees map[string][]string) {
+	t.Helper()
+	prev := gitPathsAt
+	t.Cleanup(func() { gitPathsAt = prev })
+	gitPathsAt = func(sha string, paths []string) (map[string]bool, error) {
+		have, ok := trees[sha]
+		if !ok {
+			return nil, fmt.Errorf("git ls-tree %s: not a valid object name", sha)
+		}
+		set := make(map[string]bool, len(have))
+		for _, p := range have {
+			set[p] = true
+		}
+		out := make(map[string]bool, len(paths))
+		for _, p := range paths {
+			if set[p] {
+				out[p] = true
+			}
+		}
+		return out, nil
+	}
+}
+
+func registryBytes(t *testing.T, sha string, paths ...string) []byte {
+	t.Helper()
+	reg := registry.Registry{
+		SchemaVersion: registry.SchemaVersion,
+		Source:        registry.Source{Repo: "r", Ref: "main", SHA: sha},
+	}
+	for _, p := range paths {
+		reg.Skills = append(reg.Skills, registry.Skill{Name: filepath.Base(p), Path: p})
+	}
+	b, err := json.Marshal(reg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b
+}
+
+func TestSourceSHAVerdict(t *testing.T) {
+	const (
+		old = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" // pre-dates skills/beta
+		new = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" // contains both
+	)
+	both := []string{"skills/alpha", "skills/beta"}
+	skills := []registry.Skill{{Name: "alpha", Path: "skills/alpha"}, {Name: "beta", Path: "skills/beta"}}
+
+	tests := []struct {
+		name        string
+		trees       map[string][]string
+		existingSHA string
+		newSHA      string
+		wantRewrite bool
+		wantNote    string // substring; "" means no note
+	}{
+		{
+			name:        "recorded sha contains every skill",
+			trees:       map[string][]string{old: both, new: both},
+			existingSHA: old, newSHA: new,
+			wantRewrite: false,
+		},
+		{
+			name:        "recorded sha predates a skill and the new one fixes it",
+			trees:       map[string][]string{old: {"skills/alpha"}, new: both},
+			existingSHA: old, newSHA: new,
+			wantRewrite: true, wantNote: "predates skills/beta",
+		},
+		{
+			// Both broken: rewriting cannot help, and doing it anyway would
+			// make every run dirty the file -> the workflow pushes forever.
+			name:        "neither sha contains the skill",
+			trees:       map[string][]string{old: {"skills/alpha"}, new: {"skills/alpha"}},
+			existingSHA: old, newSHA: new,
+			wantRewrite: false, wantNote: "cannot be installed",
+		},
+		{
+			name:        "git cannot resolve the recorded sha",
+			trees:       map[string][]string{new: both},
+			existingSHA: old, newSHA: new,
+			wantRewrite: false,
+		},
+		{
+			name:        "same sha is never rewritten",
+			trees:       map[string][]string{old: {"skills/alpha"}},
+			existingSHA: old, newSHA: old,
+			wantRewrite: false,
+		},
+		{
+			name:        "empty recorded sha is left alone",
+			trees:       map[string][]string{new: both},
+			existingSHA: "", newSHA: new,
+			wantRewrite: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fakeTree(t, tc.trees)
+			rewrite, note := sourceSHAVerdict(registryBytes(t, tc.existingSHA, both...), tc.newSHA, skills)
+			if rewrite != tc.wantRewrite {
+				t.Errorf("rewrite = %v, want %v (note: %q)", rewrite, tc.wantRewrite, note)
+			}
+			if tc.wantNote == "" && note != "" {
+				t.Errorf("note = %q, want none", note)
+			}
+			if tc.wantNote != "" && !strings.Contains(note, tc.wantNote) {
+				t.Errorf("note = %q, want substring %q", note, tc.wantNote)
+			}
+		})
+	}
+}
+
+// TestRun_StaleSourceSHA_IsRewrittenThenConverges is the end-to-end shape of
+// the bug: content identical, source.sha too old. The first rebuild must fix
+// the SHA; the second must take the early exit, or the Registry workflow
+// commits and pushes on every trigger.
+func TestRun_StaleSourceSHA_IsRewrittenThenConverges(t *testing.T) {
+	const (
+		beforeBeta = "1111111111111111111111111111111111111111"
+		afterBeta  = "2222222222222222222222222222222222222222"
+	)
+	root := t.TempDir()
+	skillsDir := filepath.Join(root, "skills")
+	writeSkill(t, skillsDir, "alpha", "1.0.0")
+	writeSkill(t, skillsDir, "beta", "1.0.0")
+	out := filepath.Join(root, "registry.json")
+
+	// Seed the broken state: both skills listed, SHA from before beta existed.
+	fakeTree(t, map[string][]string{
+		beforeBeta: {"skills/alpha"},
+		afterBeta:  {"skills/alpha", "skills/beta"},
+	})
+	if err := run(skillsDir, out, "r", "main", beforeBeta, false); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	if got := readSourceSHA(t, out); got != beforeBeta {
+		t.Fatalf("seed sha = %s, want %s", got, beforeBeta)
+	}
+
+	// Rebuild at a commit that does contain beta: nothing semantic changed,
+	// but the SHA must still be replaced.
+	if err := run(skillsDir, out, "r", "main", afterBeta, false); err != nil {
+		t.Fatalf("rebuild: %v", err)
+	}
+	if got := readSourceSHA(t, out); got != afterBeta {
+		t.Fatalf("sha = %s, want it rewritten to %s", got, afterBeta)
+	}
+
+	// Convergence: a second rebuild at a third good commit must be a no-op,
+	// since the recorded SHA now resolves every skill.
+	const laterStillGood = "3333333333333333333333333333333333333333"
+	fakeTree(t, map[string][]string{
+		afterBeta:      {"skills/alpha", "skills/beta"},
+		laterStillGood: {"skills/alpha", "skills/beta"},
+	})
+	before, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := run(skillsDir, out, "r", "main", laterStillGood, false); err != nil {
+		t.Fatalf("converge run: %v", err)
+	}
+	after, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(before, after) {
+		t.Errorf("registry.json changed on a run with a healthy source.sha; the Registry workflow would push on every trigger")
+	}
+}
+
+// TestRun_OutsideGitRepo_KeepsEarlyExit guards the fallback: when git cannot
+// answer, behaviour must be exactly what it was before this check existed.
+func TestRun_OutsideGitRepo_KeepsEarlyExit(t *testing.T) {
+	root := t.TempDir()
+	skillsDir := filepath.Join(root, "skills")
+	writeSkill(t, skillsDir, "alpha", "1.0.0")
+	out := filepath.Join(root, "registry.json")
+
+	fakeTree(t, nil) // every lookup errors, as outside a repository
+	if err := run(skillsDir, out, "r", "main", "1111111111111111111111111111111111111111", false); err != nil {
+		t.Fatal(err)
+	}
+	before, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := run(skillsDir, out, "r", "main", "9999999999999999999999999999999999999999", false); err != nil {
+		t.Fatal(err)
+	}
+	after, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(before, after) {
+		t.Error("file was rewritten despite git being unable to verify the recorded sha")
+	}
+}
+
+func readSourceSHA(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var reg registry.Registry
+	if err := json.Unmarshal(data, &reg); err != nil {
+		t.Fatal(err)
+	}
+	return reg.Source.SHA
+}
+
+// TestGitLsTree exercises the real git plumbing the fake stands in for: a
+// directory path resolves as a tree entry, an absent path is simply missing
+// from the output, and an unknown revision is an error rather than "absent".
+func TestGitLsTree(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	repo := t.TempDir()
+	gitRun := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = repo
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+	gitRun("init", "-q")
+	gitRun("config", "user.email", "t@example.com")
+	gitRun("config", "user.name", "t")
+	writeSkill(t, filepath.Join(repo, "skills"), "alpha", "1.0.0")
+	gitRun("add", "-A")
+	gitRun("commit", "-qm", "add alpha")
+
+	shaOut, err := exec.Command("git", "-C", repo, "rev-parse", "HEAD").Output()
+	if err != nil {
+		t.Fatal(err)
+	}
+	sha := strings.TrimSpace(string(shaOut))
+
+	// gitLsTree shells out to git in the process CWD, so run from the repo.
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(repo); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(cwd) })
+
+	present, err := gitLsTree(sha, []string{"skills/alpha", "skills/beta"})
+	if err != nil {
+		t.Fatalf("gitLsTree: %v", err)
+	}
+	if !present["skills/alpha"] {
+		t.Error("skills/alpha should resolve as a tree entry at HEAD")
+	}
+	if present["skills/beta"] {
+		t.Error("skills/beta was never committed and must not resolve")
+	}
+
+	if _, err := gitLsTree("0000000000000000000000000000000000000000", []string{"skills/alpha"}); err == nil {
+		t.Error("an unresolvable revision must error, not report the path as absent")
+	}
+
+	// Paths recorded in the registry are repo-root-relative, but the Makefile
+	// invokes this binary as `go -C cli run ...`, so the process CWD is a
+	// subdirectory. Without --full-tree git would resolve "skills/alpha" as
+	// "<subdir>/skills/alpha" and report every skill as missing — which reads
+	// as "the recorded SHA is broken" for a registry that is perfectly fine.
+	sub := filepath.Join(repo, "cli")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(sub); err != nil {
+		t.Fatal(err)
+	}
+	fromSub, err := gitLsTree(sha, []string{"skills/alpha"})
+	if err != nil {
+		t.Fatalf("gitLsTree from subdirectory: %v", err)
+	}
+	if !fromSub["skills/alpha"] {
+		t.Error("skills/alpha must resolve from a subdirectory; pathspec is repo-root-relative")
 	}
 }


### PR DESCRIPTION
## The bug

`install` fetches each skill's tarball at `registry.json`'s `source.sha`. A SHA that predates a skill the file lists makes that skill **discoverable and uninstallable**:

```
humblskills: smart-orchestrate: extract: no files found under "skills/smart-orchestrate" in tarball
```

`make registry` reads the working tree but stamps `source.sha` from git HEAD, so **the run that first adds a skill necessarily records a commit that cannot contain it**. Nothing repaired that afterwards: `semanticDiff` zeroes the whole `source` block before comparing, so every later rebuild reported "already in sync" and the broken SHA survived to release.

It bites only the release that *introduces* a skill — for pre-existing skills the frozen SHA still contains them. That is why it went unnoticed until v2.47.0 shipped a `smart-orchestrate` nobody could install (repaired as data in v2.47.1; this PR is the code fix).

## The fix

`sourceSHAVerdict`, consulted only on the "already in sync" path. It bypasses the early exit when the recorded SHA is **provably** missing a listed skill **and** the replacement **provably** contains every one of them.

That conjunction is the whole design. The write records a healthy SHA, so the next run takes the early exit and the Registry workflow pushes exactly once. Rewriting on mere suspicion would push on every trigger forever — the failure the early exit exists to prevent. When neither SHA works it warns rather than silently doing nothing.

Deliberately narrow: `semanticDiff` still ignores `source`. Comparing that block is what made `registry.json` non-deterministic and every branch's copy conflict with every other's.

| Recorded SHA | Replacement SHA | Result |
|---|---|---|
| contains every skill | — | early exit, unchanged |
| missing a skill | contains all | **rewrite**, then converges |
| missing a skill | also missing | no write, warn loudly |
| git cannot resolve it | — | early exit, silent (building outside a repo is normal) |
| same as replacement / empty | — | early exit |

## Supporting changes

- **`git ls-tree` needs `--full-tree`.** Pathspecs are otherwise resolved relative to the process CWD, and the Makefile runs this binary as `go -C cli run`, so every `skills/x` was looked up as `cli/skills/x` and reported missing. Caught during verification by the new warning firing on a perfectly healthy registry.
- **`fetch-depth: 0` on the Registry workflow checkout.** Resolving the *recorded* SHA needs history a depth-1 clone does not have, and the check declines to act when git cannot answer — so the repair would never have fired in CI. This also fixes the push-retry path, whose `git reset --hard HEAD~1` has no parent to reach at depth 1.

## Verification

Unit + integration tests (`TestSourceSHAVerdict` covers all six branches; `TestGitLsTree` exercises the real git plumbing including the subdirectory case). Both new behaviours were mutation-checked — reverting the hook fails `TestRun_StaleSourceSHA_IsRewrittenThenConverges`, dropping `--full-tree` fails `TestGitLsTree`.

Replayed against the actual failure in a throwaway clone:

- At `885504c` (the broken v2.47.0 tree), run from `cli/` as the Makefile does → `source.sha b26fd240407c predates skills/smart-orchestrate; rewriting with 885504c0f0df`. Reruns at later commits are no-ops.
- Simulated a brand-new skill: bad SHA pre-commit (expected), repaired on the next push, and the workflow's own regenerate commit re-triggers to a clean no-op — no push loop.

`make vet` clean, `go test -race -count=1 ./...` green, `make registry` reports in-sync with no spurious warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)