### PR TITLE
fix(registry): fail --check on a source.sha a rebuild would repair

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,8 +18,10 @@ so **no backend/database/network services are required** to build, test, or run 
 - Build: `make build` → binary at `bin/humblskills`.
 - Lint/vet: `make vet` (CI uses `go vet`; there is no golangci-lint config).
 - Test: `make test`, or CI-equivalent `go -C cli test -race -count=1 ./...`.
-- Registry: `make registry` regenerates `registry.json`; `make registry-check` fails if it's stale
-  (enforced in CI — run it after editing anything under `skills/`).
+- Registry: `make registry` regenerates `registry.json`; `make registry-check` fails if it's stale — run it
+  after editing anything under `skills/`. It is a **local** gate: the Registry workflow's self-heal job
+  replaced the old pre-merge check, so nothing in CI runs `--check` today. "Stale" means *anything a rebuild
+  would change* — drifted content, or a `source.sha` that predates a listed skill (see below).
 - Eval (no external deps): `make eval-mock` runs the eval harness with the deterministic `mock` runner,
   writing artifacts to `.eval-workspace/` (gitignored). Real eval runners (`claudecode`, `cursor-agent`,
   `codex`, `anthropic-api`, `openai-api`) are optional and need their respective agent CLI or
@@ -99,6 +101,10 @@ and reinstating it makes the workflow push on every trigger forever. The repair 
 (`cli/cmd/build-registry/main.go`), which bypasses the "already in sync" exit only when the recorded SHA is
 provably broken **and** the replacement provably fixes it, so it converges after one write. It needs real
 history, which is why the workflow checks out with `fetch-depth: 0`.
+
+`make registry-check` fails on the same condition, so `--check` never disagrees with `make registry`. It stays
+green when *no* rebuild could fix it — the uncommitted-skill case above — because that state is normal and
+self-heals on the next push; a gate that goes red on the expected path just teaches people to ignore it.
 
 If you ever need to repair it by hand:
 

--- a/cli/cmd/build-registry/main.go
+++ b/cli/cmd/build-registry/main.go
@@ -160,6 +160,19 @@ func run(skillsDir, outFile, repo, ref, sha string, check bool) error {
 		if diff {
 			return fmt.Errorf("%s is out of date. Run `make registry` and commit the result.", outFile)
 		}
+		// --check answers "would a rebuild change this file?". Content is only
+		// half of that: a source.sha that predates a listed skill is also
+		// something a rebuild would fix, and reporting clean there let the
+		// v2.47.0 registry pass every gate while listing a skill nobody could
+		// install. Fail on the same condition the write path acts on — broken
+		// AND fixable — so --check never disagrees with `make registry`.
+		rewrite, note := sourceSHAVerdict(existing, sha, skills)
+		if note != "" {
+			fmt.Fprintln(os.Stderr, "build-registry:", note)
+		}
+		if rewrite {
+			return fmt.Errorf("%s is out of date. Run `make registry` and commit the result.", outFile)
+		}
 		return nil
 	}
 
@@ -184,7 +197,11 @@ func run(skillsDir, outFile, repo, ref, sha string, check bool) error {
 		if diff, derr := semanticDiff(existing, out); derr == nil && !diff {
 			rewrite, note := sourceSHAVerdict(existing, sha, skills)
 			if note != "" {
-				fmt.Fprintln(os.Stderr, "build-registry:", note)
+				action := ""
+				if rewrite {
+					action = "; rewriting"
+				}
+				fmt.Fprintf(os.Stderr, "build-registry: %s%s\n", note, action)
 			}
 			if !rewrite {
 				fmt.Printf("%s already up to date (%d skills)\n", outFile, len(skills))
@@ -390,7 +407,7 @@ func sourceSHAVerdict(existing []byte, newSHA string, skills []registry.Skill) (
 	}
 
 	return true, fmt.Sprintf(
-		"source.sha %s predates %s; rewriting with %s",
+		"source.sha %s predates %s, which %s contains",
 		shortSHA(oldSHA), missing, shortSHA(newSHA))
 }
 

--- a/cli/cmd/build-registry/main_test.go
+++ b/cli/cmd/build-registry/main_test.go
@@ -683,3 +683,64 @@ func TestGitLsTree(t *testing.T) {
 		t.Error("skills/alpha must resolve from a subdirectory; pathspec is repo-root-relative")
 	}
 }
+
+// TestRun_Check_FailsOnFixableStaleSHA covers --check's contract: it answers
+// "would a rebuild change this file?", so it must fail on exactly what the
+// write path acts on. Reporting clean on a stale source.sha is how the
+// v2.47.0 registry passed every gate while listing an uninstallable skill.
+func TestRun_Check_FailsOnFixableStaleSHA(t *testing.T) {
+	const (
+		beforeBeta = "1111111111111111111111111111111111111111"
+		afterBeta  = "2222222222222222222222222222222222222222"
+	)
+	both := []string{"skills/alpha", "skills/beta"}
+
+	setup := func(t *testing.T) (skillsDir, out string) {
+		t.Helper()
+		root := t.TempDir()
+		skillsDir = filepath.Join(root, "skills")
+		writeSkill(t, skillsDir, "alpha", "1.0.0")
+		writeSkill(t, skillsDir, "beta", "1.0.0")
+		out = filepath.Join(root, "registry.json")
+		if err := run(skillsDir, out, "r", "main", beforeBeta, false); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+		return skillsDir, out
+	}
+
+	t.Run("fixable stale sha fails", func(t *testing.T) {
+		fakeTree(t, map[string][]string{beforeBeta: {"skills/alpha"}, afterBeta: both})
+		skillsDir, out := setup(t)
+		err := run(skillsDir, out, "r", "main", afterBeta, true)
+		if err == nil || !strings.Contains(err.Error(), "out of date") {
+			t.Fatalf("--check should fail when a rebuild would repair source.sha, got %v", err)
+		}
+	})
+
+	t.Run("unfixable stale sha passes", func(t *testing.T) {
+		// The skill is not committed anywhere yet, so no regeneration can help.
+		// Failing here would put `make registry-check` red on a normal,
+		// self-healing state, which trains people to ignore it.
+		fakeTree(t, map[string][]string{beforeBeta: {"skills/alpha"}, afterBeta: {"skills/alpha"}})
+		skillsDir, out := setup(t)
+		if err := run(skillsDir, out, "r", "main", afterBeta, true); err != nil {
+			t.Fatalf("--check should not fail when no rebuild can fix it: %v", err)
+		}
+	})
+
+	t.Run("healthy sha passes", func(t *testing.T) {
+		fakeTree(t, map[string][]string{beforeBeta: both, afterBeta: both})
+		skillsDir, out := setup(t)
+		if err := run(skillsDir, out, "r", "main", afterBeta, true); err != nil {
+			t.Fatalf("--check should pass on a healthy registry: %v", err)
+		}
+	})
+
+	t.Run("git unavailable passes", func(t *testing.T) {
+		fakeTree(t, nil)
+		skillsDir, out := setup(t)
+		if err := run(skillsDir, out, "r", "main", afterBeta, true); err != nil {
+			t.Fatalf("--check must not fail when git cannot verify: %v", err)
+		}
+	})
+}


### PR DESCRIPTION
Promotes `develop` to `main`.

Contains #251 — `--check` now fails on a `source.sha` that a rebuild would repair, closing the contradiction where it could report clean while `make registry` would write. Both paths share `sourceSHAVerdict`, so they cannot disagree. It stays green when no rebuild could fix it (the uncommitted-skill case, which self-heals on the next push).

Also corrects `AGENTS.md`: `make registry-check` has been a local gate since the Registry self-heal job replaced the pre-merge check, not a CI-enforced one.

All checks green on #251.

🤖 Generated with [Claude Code](https://claude.com/claude-code)