### PR TITLE
docs(registry): source.sha tree-id self-heal, provenance, and contributor runbook

### DIFF
--- a/.github/workflows/registry.yml
+++ b/.github/workflows/registry.yml
@@ -22,13 +22,14 @@ name: Registry
 # goes back to writing unconditionally, this becomes an infinite push loop.
 #
 # There is exactly one sanctioned exception, and this job is what applies it: a
-# source.sha that predates a skill registry.json already lists. `make registry`
-# reads the working tree but stamps source.sha from HEAD, so the commit that
-# first adds a skill records a SHA that cannot contain it, and install then
-# fails with "no files found under skills/<name> in tarball". build-registry
-# rewrites in that case only, and only when the new SHA actually resolves every
-# skill — so it converges after one push rather than looping. See
-# sourceSHAVerdict in cli/cmd/build-registry/main.go.
+# source.sha whose skill tree ids disagree with HEAD. `make registry` reads the
+# working tree but stamps source.sha from HEAD, so the commit that first adds
+# or edits a skill records a SHA that cannot yet serve the new bytes. install
+# then fails — missing path ("no files found under skills/<name> in tarball")
+# or outdated bytes (dir_sha mismatch after extract). build-registry compares
+# git tree object ids per skill, rewrites only when the recorded SHA is broken
+# and the new SHA resolves every skill, and converges after one push rather
+# than looping. See sourceSHAVerdict in cli/cmd/build-registry/main.go.
 
 on:
   push:
@@ -72,10 +73,10 @@ jobs:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           # Full history, not the default depth-1. Two steps here need commits
           # other than the tip: build-registry resolves the *recorded*
-          # source.sha to check it contains every skill (on a shallow clone
-          # that object is absent, git errors, and the check silently declines
-          # to fire), and the push-retry below does `git reset --hard HEAD~1`,
-          # which has no parent to reach at depth 1.
+          # source.sha to compare skill tree ids against HEAD (on a shallow
+          # clone that object is absent, git errors, and the check silently
+          # declines to fire), and the push-retry below does
+          # `git reset --hard HEAD~1`, which has no parent to reach at depth 1.
           fetch-depth: 0
       - uses: actions/setup-go@v5
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,9 +123,17 @@ If you ever need to repair it by hand:
 
 ```sh
 go -C cli run ./cmd/build-registry --skills-dir=$PWD/skills --out=$PWD/registry.json --ref=main --sha=<sha>
-git cat-file -e <sha>:skills/<name>/SKILL.md   # verify path exists before pushing
-git rev-parse <sha>:skills/<name>              # tree id must match what install will hash
+
+# Verify before pushing: equal tree ids mean <sha> serves the same bytes as HEAD.
+git rev-parse "<sha>:skills/<name>" "HEAD:skills/<name>"
 ```
+
+A git tree id is **not** the `dir_sha` install checks — that is a sha256 over
+canonicalized `(rel_path, mode, content_sha)` tuples (`registry.DirSHA`), while
+a tree id is a sha1 over git's own serialization. The two are never equal and
+comparing them is meaningless. Tree ids are only useful *between commits*,
+which is exactly how `sourceSHAVerdict` uses them: same id at two commits means
+identical bytes, so whatever `dir_sha` one produces the other produces too.
 
 ### A conflicted PR gets no CI at all
 GitHub cannot build the merge ref for a PR with conflicts, so it dispatches **no** `pull_request` workflows.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,8 @@ so **no backend/database/network services are required** to build, test, or run 
 - Registry: `make registry` regenerates `registry.json`; `make registry-check` fails if it's stale — run it
   after editing anything under `skills/`. It is a **local** gate: the Registry workflow's self-heal job
   replaced the old pre-merge check, so nothing in CI runs `--check` today. "Stale" means *anything a rebuild
-  would change* — drifted content, or a `source.sha` that predates a listed skill (see below).
+  would change* — drifted content, or a `source.sha` whose skill tree ids disagree with HEAD (skill missing
+  or serving an older revision; see below).
 - Eval (no external deps): `make eval-mock` runs the eval harness with the deterministic `mock` runner,
   writing artifacts to `.eval-workspace/` (gitignored). Real eval runners (`claudecode`, `cursor-agent`,
   `codex`, `anthropic-api`, `openai-api`) are optional and need their respective agent CLI or
@@ -89,18 +90,30 @@ gh pr merge <n> --merge      # correct
 gh pr merge <n> --squash     # breaks both of the above
 ```
 
-### `registry.json`'s `source.sha` must contain every skill it lists
-`install` fetches each skill's tarball at `source.sha`, so a SHA that predates a listed skill produces
-`extract: no files found under "skills/<name>" in tarball` — the skill is discoverable and uninstallable.
-`make registry` reads the working tree but stamps `source.sha` from git HEAD, so **the run that first adds a
-skill always records a SHA that cannot contain it**. That is expected locally; the Registry workflow repairs
-it on the next push, once the skill is committed.
+### `registry.json`'s `source.sha` must serve every skill it lists (current bytes)
+`install` fetches each skill's tarball at `source.sha`, then recomputes `dir_sha` over what it extracted
+and rejects a mismatch. Two failure modes share that path:
+
+| Recorded `source.sha` vs skill content | What install sees |
+|---|---|
+| Skill directory absent at that commit | `extract: no files found under "skills/<name>" in tarball` |
+| Skill directory present but an **older revision** | Extract succeeds, then `dir_sha` mismatch rejects the install |
+
+Presence alone is not enough. `sourceSHAVerdict` (`cli/cmd/build-registry/main.go`) compares **git tree
+object ids** per skill path (`git ls-tree`) between the recorded SHA and the candidate stamp — so a commit
+that still has `skills/<name>/` but with stale bytes is rewritten the same way as a missing skill
+(`serves outdated` vs `does not contain` in the log line).
+
+`make registry` reads the working tree but stamps `source.sha` from git HEAD, so **the run that first adds
+or edits a skill always records a SHA that cannot yet serve the new bytes**. That is expected locally; the
+Registry workflow repairs it on the next push, once the change is committed. Editing skills is the common
+case — the older presence-only check left those SHAs frozen after CI reported "already in sync".
 
 Do not "fix" this by making `semanticDiff` compare the `source` block — that comparison is zeroed on purpose,
-and reinstating it makes the workflow push on every trigger forever. The repair lives in `sourceSHAVerdict`
-(`cli/cmd/build-registry/main.go`), which bypasses the "already in sync" exit only when the recorded SHA is
-provably broken **and** the replacement provably fixes it, so it converges after one write. It needs real
-history, which is why the workflow checks out with `fetch-depth: 0`.
+and reinstating it makes the workflow push on every trigger forever. The repair bypasses the "already in sync"
+exit only when the recorded SHA is provably broken **and** the replacement provably contains every listed
+skill tree, so it converges after one write. It needs real history, which is why the workflow checks out
+with `fetch-depth: 0`.
 
 `make registry-check` fails on the same condition, so `--check` never disagrees with `make registry`. It stays
 green when *no* rebuild could fix it — the uncommitted-skill case above — because that state is normal and
@@ -110,7 +123,8 @@ If you ever need to repair it by hand:
 
 ```sh
 go -C cli run ./cmd/build-registry --skills-dir=$PWD/skills --out=$PWD/registry.json --ref=main --sha=<sha>
-git cat-file -e <sha>:skills/<name>/SKILL.md   # verify before pushing
+git cat-file -e <sha>:skills/<name>/SKILL.md   # verify path exists before pushing
+git rev-parse <sha>:skills/<name>              # tree id must match what install will hash
 ```
 
 ### A conflicted PR gets no CI at all

--- a/README.md
+++ b/README.md
@@ -427,7 +427,14 @@ The CLI source lives under [`cli/`](cli) as a nested Go module.
 make build           # builds ./bin/humblskills
 make test            # runs go test ./...
 make registry        # regenerates registry.json from skills/ + embedded adapters
+make registry-check  # local gate: fail if a rebuild would change registry.json
 ```
+
+After adding or editing anything under `skills/`, regenerate (or let the
+Registry workflow rewrite) so `source.sha` pins a commit that serves the
+**current** skill trees — not merely one that still has the directory path.
+Install fetches at that SHA and rejects `dir_sha` mismatches. Details:
+[Registry & skill format](docs/using_humblskills/registry_and_format.md#how-registryjson-is-built-contributors).
 
 ### Mirrored skills
 

--- a/docs/smart_skills.md
+++ b/docs/smart_skills.md
@@ -30,6 +30,13 @@ The brain divides `references/` into three ownership zones:
 
 The agent never edits or renames anything in `raw/` — that is human territory, the ground truth. Wiki concepts link back to it through a `sources:` array in their frontmatter, so every distilled claim has a causal chain to its origin.
 
+A wiki that has moved ahead of its raw source is the **normal state of a living
+skill**, not drift to reconcile. Raw is a point-in-time snapshot (and the
+provenance baseline `sources:` points at); rewriting it to match a later fact
+erases that citation. Read the gap as "wiki is current, snapshot is historical"
+— for example, a model-tier concept may name today's model while
+`references/raw/` still records the upstream skill that said yesterday's.
+
 ## The loop: read before, write after
 
 This is the self-learning mechanism. Every session — even a simple query — runs it:

--- a/docs/using_humblskills/registry_and_format.md
+++ b/docs/using_humblskills/registry_and_format.md
@@ -96,6 +96,34 @@ deliberately never automated.
 
 Published skills live under `skills/<skill-id>/` in the [humblSKILLS repository](https://github.com/jjfantini/humblSKILLS). The CLI reads the bundled registry and installs the matching directory to your configured location for Cursor, Claude Code, Codex, etc.
 
+## How `registry.json` is built (contributors)
+
+`make registry` (from the repo root) scans `skills/*/SKILL.md` and writes
+`registry.json`. Each entry's download pin is the registry-level
+`source.sha` — `humblskills install` fetches the skill tarball at **exactly
+that commit**, then verifies the extracted directory matches the advertised
+`dir_sha`.
+
+Constraints that trip people up:
+
+- The generator reads skill **content** from the working tree but stamps
+  `source.sha` from **git HEAD**. The first local run after you add or edit a
+  skill therefore records a SHA that cannot yet serve those new bytes. That is
+  expected: commit the skill change, then let the Registry workflow (or a
+  second `make registry` at the new HEAD) rewrite the pin.
+- "The skill directory exists at that SHA" is not enough. An older revision of
+  the same path still installs the wrong bytes and fails the `dir_sha` check.
+  The self-heal compares **git tree object ids** per skill, so both missing and
+  outdated content trigger a rewrite.
+- Run `make registry-check` locally after skill edits. It fails on the same
+  conditions a rebuild would fix; CI's Registry job auto-repairs on push rather
+  than blocking the PR.
+
+```sh
+make registry        # regenerate registry.json
+make registry-check  # fail if a rebuild would change anything (local gate)
+```
+
 ## Local install layout
 
 `humblskills install` writes one canonical skill directory, then exposes that


### PR DESCRIPTION
Promotes `develop` to `main`. Documentation only — no CLI or `registry.json` changes, so no version bump.

Contains:

- **#256** (Cursor agent) — documents the tree-id `source.sha` self-heal shipped in v2.48.0: `AGENTS.md` and the Registry workflow header now describe both failure modes (missing path → `no files found in tarball`; outdated bytes → `dir_sha` mismatch), a contributor runbook in `docs/using_humblskills/registry_and_format.md`, a `README.md` pointer, and a note in `docs/smart_skills.md` that a wiki ahead of its immutable `raw/` snapshot is normal provenance rather than drift.
- **#258** — corrects one line from #256 that claimed a git tree id "must match what install will hash". It cannot: `dir_sha` is sha256 over canonicalized `(rel_path, mode, content_sha)` tuples, a tree id is sha1 over git's serialization. Replaced with the comparison that is actually meaningful (tree ids *between commits*).

Reviewed the rest of #256 against `sourceSHAVerdict` / `gitLsTree`; it is accurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)