### PR TITLE
docs(registry): correct the tree-id vs dir_sha claim in the repair recipe

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,9 +123,17 @@ If you ever need to repair it by hand:
 
 ```sh
 go -C cli run ./cmd/build-registry --skills-dir=$PWD/skills --out=$PWD/registry.json --ref=main --sha=<sha>
-git cat-file -e <sha>:skills/<name>/SKILL.md   # verify path exists before pushing
-git rev-parse <sha>:skills/<name>              # tree id must match what install will hash
+
+# Verify before pushing: equal tree ids mean <sha> serves the same bytes as HEAD.
+git rev-parse "<sha>:skills/<name>" "HEAD:skills/<name>"
 ```
+
+A git tree id is **not** the `dir_sha` install checks — that is a sha256 over
+canonicalized `(rel_path, mode, content_sha)` tuples (`registry.DirSHA`), while
+a tree id is a sha1 over git's own serialization. The two are never equal and
+comparing them is meaningless. Tree ids are only useful *between commits*,
+which is exactly how `sourceSHAVerdict` uses them: same id at two commits means
+identical bytes, so whatever `dir_sha` one produces the other produces too.
 
 ### A conflicted PR gets no CI at all
 GitHub cannot build the merge ref for a PR with conflicts, so it dispatches **no** `pull_request` workflows.


### PR DESCRIPTION
Correction to one line from #256.

The hand-repair recipe said:

```sh
git rev-parse <sha>:skills/<name>   # tree id must match what install will hash
```

It cannot. `dir_sha` is a **sha256** over canonicalized `(rel_path, mode, content_sha)` tuples (`registry.DirSHA`); a git tree id is a **sha1** over git's own tree serialization. Different algorithm, different length, never equal:

```
git tree id (sha1):      63ce849ae5124b42f92e1253903a1727385561db
registry dir_sha (sha256): e529a1249f1543f404c66d14e890482da1573b9ae9cd047dd2ca67f9d0b62156
```

Anyone following the recipe during an incident would compare those two, see a mismatch, and conclude a healthy registry was broken — the worst time to be misled.

Replaced with the comparison that is meaningful, and the one `sourceSHAVerdict` actually makes: equal tree ids **between two commits** mean identical bytes, so whichever `dir_sha` one produces the other produces too.

The rest of #256 is accurate and untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)