### PR TITLE
feat(smart-orchestrate): Grok 4.6, and fix source.sha for skill content updates

### DIFF
--- a/cli/cmd/build-registry/main.go
+++ b/cli/cmd/build-registry/main.go
@@ -302,23 +302,30 @@ func semanticDiff(a, b []byte) (bool, error) {
 	return !reflect.DeepEqual(ra, rb), nil
 }
 
-// gitPathsAt reports which of paths exist in the tree at sha, as a set. One
-// `git ls-tree` call answers for every path at once; entries that do not exist
-// are simply absent from the output. An error means git could not answer at
-// all (not a repository, unknown or pruned object, shallow clone that never
-// fetched that commit) and must never be read as "the paths are missing".
+// gitPathsAt maps each of paths to its git object id in the tree at sha.
+// Paths that do not exist there are absent from the map. One `git ls-tree`
+// call answers for every path at once.
+//
+// Object ids, not mere presence: a skill directory that exists at sha but
+// holds older content hashes to a different tree id, and serving that content
+// is just as broken as serving nothing — install recomputes dir_sha over what
+// it extracted and rejects the mismatch.
+//
+// An error means git could not answer at all (not a repository, unknown or
+// pruned object, shallow clone that never fetched that commit) and must never
+// be read as "the paths are missing".
 //
 // Package-level so tests can substitute a fake without building a repository.
 var gitPathsAt = gitLsTree
 
-func gitLsTree(sha string, paths []string) (map[string]bool, error) {
+func gitLsTree(sha string, paths []string) (map[string]string, error) {
 	// --full-tree is load-bearing: without it ls-tree resolves pathspecs
 	// relative to the process CWD, and the Makefile runs this binary via
 	// `go -C cli run ...`, so every "skills/x" would be looked up as
 	// "cli/skills/x" and report as missing. The skill paths recorded in the
 	// registry are repo-root-relative, so the lookup must be too.
 	args := make([]string, 0, len(paths)+6)
-	args = append(args, "ls-tree", "--full-tree", "--name-only", "-z", sha, "--")
+	args = append(args, "ls-tree", "--full-tree", "-z", sha, "--")
 	args = append(args, paths...)
 
 	cmd := exec.Command("git", args...)
@@ -329,54 +336,67 @@ func gitLsTree(sha string, paths []string) (map[string]bool, error) {
 		return nil, fmt.Errorf("git ls-tree %s: %w: %s", sha, err, strings.TrimSpace(stderr.String()))
 	}
 
-	present := make(map[string]bool, len(paths))
-	for _, name := range strings.Split(string(out), "\x00") {
-		if name != "" {
-			present[name] = true
+	// Each NUL-terminated record is "<mode> SP <type> SP <objectid> TAB <path>".
+	ids := make(map[string]string, len(paths))
+	for _, rec := range strings.Split(string(out), "\x00") {
+		if rec == "" {
+			continue
 		}
+		meta, path, ok := strings.Cut(rec, "\t")
+		if !ok {
+			continue
+		}
+		fields := strings.Fields(meta)
+		if len(fields) < 3 {
+			continue
+		}
+		ids[path] = fields[2]
 	}
-	return present, nil
+	return ids, nil
 }
 
-// missingSkillAt returns the first skill path absent from the tree at sha, or
-// "" when every one of them is present.
-func missingSkillAt(sha string, skills []registry.Skill) (string, error) {
+// skillTreeIDs returns the git object id of every skill directory at sha,
+// keyed by the skill's registry path. A path missing from the result did not
+// exist at that commit.
+func skillTreeIDs(sha string, skills []registry.Skill) (map[string]string, error) {
 	paths := make([]string, 0, len(skills))
 	for _, s := range skills {
 		paths = append(paths, s.Path)
 	}
-	present, err := gitPathsAt(sha, paths)
-	if err != nil {
-		return "", err
-	}
-	for _, p := range paths {
-		if !present[p] {
-			return p, nil
-		}
-	}
-	return "", nil
+	return gitPathsAt(sha, paths)
 }
 
 // sourceSHAVerdict decides whether a registry.json that is otherwise in sync
-// must still be rewritten because its recorded source.sha predates a skill it
-// lists.
+// must still be rewritten because its recorded source.sha serves the wrong
+// content for a skill it lists.
 //
 // This is the one hole semanticDiff leaves open. `make registry` reads the
-// working tree but stamps source.sha from git HEAD, so the run that first adds
-// a skill necessarily records a commit that does not contain it. install
-// fetches each skill's tarball at exactly that SHA, so the skill is listed and
-// then fails with "no files found under skills/<name> in tarball". Because
-// semanticDiff zeroes the whole source block, every later rebuild reports
-// "already in sync" and the broken SHA is never replaced. It bites only the
-// release that introduces a skill — for skills that already existed the frozen
-// SHA still contains them, which is why it went unnoticed until v2.47.0.
+// working tree but stamps source.sha from git HEAD, so a run that adds or edits
+// a skill necessarily records a commit that predates the change. install
+// fetches each skill's tarball at exactly that SHA, so:
 //
-// rewrite is true only when the recorded SHA is provably broken AND newSHA
-// provably fixes it. That conjunction is what keeps this convergent: the write
-// records a SHA containing every skill, so the next run takes the early exit
-// and the Registry workflow pushes exactly once. Rewriting whenever the
-// recorded SHA merely looked suspect would push on every trigger, forever —
-// the failure mode the early exit exists to prevent.
+//   - a skill added in that change is absent from the tarball entirely —
+//     "no files found under skills/<name> in tarball" (shipped in v2.47.0)
+//   - a skill *edited* in that change extracts at its old content, and install
+//     recomputes dir_sha over it and rejects the mismatch
+//
+// Because semanticDiff zeroes the whole source block, every later rebuild
+// reports "already in sync" and the wrong SHA is never replaced. The trap is
+// that committing a locally generated registry.json — which AGENTS.md and
+// `make registry-check` both ask for — is exactly what makes CI's regeneration
+// a no-op and freezes the bad SHA.
+//
+// Comparison is by git tree object id, not path existence. "The directory is
+// there" is not the invariant install needs; "the directory hashes to what the
+// registry advertises" is, and an older revision of a skill fails that just as
+// surely as a missing one.
+//
+// rewrite is true only when the recorded SHA provably serves different content
+// AND newSHA provably contains every listed skill. That conjunction keeps this
+// convergent: the write records a SHA whose skill trees match, so the next run
+// takes the early exit and the Registry workflow pushes exactly once. Rewriting
+// whenever the recorded SHA merely looked suspect would push on every trigger,
+// forever — the failure mode the early exit exists to prevent.
 //
 // note is advisory text for the operator; it is printed whether or not the
 // file is rewritten, so the unfixable case cannot fail silently.
@@ -390,25 +410,47 @@ func sourceSHAVerdict(existing []byte, newSHA string, skills []registry.Skill) (
 		return false, ""
 	}
 
-	missing, err := missingSkillAt(oldSHA, skills)
+	oldIDs, err := skillTreeIDs(oldSHA, skills)
 	if err != nil {
 		// Git cannot answer. Staying silent is deliberate: building outside a
 		// repository (tests, a vendored tarball) is normal and must not warn.
 		return false, ""
 	}
-	if missing == "" {
+	newIDs, err := skillTreeIDs(newSHA, skills)
+	if err != nil {
 		return false, ""
 	}
 
-	if stillMissing, err := missingSkillAt(newSHA, skills); err != nil || stillMissing != "" {
-		return false, fmt.Sprintf(
-			"source.sha %s does not contain %s, and %s does not either — registry.json lists a skill that cannot be installed. Commit the skill, then re-run `make registry`.",
-			shortSHA(oldSHA), missing, shortSHA(newSHA))
+	// Completeness of the stamp candidate is checked first and on its own. A
+	// listed skill that exists at neither SHA compares "equal" and would
+	// otherwise look like agreement, silently swallowing the one case the
+	// operator most needs told about: nothing committed anywhere serves this
+	// skill, so no rewrite can help and the release will ship uninstallable.
+	for _, s := range skills {
+		if newIDs[s.Path] == "" {
+			return false, fmt.Sprintf(
+				"%s does not contain %s — registry.json lists a skill that cannot be installed. Commit the skill, then re-run `make registry`.",
+				shortSHA(newSHA), s.Path)
+		}
 	}
 
-	return true, fmt.Sprintf(
-		"source.sha %s predates %s, which %s contains",
-		shortSHA(oldSHA), missing, shortSHA(newSHA))
+	// Now the recorded SHA only has to agree with the candidate. Differing
+	// means it would serve the wrong bytes; name which way so the remedy is
+	// obvious.
+	for _, s := range skills {
+		if oldIDs[s.Path] == newIDs[s.Path] {
+			continue
+		}
+		kind := "serves outdated"
+		if oldIDs[s.Path] == "" {
+			kind = "does not contain"
+		}
+		return true, fmt.Sprintf(
+			"source.sha %s %s %s; %s matches",
+			shortSHA(oldSHA), kind, s.Path, shortSHA(newSHA))
+	}
+
+	return false, ""
 }
 
 func shortSHA(sha string) string {

--- a/cli/cmd/build-registry/main_test.go
+++ b/cli/cmd/build-registry/main_test.go
@@ -394,30 +394,40 @@ func TestRun_UnknownRole_Rejected(t *testing.T) {
 // in tarball`, and semanticDiff (which zeroes the source block) made that
 // state permanent.
 
-// fakeTree substitutes gitPathsAt with an in-memory sha -> paths map for the
-// duration of a test. A sha absent from the map behaves like an object git
-// cannot resolve, which is the "do not draw conclusions" case.
-func fakeTree(t *testing.T, trees map[string][]string) {
+// fakeTree substitutes gitPathsAt with an in-memory sha -> (path -> tree id)
+// map for the duration of a test. A sha absent from the map behaves like an
+// object git cannot resolve, which is the "do not draw conclusions" case.
+//
+// Tree ids matter as much as presence: two commits can both contain a skill
+// while serving different revisions of it, and install rejects that as a
+// dir_sha mismatch.
+func fakeTree(t *testing.T, trees map[string]map[string]string) {
 	t.Helper()
 	prev := gitPathsAt
 	t.Cleanup(func() { gitPathsAt = prev })
-	gitPathsAt = func(sha string, paths []string) (map[string]bool, error) {
+	gitPathsAt = func(sha string, paths []string) (map[string]string, error) {
 		have, ok := trees[sha]
 		if !ok {
 			return nil, fmt.Errorf("git ls-tree %s: not a valid object name", sha)
 		}
-		set := make(map[string]bool, len(have))
-		for _, p := range have {
-			set[p] = true
-		}
-		out := make(map[string]bool, len(paths))
+		out := make(map[string]string, len(paths))
 		for _, p := range paths {
-			if set[p] {
-				out[p] = true
+			if id := have[p]; id != "" {
+				out[p] = id
 			}
 		}
 		return out, nil
 	}
+}
+
+// tree builds a sha's contents: every path mapped to the same revision marker,
+// so callers say "these paths, at revision v1".
+func tree(rev string, paths ...string) map[string]string {
+	m := make(map[string]string, len(paths))
+	for _, p := range paths {
+		m[p] = p + "@" + rev
+	}
+	return m
 }
 
 func registryBytes(t *testing.T, sha string, paths ...string) []byte {
@@ -438,55 +448,65 @@ func registryBytes(t *testing.T, sha string, paths ...string) []byte {
 
 func TestSourceSHAVerdict(t *testing.T) {
 	const (
-		old = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" // pre-dates skills/beta
-		new = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" // contains both
+		old = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+		new = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 	)
 	both := []string{"skills/alpha", "skills/beta"}
 	skills := []registry.Skill{{Name: "alpha", Path: "skills/alpha"}, {Name: "beta", Path: "skills/beta"}}
 
 	tests := []struct {
 		name        string
-		trees       map[string][]string
+		trees       map[string]map[string]string
 		existingSHA string
 		newSHA      string
 		wantRewrite bool
 		wantNote    string // substring; "" means no note
 	}{
 		{
-			name:        "recorded sha contains every skill",
-			trees:       map[string][]string{old: both, new: both},
+			name:        "recorded sha serves identical content",
+			trees:       map[string]map[string]string{old: tree("v1", both...), new: tree("v1", both...)},
 			existingSHA: old, newSHA: new,
 			wantRewrite: false,
 		},
 		{
-			name:        "recorded sha predates a skill and the new one fixes it",
-			trees:       map[string][]string{old: {"skills/alpha"}, new: both},
+			// v2.47.0: skills/beta added in the same change that stamped old.
+			name:        "recorded sha is missing a skill entirely",
+			trees:       map[string]map[string]string{old: tree("v1", "skills/alpha"), new: tree("v1", both...)},
 			existingSHA: old, newSHA: new,
-			wantRewrite: true, wantNote: "predates skills/beta",
+			wantRewrite: true, wantNote: "does not contain skills/beta",
 		},
 		{
-			// Both broken: rewriting cannot help, and doing it anyway would
-			// make every run dirty the file -> the workflow pushes forever.
-			name:        "neither sha contains the skill",
-			trees:       map[string][]string{old: {"skills/alpha"}, new: {"skills/alpha"}},
+			// The common case: skills/beta was edited, not added. Both commits
+			// contain it, so a presence-only check passes while install fails
+			// on dir_sha.
+			name:  "recorded sha serves an outdated revision of a skill",
+			trees: map[string]map[string]string{old: tree("v1", both...), new: {"skills/alpha": "skills/alpha@v1", "skills/beta": "skills/beta@v2"}},
+			existingSHA: old, newSHA: new,
+			wantRewrite: true, wantNote: "serves outdated skills/beta",
+		},
+		{
+			// Rewriting would trade one broken SHA for another, and the result
+			// would differ again on every run -> the workflow pushes forever.
+			name:        "replacement sha is missing a skill",
+			trees:       map[string]map[string]string{old: tree("v1", "skills/alpha"), new: tree("v1", "skills/alpha")},
 			existingSHA: old, newSHA: new,
 			wantRewrite: false, wantNote: "cannot be installed",
 		},
 		{
 			name:        "git cannot resolve the recorded sha",
-			trees:       map[string][]string{new: both},
+			trees:       map[string]map[string]string{new: tree("v1", both...)},
 			existingSHA: old, newSHA: new,
 			wantRewrite: false,
 		},
 		{
 			name:        "same sha is never rewritten",
-			trees:       map[string][]string{old: {"skills/alpha"}},
+			trees:       map[string]map[string]string{old: tree("v1", "skills/alpha")},
 			existingSHA: old, newSHA: old,
 			wantRewrite: false,
 		},
 		{
 			name:        "empty recorded sha is left alone",
-			trees:       map[string][]string{new: both},
+			trees:       map[string]map[string]string{new: tree("v1", both...)},
 			existingSHA: "", newSHA: new,
 			wantRewrite: false,
 		},
@@ -525,9 +545,9 @@ func TestRun_StaleSourceSHA_IsRewrittenThenConverges(t *testing.T) {
 	out := filepath.Join(root, "registry.json")
 
 	// Seed the broken state: both skills listed, SHA from before beta existed.
-	fakeTree(t, map[string][]string{
-		beforeBeta: {"skills/alpha"},
-		afterBeta:  {"skills/alpha", "skills/beta"},
+	fakeTree(t, map[string]map[string]string{
+		beforeBeta: tree("v1", "skills/alpha"),
+		afterBeta:  tree("v1", "skills/alpha", "skills/beta"),
 	})
 	if err := run(skillsDir, out, "r", "main", beforeBeta, false); err != nil {
 		t.Fatalf("seed run: %v", err)
@@ -548,9 +568,9 @@ func TestRun_StaleSourceSHA_IsRewrittenThenConverges(t *testing.T) {
 	// Convergence: a second rebuild at a third good commit must be a no-op,
 	// since the recorded SHA now resolves every skill.
 	const laterStillGood = "3333333333333333333333333333333333333333"
-	fakeTree(t, map[string][]string{
-		afterBeta:      {"skills/alpha", "skills/beta"},
-		laterStillGood: {"skills/alpha", "skills/beta"},
+	fakeTree(t, map[string]map[string]string{
+		afterBeta:      tree("v1", "skills/alpha", "skills/beta"),
+		laterStillGood: tree("v1", "skills/alpha", "skills/beta"),
 	})
 	before, err := os.ReadFile(out)
 	if err != nil {
@@ -652,10 +672,10 @@ func TestGitLsTree(t *testing.T) {
 	if err != nil {
 		t.Fatalf("gitLsTree: %v", err)
 	}
-	if !present["skills/alpha"] {
-		t.Error("skills/alpha should resolve as a tree entry at HEAD")
+	if present["skills/alpha"] == "" {
+		t.Error("skills/alpha should resolve to a tree object id at HEAD")
 	}
-	if present["skills/beta"] {
+	if present["skills/beta"] != "" {
 		t.Error("skills/beta was never committed and must not resolve")
 	}
 
@@ -679,7 +699,7 @@ func TestGitLsTree(t *testing.T) {
 	if err != nil {
 		t.Fatalf("gitLsTree from subdirectory: %v", err)
 	}
-	if !fromSub["skills/alpha"] {
+	if fromSub["skills/alpha"] == "" {
 		t.Error("skills/alpha must resolve from a subdirectory; pathspec is repo-root-relative")
 	}
 }
@@ -709,7 +729,7 @@ func TestRun_Check_FailsOnFixableStaleSHA(t *testing.T) {
 	}
 
 	t.Run("fixable stale sha fails", func(t *testing.T) {
-		fakeTree(t, map[string][]string{beforeBeta: {"skills/alpha"}, afterBeta: both})
+		fakeTree(t, map[string]map[string]string{beforeBeta: tree("v1", "skills/alpha"), afterBeta: tree("v1", both...)})
 		skillsDir, out := setup(t)
 		err := run(skillsDir, out, "r", "main", afterBeta, true)
 		if err == nil || !strings.Contains(err.Error(), "out of date") {
@@ -721,7 +741,7 @@ func TestRun_Check_FailsOnFixableStaleSHA(t *testing.T) {
 		// The skill is not committed anywhere yet, so no regeneration can help.
 		// Failing here would put `make registry-check` red on a normal,
 		// self-healing state, which trains people to ignore it.
-		fakeTree(t, map[string][]string{beforeBeta: {"skills/alpha"}, afterBeta: {"skills/alpha"}})
+		fakeTree(t, map[string]map[string]string{beforeBeta: tree("v1", "skills/alpha"), afterBeta: tree("v1", "skills/alpha")})
 		skillsDir, out := setup(t)
 		if err := run(skillsDir, out, "r", "main", afterBeta, true); err != nil {
 			t.Fatalf("--check should not fail when no rebuild can fix it: %v", err)
@@ -729,7 +749,7 @@ func TestRun_Check_FailsOnFixableStaleSHA(t *testing.T) {
 	})
 
 	t.Run("healthy sha passes", func(t *testing.T) {
-		fakeTree(t, map[string][]string{beforeBeta: both, afterBeta: both})
+		fakeTree(t, map[string]map[string]string{beforeBeta: tree("v1", both...), afterBeta: tree("v1", both...)})
 		skillsDir, out := setup(t)
 		if err := run(skillsDir, out, "r", "main", afterBeta, true); err != nil {
 			t.Fatalf("--check should pass on a healthy registry: %v", err)

--- a/registry.json
+++ b/registry.json
@@ -1,10 +1,10 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-08-12T18:55:37Z",
+  "generated_at": "2026-08-12T19:22:01Z",
   "source": {
     "repo": "github.com/jjfantini/humblSKILLS",
     "ref": "main",
-    "sha": "d6201aba0421714bcb04319133846f9fd6e17670"
+    "sha": "25b4a4c5bf1d19ad7d9b61b7f74d39b04ef1dd4c"
   },
   "skills": [
     {

--- a/registry.json
+++ b/registry.json
@@ -1,10 +1,10 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-08-12T17:36:35Z",
+  "generated_at": "2026-08-12T18:55:37Z",
   "source": {
     "repo": "github.com/jjfantini/humblSKILLS",
     "ref": "main",
-    "sha": "885504c0f0df10ef14c5e8d67bc3b49a9a4539d1"
+    "sha": "d6201aba0421714bcb04319133846f9fd6e17670"
   },
   "skills": [
     {
@@ -648,7 +648,7 @@
     },
     {
       "name": "smart-orchestrate",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "description": "Run a frontier-parent / cost-optimized-worker orchestration pattern across the Claude, Codex, and Cursor CLIs: plan on a strong model, isolate in a worktree, dispatch bounded briefs to cheaper worker agents, and verify the whole. Use when the user says \"orchestrate this\", \"farm this out to subagents\", \"plan then gate execution\", \"parent orchestrator\", \"multi-agent this feature\", or wants planning split from implementation across model tiers. Do NOT use for a single-file edit, for authoring commits (use smart-commit), or for the worktree/PR mechanics themselves (use smart-worktree-flow).\n",
       "category": "development",
       "tags": [
@@ -673,7 +673,7 @@
         "references/patterns.md"
       ],
       "path": "skills/smart-orchestrate",
-      "dir_sha": "a01d707139e46a3bfff3ea0a31e4f88b011a16015ee190245a97435966a2b0c2"
+      "dir_sha": "e529a1249f1543f404c66d14e890482da1573b9ae9cd047dd2ca67f9d0b62156"
     },
     {
       "name": "smart-skill",

--- a/skills/smart-orchestrate/SKILL.md
+++ b/skills/smart-orchestrate/SKILL.md
@@ -14,7 +14,7 @@ compatibility: "Requires git 2.5+ for worktree isolation and at least one agent 
 disable-model-invocation: true
 metadata:
   author: jjfantini
-  version: "1.0.0"
+  version: "1.0.1"
   category: development
   tags: [orchestration, multi-agent, subagents, planning, worktree, routing, humblskill]
   platforms: [claude-code, cursor, codex]

--- a/skills/smart-orchestrate/references/decisions.md
+++ b/skills/smart-orchestrate/references/decisions.md
@@ -59,3 +59,10 @@ Entry shape:
 - Chose: B.
 - Why: a second file named `SKILL.md` inside a skill directory is a genuine hazard for humans grepping the tree, and would be a hazard for tooling too if `build-registry` ever walked recursively (today it only joins `skills/<name>/SKILL.md`, so it is safe by one implementation detail). The no-rename rule exists to protect human-dropped provenance; here the drop was performed by the migration itself, and the prefix adds provenance rather than erasing it.
 - Result: raw file is `references/raw/orchestrate-SKILL.md`, cited by all 9 concepts, byte-identical to the upstream flat skill.
+
+### 2026-08-12 | Refresh model names in the wiki, leave `references/raw/` at 4.5
+- Context: Grok 4.5 was superseded by Grok 4.6. Two wiki concepts named 4.5 as a model tier (`roles/parent-orchestrator` for the Cursor parent slot, `roles/worker-agent` for the cheap worker slot), and so does the preserved upstream skill at `references/raw/orchestrate-SKILL.md`.
+- Options: (A) update the wiki only, (B) update the wiki and the raw file so nothing in the skill reads "4.5", (C) update the wiki and annotate the raw file's line as superseded.
+- Chose: A - wiki only. The raw file keeps saying Grok 4.5.
+- Why: raw is human territory and immutable by the brain spec ("Never edit raw to satisfy a wiki claim"). It is a point-in-time snapshot of what was handed over, and it doubles as the provenance baseline every concept's `sources:` array points at - editing it to match a later fact destroys what makes the citation meaningful, and silently rewrites history for anyone diffing the distillation against its origin. A wiki that has moved ahead of its raw source is the normal state of a living skill, not drift to be reconciled.
+- Result: `roles/parent-orchestrator.md` and `roles/worker-agent.md` say Grok 4.6; the raw file still says 4.5. Read the difference as "wiki is current, snapshot is historical" - that is exactly what `sources:` is for. Skill version 1.0.0 -> 1.0.1.

--- a/skills/smart-orchestrate/references/log.md
+++ b/skills/smart-orchestrate/references/log.md
@@ -34,3 +34,14 @@ Entry shape:
   - humblSKILLS extension fields nested under `metadata:` per repo convention
 
 [LINT 2026-08-12] 9 wiki, 1 raw. Hard: 0, Soft: 0. Regenerated _index.md.
+
+[QUERY 2026-08-12] Pointed the model tiers at Grok 4.6 (was 4.5).
+  - Updated: wiki/orchestrate/roles/parent-orchestrator.md (Cursor parent tier)
+  - Updated: wiki/orchestrate/roles/worker-agent.md (cheap worker tier)
+  - references/raw/orchestrate-SKILL.md deliberately NOT touched - raw is
+    immutable and is the provenance baseline; see decisions.md 2026-08-12
+  - metadata.version 1.0.0 -> 1.0.1
+
+[LINT 2026-08-12] 9 wiki, 1 raw. Hard: 0, Soft: 0. Regenerated _index.md.
+
+[LINT 2026-08-12] 9 wiki, 1 raw. Hard: 0, Soft: 0. Regenerated _index.md.

--- a/skills/smart-orchestrate/references/wiki/orchestrate/roles/parent-orchestrator.md
+++ b/skills/smart-orchestrate/references/wiki/orchestrate/roles/parent-orchestrator.md
@@ -45,7 +45,7 @@ against anything.
 |--------|--------------|
 | Claude | Opus 5 on max is the default — same or better performance than Fable 5 and much cheaper. Reach for Fable 5 (high–max) only when the user asks for it. |
 | Codex  | GPT-5.6 Sol Max |
-| Cursor | Auto Intelligence, or Grok 4.5 High |
+| Cursor | Auto Intelligence, or Grok 4.6 High |
 
 **Ultracode is a spend decision, not a quality dial.** Use it only for a massive
 refactor touching many services and e2e flows, and **always confirm with the user

--- a/skills/smart-orchestrate/references/wiki/orchestrate/roles/worker-agent.md
+++ b/skills/smart-orchestrate/references/wiki/orchestrate/roles/worker-agent.md
@@ -14,7 +14,7 @@ last_ingested: 2026-08-12
 
 Prefer the smallest, fastest model that can finish the brief cleanly:
 
-- Grok 4.5, Composer 2.5
+- Grok 4.6, Composer 2.5
 - GPT-5.6 Terra, Luna
 - Claude Sonnet 5, Opus 5 (reserve Opus for the harder worker slots)
 


### PR DESCRIPTION
Promotes `develop` to `main`.

Contains #254:

- **`smart-orchestrate` 1.0.1** — model tiers point at Grok 4.6 (4.5 superseded). `references/raw/` deliberately keeps the 4.5 snapshot; it is the immutable provenance baseline every concept's `sources:` cites.
- **`source.sha` now compares git tree object ids, not path existence.** The v2.47.2 check only asked whether a skill's *directory* existed at `source.sha`, but `install` recomputes `dir_sha` over what it extracts and rejects a mismatch — so a commit holding an older revision of a skill fails just as hard as one missing it. That covers the common case: editing a skill, not adding one.

Verified live on #254 — the Registry job rewrote `source.sha` to `25b4a4c`, the commit that actually carries the 1.0.1 / Grok 4.6 content, and re-triggered to a clean no-op.

All checks green on #254.

🤖 Generated with [Claude Code](https://claude.com/claude-code)