### PR TITLE
feat(smart-animation): add liquid-gooey as the ninth bundled library

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1,10 +1,10 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-08-12T20:17:07Z",
+  "generated_at": "2026-08-12T20:26:18Z",
   "source": {
     "repo": "github.com/jjfantini/humblSKILLS",
     "ref": "main",
-    "sha": "d397ab7eb24e23b936c03b2f8b7753bbf6122dc6"
+    "sha": "89a6a76cacb9dafc8906bc1cc287f35997844da7"
   },
   "skills": [
     {

--- a/registry.json
+++ b/registry.json
@@ -1,10 +1,10 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-08-12T19:22:01Z",
+  "generated_at": "2026-08-12T20:17:07Z",
   "source": {
     "repo": "github.com/jjfantini/humblSKILLS",
     "ref": "main",
-    "sha": "25b4a4c5bf1d19ad7d9b61b7f74d39b04ef1dd4c"
+    "sha": "d397ab7eb24e23b936c03b2f8b7753bbf6122dc6"
   },
   "skills": [
     {
@@ -461,8 +461,8 @@
     },
     {
       "name": "smart-animation",
-      "version": "0.4.0",
-      "description": "Professional, performance-first frontend animation and transition guidance that routes by the codebase you are in (HTML, CSS, JavaScript, TypeScript, React) and by ready-made libraries (thinking-orbs, border-beam, metal-fx, transitions.dev, Canvas UI, Motion/Framer Motion, React Bits, Beautiful UI). Use when adding animations, motion, transitions, page or route transitions, scroll reveals, hover micro-interactions, loading/thinking indicators, agent and AI-interface states (streaming text, tool calls, approval gates), or when the user says \"animate this\", \"add motion\", \"make it feel premium/polished\", \"page transition\", \"reveal on scroll\", or asks which animation library to use. Enforces compositor-only performance and a prefers-reduced-motion floor, and favors distinctive, non-generic motion. This skill owns motion implementation - technique, orchestration, performance, reduced-motion, and library choice. For whole-interface design direction (aesthetic thesis, typography, color, layout) use smart-frontend-design. Do NOT use for non-frontend work or for static visual design with no motion.\n",
+      "version": "0.5.0",
+      "description": "Professional, performance-first frontend animation and transition guidance that routes by the codebase you are in (HTML, CSS, JavaScript, TypeScript, React) and by ready-made libraries (thinking-orbs, border-beam, metal-fx, liquid-gooey, transitions.dev, Canvas UI, Motion/Framer Motion, React Bits, Beautiful UI). Use when adding animations, motion, transitions, page or route transitions, scroll reveals, hover micro-interactions, loading/thinking indicators, agent and AI-interface states (streaming text, tool calls, approval gates), or when the user says \"animate this\", \"add motion\", \"make it feel premium/polished\", \"page transition\", \"reveal on scroll\", or asks which animation library to use. Enforces compositor-only performance and a prefers-reduced-motion floor, and favors distinctive, non-generic motion. This skill owns motion implementation - technique, orchestration, performance, reduced-motion, and library choice. For whole-interface design direction (aesthetic thesis, typography, color, layout) use smart-frontend-design. Do NOT use for non-frontend work or for static visual design with no motion.\n",
       "category": "design",
       "tags": [
         "animation",
@@ -493,7 +493,7 @@
         "use-smart-animation"
       ],
       "path": "skills/smart-animation",
-      "dir_sha": "f1db4765581c0527aaeff8f85388472e39a01339bd00ba1eaffdfb111c79125e"
+      "dir_sha": "d88803e2c246f9ddfe8648020ec8521a347f1e18b03fbb0123a41485bf79e8d6"
     },
     {
       "name": "smart-claude-init",

--- a/skills/smart-animation/SKILL.md
+++ b/skills/smart-animation/SKILL.md
@@ -4,7 +4,8 @@ description: >
   Professional, performance-first frontend animation and transition guidance
   that routes by the codebase you are in (HTML, CSS, JavaScript, TypeScript,
   React) and by ready-made libraries (thinking-orbs, border-beam, metal-fx,
-  transitions.dev, Canvas UI, Motion/Framer Motion, React Bits, Beautiful UI).
+  liquid-gooey, transitions.dev, Canvas UI, Motion/Framer Motion, React Bits,
+  Beautiful UI).
   Use when adding animations, motion, transitions, page or
   route transitions, scroll reveals, hover micro-interactions, loading/thinking
   indicators, agent and AI-interface states (streaming text, tool calls,
@@ -20,7 +21,7 @@ license: MIT
 compatibility: Requires bash, POSIX utilities (awk, sed, find, grep), python3, writable filesystem at the skill target path.
 metadata:
   author: jjfantini
-  version: "0.4.0"
+  version: "0.5.0"
   previous_names: ["use-smart-animation"]
   category: design
   tags: [animation, transitions, frontend, motion, css, react, webgl, performance, accessibility, agent-ui, humblskill]
@@ -74,7 +75,7 @@ _Full spec: `references/_brain.md`._
 
 - Adding or reviewing animations/transitions in a web frontend
 - Choosing a motion approach for a specific language (HTML/CSS/JS/TS/React)
-- Wiring one of the eight bundled libraries (orbs, border-beam, metal-fx, transitions.dev, Canvas UI, Motion, React Bits, Beautiful UI)
+- Wiring one of the nine bundled libraries (orbs, border-beam, metal-fx, liquid-gooey, transitions.dev, Canvas UI, Motion, React Bits, Beautiful UI)
 - Building the UI around an agent: thinking states, streaming answers, tool calls, human-in-the-loop approval
 - Page/route transitions, scroll reveals, hover micro-interactions, loading states
 - Fixing janky animation (dropped frames) or missing reduced-motion handling
@@ -99,6 +100,7 @@ and `references/wiki/motion/principles/accessibility.md` (reduced-motion floor +
 - **Thinking / loading indicator for an AI or agent UI:** Read `references/wiki/lib/orbs/usage.md` (thinking-orbs)
 - **Animated glow around a card, button, or input border:** Read `references/wiki/lib/beams/usage.md` (border-beam)
 - **Metallic / liquid-metal accent on one premium element:** Read `references/wiki/lib/metal/usage.md` (metal-fx)
+- **Elements that merge like drops of liquid (expanding FAB cluster, morphing card, slider thumb with a rubbery trail):** Read `references/wiki/lib/gooey/usage.md` (liquid-gooey)
 - **Standard UI transitions (modals, toasts, tabs) in any stack:** Read `references/wiki/lib/transitions/usage.md` (transitions.dev)
 - **Creative canvas/WebGL effects over content (particle reveal, liquid, glass, shatter) for a hero or signature moment:** Read `references/wiki/lib/canvas-ui/usage.md` (Canvas UI)
 - **Exit animations, layout/FLIP animation, spring physics, or interruptible orchestration in React:** Read `references/wiki/lib/motion-react/usage.md` (Motion, formerly Framer Motion) — the four things CSS cannot do

--- a/skills/smart-animation/references/_index.md
+++ b/skills/smart-animation/references/_index.md
@@ -12,7 +12,7 @@ files and re-run lint.
 Context -> categories. See `## Wiki` below for the concept enumeration.
 
 - **lang** -> `css`, `html`, `js`, `react`, `ts`
-- **lib** -> `beams`, `beautiful-ui`, `canvas-ui`, `metal`, `motion-react`, `orbs`, `react-bits`, `transitions`
+- **lib** -> `beams`, `beautiful-ui`, `canvas-ui`, `gooey`, `metal`, `motion-react`, `orbs`, `react-bits`, `transitions`
 - **motion** -> `principles`
 
 ## Wiki
@@ -53,6 +53,10 @@ Context -> categories. See `## Wiki` below for the concept enumeration.
 
 - [usage.md](wiki/lib/canvas-ui/usage.md) - Canvas UI: Creative Canvas & WebGL Effects
 
+#### gooey
+
+- [usage.md](wiki/lib/gooey/usage.md) - liquid-gooey: Metaball Merge and Liquid Trails
+
 #### metal
 
 - [usage.md](wiki/lib/metal/usage.md) - metal-fx: Liquid-Metal Shader Accent
@@ -89,6 +93,7 @@ Context -> categories. See `## Wiki` below for the concept enumeration.
 - [border-beam.md](raw/border-beam.md) - cited by: references/wiki/lib/beams/usage.md
 - [canvas-ui.md](raw/canvas-ui.md) - cited by: references/wiki/lib/canvas-ui/usage.md
 - [frontend-design-motion-principles.md](raw/frontend-design-motion-principles.md) - cited by: references/wiki/lang/react/animation.md, references/wiki/motion/principles/design.md
+- [liquid-gooey.md](raw/liquid-gooey.md) - cited by: references/wiki/lib/gooey/usage.md
 - [metal-fx.md](raw/metal-fx.md) - cited by: references/wiki/lib/metal/usage.md
 - [motion-react.md](raw/motion-react.md) - cited by: references/wiki/lib/motion-react/usage.md
 - [react-bits.md](raw/react-bits.md) - cited by: references/wiki/lib/react-bits/usage.md

--- a/skills/smart-animation/references/log.md
+++ b/skills/smart-animation/references/log.md
@@ -68,3 +68,22 @@ Entry shape:
 [LINT 2026-07-30] 16 wiki, 10 raw. Hard: 0, Soft: 11. Regenerated _index.md.
 
 [LINT 2026-07-30] 16 wiki, 10 raw. Hard: 0, Soft: 11. Regenerated _index.md.
+
+[LINT 2026-08-12] 17 wiki, 11 raw. Hard: 0, Soft: 12. Regenerated _index.md.
+
+[INGEST 2026-08-12] Added liquid-gooey (gooey.jakubantalik.com); version 0.4.0 -> 0.5.0.
+  - raw/liquid-gooey.md: full README distillation from the npm package README in
+    Jakubantalik/Libraries (packages/liquid-gooey), plus registry metadata
+    (v0.1.0, MIT, zero deps, react/react-dom >=18 peers).
+  - wiki/lib/gooey/usage.md: ninth bundled library. Headline is the two-layer
+    architecture (SVG silhouette below carries goo + shadow, real DOM above stays
+    unfiltered) — that is what separates it from the CSS `filter: blur+contrast`
+    gooey hack, which blurs text and can't draw one shadow on a merged shape.
+  - The knob users get wrong first: bridging is a ratio of `blur` to gap, not a
+    mode. 8px apart barely bridges at blur 5, merges cleanly at blur 12.
+  - Reduced motion is honored for component-driven transitions (collapse to
+    instant snaps) — unlike metal-fx, which needs manual `paused` wiring.
+  - SKILL.md description, When-to-Use count (eight -> nine) and library routing
+    list updated so the skill can actually be selected for gooey work.
+
+[LINT 2026-08-12] 17 wiki, 11 raw. Hard: 0, Soft: 12. Regenerated _index.md.

--- a/skills/smart-animation/references/raw/liquid-gooey.md
+++ b/skills/smart-animation/references/raw/liquid-gooey.md
@@ -1,0 +1,184 @@
+# liquid-gooey (the "gooey" library)
+
+Source: https://gooey.jakubantalik.com/ and
+https://github.com/Jakubantalik/Libraries (monorepo, `packages/liquid-gooey`).
+npm: `liquid-gooey` (v0.1.0 at time of research). Author: Jakub Antalik.
+License: MIT. Researched 2026-08-12.
+
+Same author as `border-beam` and `metal-fx`. The monorepo root README lists two
+published libraries: `border-beam` and `liquid-gooey`.
+
+## What it is
+"Liquid effects for React UI. Two effects and one modifier cover the whole
+family."
+
+- **Morph** (default) — touching pieces merge gooily and change shape like jelly
+  (metaball / gooey-filter behavior).
+- **Move** — the surface trails a moving element as liquid rubber with a droplet
+  tail.
+- **dissolve** — an orthogonal modifier: the item's imagery melts into whatever
+  it touches at the contact point (a liquid warp with two-liquid mixing, not a
+  blur). Text is unaffected; only imagery warps.
+
+## The architectural point (why it isn't just a CSS gooey filter)
+Two rendering layers, filters never touch content:
+
+- **Silhouette layer (SVG, below):** one blob per item, carrying the goo filter
+  and the shadow chain.
+- **Content layer (DOM, above):** the real, unfiltered, interactive elements.
+
+Consequences the README calls out:
+- Real shadows parsed from `box-shadow` syntax, rendered on the **merged**
+  silhouette — one consistent shadow hugs the liquid through every merge/split.
+  `inset` layers paint inside the liquid edge.
+- Text, icons and images stay sharp (content never receives a filter).
+- Works in Safari, because it filters via SVG rather than CSS `url()`.
+- Focus, ARIA and handlers stay live on real DOM.
+- GPU-composited animation, zero idle overhead.
+
+## Install
+```bash
+npm install liquid-gooey
+```
+
+## Framework / requirements
+React >= 18 (`react` and `react-dom` peer deps `>=18`). Zero runtime
+dependencies. Ships ESM + CJS + types, `sideEffects: false`.
+
+## Minimal usage
+```tsx
+import { Liquid } from 'liquid-gooey'
+
+<Liquid blur={6} contrast={18} fill="#fff" shadow="0 2px 6px rgba(0,0,0,.08)">
+  <Liquid.Item x={open ? -54 : 0} y={open ? -34 : 0} transition="bouncy">
+    <button className="round-btn">…</button>
+  </Liquid.Item>
+  <Liquid.Item x={0} y={open ? -64 : 0} transition="bouncy" delay={40}>
+    <button className="round-btn">…</button>
+  </Liquid.Item>
+</Liquid>
+```
+
+## Morph
+Default. Items that touch bridge and merge automatically. Opt into jelly
+shape-change physics:
+
+```tsx
+<Liquid.Item morph={{ shape: true }}>
+  <div className={open ? 'panel-open' : 'panel-closed'}>…</div>
+</Liquid.Item>
+```
+
+| Knob | Default | Meaning |
+| --- | --- | --- |
+| `shape` | `false` | Liquid shape-change physics (springs + droplet travel + corner timeline). |
+| `speed` | `1` | Tempo multiplier for the shape physics (2 = twice as fast, same character). |
+| `bounce` | `0.5` | `0..1` overshoot/wobble. `0` = calm, critically damped. |
+| `contentBlur` | `7` | Max px **your content** cross-blurs by while the liquid moves, sharpening as it settles. `0` disables. |
+
+## Move
+```tsx
+<Liquid.Item effect="move" move={{ springiness: 0.5, trail: 0.575 }}>
+  <div className="thumb" style={{ transform: `translateX(${x}px)` }} />
+</Liquid.Item>
+```
+You move the element; the liquid trails behind it.
+
+| Knob | Default | Meaning |
+| --- | --- | --- |
+| `springiness` | `0.5` | `0..1` how tightly the liquid chases. 0 = heavy syrup, 1 = near-instant. |
+| `wobble` | `0.5` | `0..1` overshoot on arrival. |
+| `stretch` | `0.36` | `0..1` velocity stretch of the drop. |
+| `trail` | `0.575` | `0..1` trailing droplet size. 0 disables the tail. |
+
+## dissolve (modifier, not an effect)
+```tsx
+<Liquid.Item dissolve />                                   // the tuned look
+<Liquid.Item dissolve={0.5} />                             // scaled intensity
+<Liquid.Item dissolve={{ mix: 0.7, active: dragging }} />  // full DissolveOptions
+```
+Applies to **morph items only**; under `effect="move"` it emits a developer
+warning.
+
+## `<Liquid>` group props
+Renders a `position: relative` container with the liquid silhouette SVG behind
+its children. Accepts all standard `div` props. Size the group to contain the
+full travel of its items.
+
+| Prop | Default | Description |
+| --- | --- | --- |
+| `blur` | `6` | Goo blur sigma (px). **Bridging is a ratio of blur to gap** — neighbours merge once `blur` ≳ the gap. Items 8px apart barely bridge at `blur={5}`, merge cleanly at `blur={12}`. If pieces that should merge look separate, raise `blur` (or close the gap) first. |
+| `contrast` | `18` | Alpha-contrast slope. Larger = sharper liquid edge. |
+| `fill` | `'#fff'` | Liquid surface color. Any CSS color; `var(--surface)` works for theming. |
+| `shadow` | — | `box-shadow` syntax, multi-layer, rendered on the merged silhouette. |
+| `filterPadding` | `24` | Extra filter-region slack (px) if blobs travel outside the group's box. |
+
+## `<Liquid.Item>` props
+| Prop | Description |
+| --- | --- |
+| `effect` | `'morph'` (default) or `'move'`. |
+| `morph` / `move` | The knobs above, plus `advanced`. |
+| `dissolve` | `true`, `0..1`, or raw `DissolveOptions`. Orthogonal to `effect`. |
+| `x` `y` `scale` `transition` `delay` | Component-driven position: the library animates element + liquid in one commit (pixel-perfect sync). `transition` is `'snappy' \| 'smooth' \| 'bouncy'`, `{ stiffness, damping, mass }` or `{ duration, ease }`. |
+| `observe` | For plain-merge items animated by *your* code: the liquid follows the child's rendered rect. Implied by `morph.shape`, `dissolve` and `effect="move"`. |
+| `radius` | Override the measured border-radius (`number` or `[tl, tr, br, bl]`). |
+
+Border-radius is measured from computed style; percentages, circles and pills
+work automatically. Item backgrounds should be transparent — the blob *is* the
+visual surface.
+
+## Advanced (raw engine values)
+```tsx
+<Liquid.Item
+  morph={{
+    shape: true,
+    advanced: {
+      evolve: { massStiffness: 320, cornerDuration: 820, roundness: 1 /* EvolveOptions */ },
+      blobInset: 2,   // shrink the blob so an opaque photo covers its own liquid
+      bridgeGrow: 8,  // liquid coat that swells out and necks into a neighbour
+    },
+  }}
+  dissolve={{ warp: 26, mix: 0.7, gravity: 60, active: dragging /* DissolveOptions */ }}
+/>
+
+<Liquid.Item effect="move" move={{ advanced: { stiffness: 380, damping: 18 /* MoveOptions */ } }} />
+```
+
+- **EvolveOptions:** `massStiffness/Damping`, `sizeStiffness/Damping`,
+  `radiusStiffness/Damping`, `contentBlur`, `roundness`, `anticipation`/`travel`,
+  corner timeline (`cornerDuration`/`cornerDelay`/`cornerEase`).
+- **DissolveOptions:** `blur`, `warp`, `zone`, `range`, `mix`, `gravity`/`taper`,
+  `warpFreq`, `flowSpeed`, `warpStyle`, `detail`, `active`/`releaseMs`.
+- **MoveOptions:** `stiffness`, `damping`, `stretch`, `tail`.
+
+## Performance
+- Component-driven motion compiles to CSS `linear()` easings (GPU-composited).
+- One rAF loop per group; it sleeps entirely after stillness — zero idle cost.
+- Dissolve overlay renders only near contact areas.
+
+Caveats:
+- Dissolve warps a snapshot of each image's `src` (rebuilt on resize).
+- Dissolve writes `mask-image` onto `<img>` elements during contact.
+- `morph.shape` applies `filter: blur()` mid-morph.
+- Rotation is not mirrored in v1.
+
+## Accessibility
+- "The content layer is real DOM — focus rings, hit targets and ARIA are never
+  filtered."
+- **Reduced motion is respected**: component-driven transitions collapse to
+  instant snaps. (Unlike metal-fx, this does not need manual wiring — but
+  motion you drive yourself, e.g. the `effect="move"` transform, is still
+  yours to gate.)
+
+## Theming
+Pass `fill="var(--surface)"` for light/dark switching.
+
+## Playground
+```bash
+npm install && npm run dev
+```
+Append `?pro` to the URL for full raw-physics control panels.
+
+## Credits (from the README)
+"Filter architecture distilled from the PRO7 'Gooey plus menu' prototype; API
+philosophy inspired by Sileo."

--- a/skills/smart-animation/references/wiki/lib/gooey/usage.md
+++ b/skills/smart-animation/references/wiki/lib/gooey/usage.md
@@ -1,0 +1,94 @@
+---
+title: "liquid-gooey: Metaball Merge and Liquid Trails"
+context: lib
+category: gooey
+concept: usage
+description: "liquid-gooey (React): Morph (touching pieces merge like jelly), Move (liquid-rubber trail), and the dissolve modifier. SVG silhouette layer keeps content crisp and interactive; blur-to-gap ratio controls bridging."
+tags: liquid-gooey, react, metaball, gooey, svg-filter, fab, morph, spring
+sources:
+  - "references/raw/liquid-gooey.md"
+last_ingested: 2026-08-12
+---
+
+## liquid-gooey: Metaball Merge and Liquid Trails
+
+`liquid-gooey` makes React elements behave like drops of liquid: pieces that
+touch merge, a moving element drags a rubbery tail, and imagery can melt into a
+neighbour at the contact point. React >= 18, zero runtime dependencies.
+
+The reason to reach for it over a hand-rolled CSS gooey filter: it renders **two
+layers**. An SVG silhouette below carries the goo filter and the shadow; your
+real DOM rides crisp on top and is never filtered. So text stays sharp, focus
+rings and ARIA survive, and it works in Safari (SVG filtering, not CSS `url()`).
+
+```
+npm install liquid-gooey
+```
+
+**Incorrect (filter the content itself — the classic CSS gooey hack):**
+
+```css
+/* Blurs the text and icons along with the shapes, kills hit-testing
+   precision, and the shadow is per-element so merged blobs show seams. */
+.fab-group { filter: blur(6px) contrast(18); }
+```
+
+**Correct (silhouette below, real DOM above, one shadow on the merged shape):**
+
+```tsx
+import { Liquid } from 'liquid-gooey'
+
+<Liquid blur={12} contrast={18} fill="var(--surface)" shadow="0 2px 6px rgba(0,0,0,.08)">
+  <Liquid.Item x={open ? -54 : 0} y={open ? -34 : 0} transition="bouncy">
+    <button className="round-btn" aria-label="Share">…</button>
+  </Liquid.Item>
+  <Liquid.Item x={0} y={open ? -64 : 0} transition="bouncy" delay={40}>
+    <button className="round-btn" aria-label="Edit">…</button>
+  </Liquid.Item>
+</Liquid>
+```
+
+Two effects and one modifier cover everything:
+
+- **Morph** (default) — touching items bridge and merge. `morph={{ shape: true }}`
+  adds jelly shape-change physics (`speed` 1, `bounce` 0.5, `contentBlur` 7).
+- **Move** — `effect="move"`; you move the child, the liquid trails it
+  (`springiness` 0.5, `wobble` 0.5, `stretch` 0.36, `trail` 0.575).
+- **dissolve** — orthogonal modifier (`true` | `0..1` | `DissolveOptions`); the
+  item's imagery melts into what it touches. **Morph items only** — under
+  `effect="move"` it just warns.
+
+**Bridging is a ratio of blur to gap, not a mode.** Items merge once `blur` ≳ the
+gap between them: 8px apart barely bridges at `blur={5}`, merges cleanly at
+`blur={12}`. If pieces that should merge look separate, raise `blur` or close
+the gap before suspecting anything else. Give items transparent backgrounds —
+the blob *is* the surface — and size the group to contain the items' full
+travel (or raise `filterPadding`, default 24).
+
+Group props: `blur` 6, `contrast` 18, `fill` `'#fff'`, `shadow` (box-shadow
+syntax, drawn on the *merged* silhouette so one shadow hugs it through every
+merge and split; `inset` layers paint inside the liquid edge), `filterPadding`
+24. Item props: `x`/`y`/`scale`/`transition`/`delay` (component-driven — element
+and liquid animate in one commit, so they can't desync), `observe` (follow a
+child your own code animates), `radius`.
+
+Performance: component-driven motion compiles to CSS `linear()` easings, one rAF
+loop per group that sleeps completely once still — zero idle cost. Watch the
+caveats: dissolve snapshots each image `src` (rebuilt on resize) and writes
+`mask-image` onto `<img>` during contact, `morph.shape` applies a real
+`filter: blur()` mid-morph, and rotation is not mirrored in v1.
+
+Reduced motion is honored — component-driven transitions collapse to instant
+snaps. Motion you drive yourself (the transform you feed an `effect="move"`
+child) is still yours to gate; see `motion/principles/accessibility`.
+
+Fit: ONE liquid moment — an expanding FAB cluster, a toggle/slider thumb with a
+trail, a card that morphs into a panel. It is a signature effect, not a
+site-wide texture. For a border glow use `lib/beams`; for a metallic accent use
+`lib/metal`.
+
+## Sources
+
+- `references/raw/liquid-gooey.md` — two-layer architecture, full prop and knob
+  tables with defaults, blur-to-gap bridging rule, performance caveats,
+  reduced-motion behavior, npm/peer-dep facts.


### PR DESCRIPTION
Promotes `develop` to `main`.

Adds [liquid-gooey](https://gooey.jakubantalik.com) to the `smart-animation` skill (#260) — Morph, Move and the `dissolve` modifier, with the two-layer SVG-silhouette architecture as the headline and the blur-to-gap bridging rule recorded. Skill `0.4.0` → `0.5.0`.

## Registry self-heal fired as designed

This is the first skill *edit* to land since the `sourceSHAVerdict` repair in v2.47.2. On the branch push the Registry workflow detected that the recorded `source.sha` (`d397ab7`) served outdated `smart-animation` bytes and rewrote it to `89a6a76` in `ecb9522` — instead of the old presence-only check reporting "already in sync" and freezing a SHA that `install` would reject on `dir_sha` mismatch.