### PR TITLE
feat(release): develop pre-releases, stable brew, and first-class beta channel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [develop, main]
   pull_request:
 
 permissions:

--- a/.github/workflows/release-auto-merge.yml
+++ b/.github/workflows/release-auto-merge.yml
@@ -1,18 +1,11 @@
-# Enables GitHub auto-merge on release-please PRs so they land on main as soon as
-# required checks pass, without a manual merge click. That push then lets the
-# release workflow create the tag, GitHub Release, and GoReleaser artifacts.
+# Enable GitHub auto-merge on release-please PRs targeting develop or main.
+# Merging the PR is what makes release-please tag the release and run
+# GoReleaser. A major bump on either branch is left for a human.
 #
-# Prerequisites (repo Settings):
+# Repo settings:
 #   - General → Pull Requests → Allow auto-merge: ON
-#   - Branch protection on main: if "Require approvals" is ON, auto-merge will
-#     wait forever unless you add a bypass (bot review, ruleset exception, or
-#     relax reviews for maintainers). Required *status checks* alone work well.
-#
-# This only targets branches created by release-please (head ref contains
-# release-please--). The branch prefix is unique to release-please, so we don't
-# additionally pin on PR author — release-please switched to a PAT-authored
-# identity to escape the GITHUB_TOKEN workflow-trigger suppression, so pinning
-# to github-actions[bot] would lock this workflow out.
+#   - Use a PAT (RELEASE_PLEASE_TOKEN) so the merge commit triggers the
+#     `release` workflow. A GITHUB_TOKEN merge does not.
 
 name: Auto-merge release-please PR
 
@@ -31,18 +24,12 @@ concurrency:
 jobs:
   enable-auto-merge:
     if: |
-      github.base_ref == 'main' &&
+      (github.base_ref == 'main' || github.base_ref == 'develop') &&
       contains(github.head_ref, 'release-please--') &&
       github.event.pull_request.draft == false
     runs-on: ubuntu-latest
-    # RELEASE_PLEASE_TOKEN is an environment secret on `release`. Without
-    # this declaration, secrets.RELEASE_PLEASE_TOKEN resolves to empty
-    # and gh errors out with "GH_TOKEN ... not set".
     environment: release
     steps:
-      # A major bump is never auto-merged. See scripts/guard-major-bump.sh for
-      # why. This step failing is the intended outcome, not a broken pipeline:
-      # the PR stays open for a human to merge.
       - uses: actions/checkout@v4
         with:
           sparse-checkout: scripts/guard-major-bump.sh
@@ -53,18 +40,10 @@ jobs:
           GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
         run: |
           bash scripts/guard-major-bump.sh \
-            "${{ github.repository }}" "${{ github.event.pull_request.head.sha }}"
+            "${{ github.repository }}" \
+            "${{ github.event.pull_request.head.sha }}" \
+            "${{ github.base_ref }}"
 
-      # Use the release-please PAT, not GITHUB_TOKEN. When auto-merge fires
-      # with GITHUB_TOKEN, the resulting merge commit is authored by
-      # github-actions[bot] and GitHub suppresses downstream workflow
-      # triggers — so the `release` workflow never runs, no v tag, no
-      # GoReleaser artifacts. A PAT-authored merge cascades normally.
-      #
-      # -R names the repo explicitly instead of letting `gh pr merge` shell out
-      # to `git` to discover it. The guard step above now checks out the repo
-      # (sparsely), so the lookup would succeed either way — but -R keeps this
-      # step working if that checkout is ever dropped.
       - name: Enable auto-merge (merge commit)
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,87 +1,69 @@
 name: release
 
-# Single entry-point release pipeline.
+# Two-branch path, one workflow:
 #
-# Automated path (push: main):
-#   release-please evaluates conventional commits on main. When a release is
-#   due, it opens a release PR (changelog + manifest bump). Merging that PR
-#   triggers another push to main; release-please then creates the `vX.Y.Z`
-#   tag and GitHub release, and this workflow continues into goreleaser -
-#   publishing binaries and updating the `jjfantini/homebrew-humbl` tap.
+#   develop → GitHub pre-release (tag vX.Y.Z-pre.N, prerelease: true). No brew.
+#   main    → GitHub stable      (tag vX.Y.Z) + Homebrew tap update.
 #
-#   Do not set skip-github-pull-request: true with this layout - it breaks
-#   tagging/releases when using manifest + release PRs (see release-please#937).
+# release-please reads conventional commits on the pushed branch, opens a
+# release PR, and after that PR merges it creates the tag and GitHub Release.
+# GoReleaser publishes archives. Brew uses skip_upload: auto, so only a
+# stable tag updates jjfantini/homebrew-humbl.
 #
-#   Auto-merge: .github/workflows/release-auto-merge.yml enables GitHub
-#   auto-merge on those PRs so they land when CI passes (enable in repo settings).
-#
-# Manual backfill (workflow_dispatch):
-#   Re-run goreleaser against an existing tag. Skips release-please.
+# workflow_dispatch re-runs GoReleaser for an existing tag (backfill).
 
 on:
   push:
     branches:
+      - develop
       - main
   workflow_dispatch:
     inputs:
       tag:
-        description: "Existing tag to (re)release, e.g. v0.2.0. Used to backfill binaries + Homebrew formula."
+        description: "Existing tag to (re)release, e.g. v2.51.0 or v2.52.0-pre.1"
         required: true
 
 permissions:
   contents: write
   pull-requests: write
 
-# Serialize releases. Merging a feature PR and merging the release PR it
-# produces land ~40s apart, so without this two release-please runs overlap:
-# the second starts while the first is still tagging, sees no latest release,
-# and rescans history. That is how v3.0.0 happened. Never cancel in progress -
-# a half-finished goreleaser run leaves a tag with no artifacts.
+# Per-branch, never cancel. Two pushes to the same branch ~40s apart (feature
+# merge, then the release PR it opened) must not overlap, and a half-finished
+# goreleaser run must not be killed.
 concurrency:
-  group: release
+  group: release-${{ github.ref_name }}
   cancel-in-progress: false
 
 jobs:
   release_please:
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
-    # The `release` environment scopes RELEASE_PLEASE_TOKEN (a PAT). Using a
-    # PAT instead of GITHUB_TOKEN means the release PR is authored by a human
-    # account, so it escapes GitHub's rule that PRs opened via GITHUB_TOKEN
-    # don't trigger downstream `pull_request` workflows (CI, auto-merge). The
-    # environment has no protection rules, so this is pure secret scoping.
+    # RELEASE_PLEASE_TOKEN is a PAT on the `release` environment. A PAT-authored
+    # release PR triggers downstream pull_request workflows (CI, auto-merge);
+    # GITHUB_TOKEN-authored PRs do not.
     environment: release
     outputs:
       release_created: ${{ steps.rp.outputs.release_created }}
       tag_name: ${{ steps.rp.outputs.tag_name }}
     steps:
-      # `last-release-sha` in release-please-config.json bounds the fallback
-      # path. When release-please cannot find the latest release it does not
-      # fail - it logs "No latest release found" and re-derives the version
-      # from every commit it collected. On 2026-07-30 that reached
-      # `feat(cli)!: local-owned preserve list (#34)` from months earlier and
-      # cut a phantom 3.0.0. last-release-sha caps how far back that can go.
-      # Bump it at any release where the history walk gets slow again.
       - uses: googleapis/release-please-action@v4
         id: rp
         with:
-          config-file: release-please-config.json
+          config-file: ${{ github.ref_name == 'develop' && 'release-please-config.develop.json' || 'release-please-config.json' }}
           manifest-file: .release-please-manifest.json
+          target-branch: ${{ github.ref_name }}
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
 
   goreleaser:
     needs: release_please
-    # `always()` is required so this job still runs when `release_please` is
-    # skipped on the workflow_dispatch path; otherwise a skipped need would
-    # propagate as skipped here too.
     if: |
       always() && (
         (github.event_name == 'push' && needs.release_please.outputs.release_created == 'true') ||
         github.event_name == 'workflow_dispatch'
       )
     runs-on: ubuntu-latest
-    # The `release` environment gates the Homebrew tap PAT. HOMEBREW_TAP_TOKEN
-    # is configured as an environment secret in repo settings.
+    # HOMEBREW_TAP_TOKEN is an environment secret. Unused on pre-release tags
+    # (goreleaser skip_upload: auto) but still required to be present.
     environment: release
     permissions:
       contents: write
@@ -95,25 +77,18 @@ jobs:
             echo "tag=${{ needs.release_please.outputs.tag_name }}" >> "$GITHUB_OUTPUT"
           fi
 
-      # token: RELEASE_PLEASE_TOKEN so the sibling tag push below can touch
-      # commits that include workflow file changes. GITHUB_TOKEN cannot
-      # push refs referencing commits that modify .github/workflows/
-      # without the `workflows` app permission, which it doesn't have.
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ steps.resolve.outputs.tag }}
+          # PAT: GITHUB_TOKEN cannot push tags that point at commits touching
+          # .github/workflows/ (needs the `workflows` permission).
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
 
       - name: Push sibling cli/* tag for go install
-        # Go's nested-module resolution requires `cli/vX.Y.Z` to exist on the
-        # same commit as `vX.Y.Z` so
-        # `go install github.com/jjfantini/humblSKILLS/cli/v2/cmd/humblskills@vX.Y.Z`
-        # works. The `/v2` is load-bearing: for v2+ the module path must carry
-        # the major version, and `cli/go.mod` declares it. Without the suffix
-        # the proxy ignored every cli/v2.* tag and `@latest` served v1.1.0 for
-        # four months. At v3, move the module path and imports to `/v3` or this
-        # silently breaks again.
+        # Nested module: `cli/go.mod` is `github.com/jjfantini/humblSKILLS/cli/v2`,
+        # so `go install .../cli/v2/cmd/humblskills@vX.Y.Z` needs `cli/vX.Y.Z`
+        # on the same commit as `vX.Y.Z`. At v3, move the module path to `/v3`.
         run: |
           set -eu
           ver="${{ steps.resolve.outputs.tag }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,14 +1,16 @@
 name: release
 
-# Two-branch path, one workflow:
+# Two-branch path, one workflow. Not a second goreleaser entry-point:
+# release-please already knows pre-release branches (prerelease + versioning
+# prerelease). A custom "compute next -pre tag" job would be new glue.
 #
-#   develop → GitHub pre-release (tag vX.Y.Z-pre.N, prerelease: true). No brew.
-#   main    → GitHub stable      (tag vX.Y.Z) + Homebrew tap update.
+#   develop → vX.Y.Z-pre.N GitHub pre-release. No brew.
+#   main    → vX.Y.Z stable + Homebrew tap (jjfantini/homebrew-humbl).
 #
-# release-please reads conventional commits on the pushed branch, opens a
-# release PR, and after that PR merges it creates the tag and GitHub Release.
-# GoReleaser publishes archives. Brew uses skip_upload: auto, so only a
-# stable tag updates jjfantini/homebrew-humbl.
+# Tag rule: the `-pre.N` suffix is semver-prerelease, so it cannot equal a
+# stable `vX.Y.Z` tag. GitHub /releases/latest and `go install @latest`
+# ignore prereleases. goreleaser `prerelease: auto` + `skip_upload: auto`
+# consume the same suffix — no develop Homebrew channel.
 #
 # workflow_dispatch re-runs GoReleaser for an existing tag (backfill).
 

--- a/.github/workflows/sync-develop.yml
+++ b/.github/workflows/sync-develop.yml
@@ -1,18 +1,8 @@
 name: Sync develop
 
-# Keeps `develop` at or ahead of `main`, never behind.
-#
-# The normal flow is feature -> develop -> main, but small changes sometimes go
-# straight to main, and release-please and the registry bot commit there too.
-# Left alone `develop` drifts: it sat 126 commits behind for a month, which
-# broke the "Edit this page" links on the docs site and made every doc link
-# into tree/develop 404 after the smart-* rename.
-#
-# Deliberately a plain push, never --force. When develop holds feature work
-# that has not merged into main yet the push is a non-fast-forward and is
-# skipped — that work is the reason develop exists and must not be clobbered.
-# Merging develop into main makes develop an ancestor of main again, and the
-# next push to main fast-forwards it.
+# After a main release, release-please commits changelog + manifest on main.
+# Fast-forward develop so it is not left behind. Plain push, never --force:
+# if develop has unmerged work the push is a non-fast-forward and is skipped.
 
 on:
   push:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -43,6 +43,9 @@ checksum:
 
 brews:
   - name: humblskills
+    # auto = upload only for stable tags. vX.Y.Z-pre.N must not move the tap;
+    # `brew upgrade humblskills` tracks the last main release.
+    skip_upload: auto
     repository:
       owner: jjfantini
       name: homebrew-humbl

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -42,9 +42,9 @@ checksum:
   name_template: checksums.txt
 
 brews:
+  # Stable formula. skip_upload: auto = do not touch this file on vX.Y.Z-pre.N.
+  # `brew upgrade humblskills` stays on the last main release.
   - name: humblskills
-    # auto = upload only for stable tags. vX.Y.Z-pre.N must not move the tap;
-    # `brew upgrade humblskills` tracks the last main release.
     skip_upload: auto
     repository:
       owner: jjfantini
@@ -55,10 +55,37 @@ brews:
     homepage: https://github.com/jjfantini/humblSKILLS
     description: Install agentskills.io-format skills into Claude Code, Cursor, and friends.
     license: CC-BY-4.0
+    conflicts:
+      - humblskills-pre
     commit_author:
       name: goreleaserbot
       email: goreleaser@users.noreply.github.com
     commit_msg_template: "humblskills: update to {{ .Tag }}"
+    install: |
+      bin.install "humblskills"
+    test: |
+      system "#{bin}/humblskills", "version"
+
+  # Pre-release formula. Homebrew rejects `name@version` unless the suffix is
+  # numeric (`python@3.12` → class PythonAT312); `humblskills@beta` is illegal.
+  # Inverse of auto: upload only when the tag has a semver prerelease component.
+  - name: humblskills-pre
+    skip_upload: "{{ if .Prerelease }}false{{ else }}true{{ end }}"
+    repository:
+      owner: jjfantini
+      name: homebrew-humbl
+      branch: main
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+    directory: Formula
+    homepage: https://github.com/jjfantini/humblSKILLS
+    description: Pre-release (develop) build of humblskills. Does not replace the stable formula.
+    license: CC-BY-4.0
+    conflicts:
+      - humblskills
+    commit_author:
+      name: goreleaserbot
+      email: goreleaser@users.noreply.github.com
+    commit_msg_template: "humblskills-pre: update to {{ .Tag }}"
     install: |
       bin.install "humblskills"
     test: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,10 +43,27 @@ so **no backend/database/network services are required** to build, test, or run 
   `~/.venvs/humblskills-docs/bin/mkdocs build --strict` (config: `mkdocs.yml`). `mkdocs serve` for preview.
   Note `mkdocs build` drops a `docs/__pycache__/` (not gitignored) — remove it after building.
 
+### Release path (develop pre-release → main stable + brew)
+`.github/workflows/release.yml` is the only release entry point:
+
+- Push/merge to **`develop`** → release-please (`release-please-config.develop.json`) cuts a
+  GitHub **pre-release** tagged `vX.Y.Z-pre.N`. GoReleaser publishes archives. The Homebrew
+  tap is not touched (`skip_upload: auto`).
+- Merge **`develop` → `main`** (merge commit, never squash) → release-please
+  (`release-please-config.json`) cuts the **stable** `vX.Y.Z` GitHub Release and GoReleaser
+  updates `jjfantini/homebrew-humbl` so `brew upgrade humblskills` gets that version.
+
+Both release PRs auto-merge on green for same-major bumps (`scripts/guard-major-bump.sh`
+blocks majors). Secrets live on the `release` environment: `RELEASE_PLEASE_TOKEN` (repo PAT)
+and `HOMEBREW_TAP_TOKEN` (write to the tap). Do not add extra patch workflows around this
+path; if a release fails, fix the two configs or the one workflow.
+
 ### Commit messages MUST be Conventional Commits (non-negotiable)
-`release-please-config.json` sets `release-type: "go"`, which cuts releases **only** from commits that
-follow [Conventional Commits](https://www.conventionalcommits.org) syntax on `main`. A commit that doesn't
-match is silently invisible to release-please — no changelog entry, no version bump, no release, and
+`release-please-config.json` / `release-please-config.develop.json` set `release-type: "go"`,
+which cut releases **only** from commits that follow
+[Conventional Commits](https://www.conventionalcommits.org) syntax on the branch that
+releases (`develop` for pre, `main` for stable). A commit that doesn't match is silently
+invisible to release-please — no changelog entry, no version bump, no release, and
 `humblskills upgrade` never sees the change. This already happened once (commits like `profile:`,
 `adapters:`, `install:`, `tui:` merged to `main` with zero release effect) and had to be fixed forward with
 an extra empty `feat:` commit — don't repeat it.
@@ -77,7 +94,7 @@ when you need to refer to it in prose.
 ### Merge PRs with `--merge`. Never `--squash`, never `--rebase`.
 Two independent things break on a squash, both silently:
 
-1. **release-please reads the individual commit messages on `main`.** A squash collapses the whole PR into
+1. **release-please reads the individual commit messages on `develop` and `main`.** A squash collapses the whole PR into
    its title, so a branch carrying `fix:` plus two `feat:` commits ships as a patch and loses both feature
    changelog entries. A merge commit preserved all four and correctly produced the 2.43.0 minor bump.
 2. **`registry.json` pins `source.sha` to the commit where skill content last changed, and `install`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,11 +47,13 @@ so **no backend/database/network services are required** to build, test, or run 
 `.github/workflows/release.yml` is the only release entry point:
 
 - Push/merge to **`develop`** → release-please (`release-please-config.develop.json`) cuts a
-  GitHub **pre-release** tagged `vX.Y.Z-pre.N`. GoReleaser publishes archives. The Homebrew
-  tap is not touched (`skip_upload: auto`).
+  GitHub **pre-release** tagged `vX.Y.Z-pre.N`. GoReleaser publishes archives and the
+  `humblskills-pre` formula. The stable `humblskills` formula is not touched
+  (`skip_upload: auto`).
 - Merge **`develop` → `main`** (merge commit, never squash) → release-please
   (`release-please-config.json`) cuts the **stable** `vX.Y.Z` GitHub Release and GoReleaser
-  updates `jjfantini/homebrew-humbl` so `brew upgrade humblskills` gets that version.
+  updates `jjfantini/homebrew-humbl` `Formula/humblskills.rb` so `brew upgrade humblskills`
+  gets that version. The pre formula is not rewritten on a stable tag.
 
 Both release PRs auto-merge on green for same-major bumps (`scripts/guard-major-bump.sh`
 blocks majors). Secrets live on the `release` environment: `RELEASE_PLEASE_TOKEN` (repo PAT)

--- a/README.md
+++ b/README.md
@@ -31,10 +31,26 @@ If you use [Homebrew](https://brew.sh), install and upgrade with:
 
 ```sh
 brew install jjfantini/humbl/humblskills
+brew upgrade humblskills
 ```
 
+Pre-releases from `develop` (`vX.Y.Z-pre.N`) ship a **second** formula and never
+replace the stable one (`humblskills@beta` is an illegal Homebrew class name):
+
+```sh
+brew install jjfantini/humbl/humblskills-pre
+brew upgrade humblskills-pre
+```
+
+The CLI install channel is one field in `~/.humblskills/profile.json`
+(`channel`: `stable` or `beta`; unset means stable). Read or change it with
+`humblskills profile get channel` / `profile set channel beta`, the existing
+Profile TUI (`humblskills` → Profile → **install channel**), or a one-shot
+`humblskills upgrade --channel beta`. Same field Homebrew and `upgrade` use.
+
 Formulas live in [`jjfantini/homebrew-humbl`](https://github.com/jjfantini/homebrew-humbl)
-and are bumped automatically by the release workflow. Upgrade with `brew upgrade humblskills`.
+and are bumped by GoReleaser: `humblskills` on stable tags, `humblskills-pre`
+on pre tags.
 
 ### Shell installer (Linux/macOS)
 
@@ -461,11 +477,12 @@ Releases follow the two-branch path in
 
 - **`develop`** — release-please opens a pre-release PR. Merging it tags
   `vX.Y.Z-pre.N` and publishes a GitHub **pre-release** (archives + checksums).
-  The Homebrew tap is left alone.
+  GoReleaser updates `Formula/humblskills-pre.rb` only. The stable
+  `humblskills` formula is left alone.
 - **`main`** — merge `develop` with a merge commit (never squash). release-please
   opens a stable PR. Merging it tags `vX.Y.Z`, publishes the GitHub Release, and
-  GoReleaser updates the `jjfantini/homebrew-humbl` formula so
-  `brew upgrade humblskills` gets that version.
+  GoReleaser updates `Formula/humblskills.rb` so `brew upgrade humblskills`
+  gets that version. The pre formula is not rewritten.
 
 Both release PRs auto-merge on green for same-major bumps. A major bump waits
 for a human.

--- a/README.md
+++ b/README.md
@@ -456,11 +456,19 @@ a completion checklist. Detection is deterministic and automated;
 re-distillation is judgment and is never automated. Both read a source checkout,
 not installed copies.
 
-Releases are cut by release-please from the conventional commits on `main`: it
-opens a release PR, and merging that PR tags `vX.Y.Z` and triggers
-[`.github/workflows/release.yml`](.github/workflows/release.yml), which runs
-GoReleaser, uploads archives + checksums to GitHub Releases, and updates the
-`jjfantini/homebrew-humbl` tap.
+Releases follow the two-branch path in
+[`.github/workflows/release.yml`](.github/workflows/release.yml):
+
+- **`develop`** — release-please opens a pre-release PR. Merging it tags
+  `vX.Y.Z-pre.N` and publishes a GitHub **pre-release** (archives + checksums).
+  The Homebrew tap is left alone.
+- **`main`** — merge `develop` with a merge commit (never squash). release-please
+  opens a stable PR. Merging it tags `vX.Y.Z`, publishes the GitHub Release, and
+  GoReleaser updates the `jjfantini/homebrew-humbl` formula so
+  `brew upgrade humblskills` gets that version.
+
+Both release PRs auto-merge on green for same-major bumps. A major bump waits
+for a human.
 
 The same job also pushes a sibling `cli/vX.Y.Z` tag, which is what `go install`
 resolves against the nested module. Go's semantic import versioning requires the

--- a/cli/cmd/humblskills/profile.go
+++ b/cli/cmd/humblskills/profile.go
@@ -16,16 +16,19 @@ import (
 func newProfileCmd(app *App) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "profile",
-		Short: "View or edit your humblskills profile (default platforms + scope)",
-		Long: "profile edits the user profile that drives install defaults. " +
-			"Run bare for an interactive TUI editor, or use subcommands " +
-			"(`show`, `set`, `reset`, `path`) for scripting.",
+		Short: "View or edit your humblskills profile (defaults + CLI install channel)",
+		Long: "profile edits the user profile that drives install defaults and the " +
+			"CLI upgrade channel (stable vs beta). Run bare for an interactive TUI " +
+			"editor, or use subcommands (`show`, `get`, `set`, `reset`, `path`) " +
+			"for scripting. The TUI path is the same editor: `humblskills` → " +
+			"Profile, or `humblskills profile`.",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runProfileDefault(app)
 		},
 	}
 	cmd.AddCommand(
 		newProfileShowCmd(app),
+		newProfileGetCmd(app),
 		newProfileSetCmd(app),
 		newProfileResetCmd(app),
 		newProfilePathCmd(app),
@@ -43,12 +46,28 @@ func newProfileShowCmd(app *App) *cobra.Command {
 	}
 }
 
+func newProfileGetCmd(app *App) *cobra.Command {
+	return &cobra.Command{
+		Use:   "get [key]",
+		Short: "Print a profile value. Keys: platforms, scope, registry, status_auto_return_seconds, group_by_category, channel, path. No key prints the full profile.",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			key := ""
+			if len(args) == 1 {
+				key = args[0]
+			}
+			return runProfileGet(app, key)
+		},
+		ValidArgsFunction: cobra.FixedCompletions(profileValueKeys, cobra.ShellCompDirectiveNoFileComp),
+	}
+}
+
 func newProfileSetCmd(app *App) *cobra.Command {
 	return &cobra.Command{
 		Use: "set <key> <value>",
 		Short: "Set a profile value. Keys: platforms (csv), scope (global|user|project|adapter-default), " +
 			"registry (URL/file:// path, or \"\" to clear), status_auto_return_seconds (seconds, or default|off), " +
-			"group_by_category (on|off|default).",
+			"group_by_category (on|off|default), channel (stable|beta|default).",
 		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runProfileSet(app, args[0], args[1])
@@ -149,6 +168,8 @@ func runProfileShow(app *App) error {
 		th.KVValue.Render(formatAutoReturn(p.StatusAutoReturnSeconds)))
 	fmt.Fprintln(app.UI.Out(), "  "+th.KVKey.Render("group-by")+"     "+
 		th.KVValue.Render(formatGroupByCategory(p.GroupByCategory)))
+	fmt.Fprintln(app.UI.Out(), "  "+th.KVKey.Render("channel")+"      "+
+		th.KVValue.Render(formatChannel(p.Channel)))
 	fmt.Fprintln(app.UI.Out(), "  "+th.KVKey.Render("path")+"         "+
 		th.KVValue.Render(app.Config.ProfilePath))
 
@@ -160,6 +181,56 @@ func runProfileShow(app *App) error {
 		}
 	}
 	return nil
+}
+
+var profileValueKeys = []string{
+	"platforms",
+	"scope",
+	"registry",
+	"status_auto_return_seconds",
+	"group_by_category",
+	"channel",
+	"path",
+}
+
+func runProfileGet(app *App, key string) error {
+	if key == "" {
+		return runProfileShow(app)
+	}
+	p, err := profile.Load(app.Config.ProfilePath)
+	if err != nil {
+		return err
+	}
+	val, err := profileValue(p, key, app.Config.ProfilePath)
+	if err != nil {
+		return err
+	}
+	if app.Config.JSON {
+		return app.UI.JSON(map[string]string{"key": key, "value": val})
+	}
+	fmt.Fprintln(app.UI.Out(), val)
+	return nil
+}
+
+func profileValue(p *profile.Profile, key, path string) (string, error) {
+	switch key {
+	case "platforms":
+		return formatPlatforms(p.DefaultPlatforms), nil
+	case "scope":
+		return formatScope(p.DefaultScope), nil
+	case "registry":
+		return formatRegistry(p.Registry), nil
+	case "status_auto_return_seconds":
+		return formatAutoReturn(p.StatusAutoReturnSeconds), nil
+	case "group_by_category":
+		return formatGroupByCategory(p.GroupByCategory), nil
+	case "channel":
+		return p.ResolvedChannel(), nil
+	case "path":
+		return path, nil
+	default:
+		return "", fmt.Errorf("unknown key %q — valid keys: %s", key, strings.Join(profileValueKeys, ", "))
+	}
 }
 
 func runProfileSet(app *App, key, value string) error {
@@ -209,8 +280,14 @@ func runProfileSet(app *App, key, value string) error {
 			return err
 		}
 		p.GroupByCategory = flag
+	case "channel":
+		ch, err := parseChannel(value)
+		if err != nil {
+			return err
+		}
+		p.Channel = ch
 	default:
-		return fmt.Errorf("unknown key %q — valid keys: platforms, scope, registry, status_auto_return_seconds, group_by_category", key)
+		return fmt.Errorf("unknown key %q — valid keys: platforms, scope, registry, status_auto_return_seconds, group_by_category, channel", key)
 	}
 
 	if err := profile.Save(app.Config.ProfilePath, p); err != nil {
@@ -335,6 +412,33 @@ func formatGroupByCategory(flag *bool) string {
 		return "on"
 	default:
 		return "off"
+	}
+}
+
+// parseChannel parses `profile set channel`: "default"/"" resets to unset
+// (stable), "stable" stores the explicit stable value, "beta" follows
+// prereleases. Same field Homebrew and `upgrade --channel` read.
+func parseChannel(value string) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "default", "":
+		return "", nil
+	case profile.ChannelStable:
+		return profile.ChannelStable, nil
+	case profile.ChannelBeta:
+		return profile.ChannelBeta, nil
+	}
+	return "", fmt.Errorf("invalid channel %q — expected stable, beta, or default", value)
+}
+
+// formatChannel renders Profile.Channel for `profile show`.
+func formatChannel(channel string) string {
+	switch channel {
+	case "":
+		return "stable (default)"
+	case profile.ChannelBeta:
+		return profile.ChannelBeta
+	default:
+		return profile.ChannelStable
 	}
 }
 

--- a/cli/cmd/humblskills/profile_test.go
+++ b/cli/cmd/humblskills/profile_test.go
@@ -336,6 +336,95 @@ func TestFormatPlatforms(t *testing.T) {
 	}
 }
 
+func TestProfileSet_Channel(t *testing.T) {
+	s := testutil.NewSandbox(t)
+
+	res := runCLIWithStdoutCapture(t,
+		"profile", "set", "channel", "beta",
+		"--profile", s.ProfilePath,
+		"--json",
+	)
+	if res.RunErr != nil {
+		t.Fatalf("set beta: %v\n%s", res.RunErr, res.Err)
+	}
+	p, err := profile.Load(s.ProfilePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.Channel != profile.ChannelBeta {
+		t.Errorf("Channel = %q, want beta", p.Channel)
+	}
+
+	res = runCLIWithStdoutCapture(t,
+		"profile", "get", "channel",
+		"--profile", s.ProfilePath,
+	)
+	if res.RunErr != nil {
+		t.Fatalf("get: %v", res.RunErr)
+	}
+	if got := strings.TrimSpace(res.Out); got != profile.ChannelBeta {
+		t.Errorf("get channel = %q, want beta", got)
+	}
+
+	res = runCLIWithStdoutCapture(t,
+		"profile", "set", "channel", "default",
+		"--profile", s.ProfilePath,
+		"--json",
+	)
+	if res.RunErr != nil {
+		t.Fatalf("set default: %v", res.RunErr)
+	}
+	p, err = profile.Load(s.ProfilePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.Channel != "" {
+		t.Errorf("Channel = %q, want empty after default", p.Channel)
+	}
+	if p.ResolvedChannel() != profile.ChannelStable {
+		t.Errorf("ResolvedChannel = %q, want stable", p.ResolvedChannel())
+	}
+}
+
+func TestProfileGet_ChannelDefaultStable(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	res := runCLIWithStdoutCapture(t,
+		"profile", "get", "channel",
+		"--profile", s.ProfilePath,
+	)
+	if res.RunErr != nil {
+		t.Fatalf("get: %v", res.RunErr)
+	}
+	if got := strings.TrimSpace(res.Out); got != profile.ChannelStable {
+		t.Errorf("unset get channel = %q, want stable", got)
+	}
+}
+
+func TestProfileSet_ChannelInvalid(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	res := runCLIWithStdoutCapture(t,
+		"profile", "set", "channel", "nightly",
+		"--profile", s.ProfilePath,
+	)
+	if res.RunErr == nil {
+		t.Fatal("expected error for invalid channel")
+	}
+}
+
+func TestProfileShow_IncludesChannel(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	res := runCLIWithStdoutCapture(t,
+		"profile", "show",
+		"--profile", s.ProfilePath,
+	)
+	if res.RunErr != nil {
+		t.Fatalf("show: %v", res.RunErr)
+	}
+	if !strings.Contains(res.Out, "channel") || !strings.Contains(res.Out, "stable") {
+		t.Errorf("show should print channel (stable default), got:\n%s", res.Out)
+	}
+}
+
 func TestFormatScope(t *testing.T) {
 	if got := formatScope(""); got != "global humblskills (default)" {
 		t.Errorf("got %q", got)

--- a/cli/cmd/humblskills/upgrade.go
+++ b/cli/cmd/humblskills/upgrade.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/jjfantini/humblSKILLS/cli/v2/internal/profile"
 	"github.com/jjfantini/humblSKILLS/cli/v2/internal/selfupdate"
 	"github.com/jjfantini/humblSKILLS/cli/v2/internal/tui"
 )
@@ -41,7 +42,8 @@ var applyPhaseSteps = map[selfupdate.Phase]tui.UpgradeStep{
 }
 
 type upgradeFlags struct {
-	dryRun bool
+	dryRun  bool
+	channel string // one-shot override; empty means use the profile (default stable)
 }
 
 // upgradeResult is both the --json payload and the source of truth the
@@ -56,6 +58,8 @@ type upgradeResult struct {
 	Applied          bool   `json:"applied"`
 	Skipped          bool   `json:"skipped,omitempty"`
 	InstalledVersion string `json:"installedVersion,omitempty"`
+	Channel          string `json:"channel"`
+	Formula          string `json:"formula,omitempty"`
 }
 
 func newUpgradeCmd(app *App) *cobra.Command {
@@ -66,9 +70,12 @@ func newUpgradeCmd(app *App) *cobra.Command {
 		Long: "upgrade checks GitHub releases for a newer humblskills CLI build, " +
 			"downloads it, verifies its checksum, and swaps it onto the running " +
 			"binary's path. Installs managed by Homebrew are upgraded via " +
-			"`brew upgrade humblskills` instead, so Homebrew's own bookkeeping " +
-			"stays correct. --dry-run reports the version you'd upgrade to " +
-			"without changing anything.\n\n" +
+			"`brew upgrade <formula>` instead, so Homebrew's own bookkeeping " +
+			"stays correct. The formula and GitHub endpoint come from the " +
+			"profile channel (stable by default): stable → /releases/latest + " +
+			"`humblskills`; beta → latest prerelease + `humblskills-pre`. " +
+			"--channel overrides the profile for this run only. --dry-run " +
+			"reports the version you'd upgrade to without changing anything.\n\n" +
 			"This upgrades the CLI binary itself. To upgrade installed skills, " +
 			"use `humblskills update`.",
 		Args: cobra.NoArgs,
@@ -77,6 +84,8 @@ func newUpgradeCmd(app *App) *cobra.Command {
 		},
 	}
 	cmd.Flags().BoolVar(&f.dryRun, "dry-run", false, "show the version you'd upgrade to without changing anything")
+	cmd.Flags().StringVar(&f.channel, "channel", "", "release channel for this run: stable|beta (default: profile channel, itself stable unless set)")
+	_ = cmd.RegisterFlagCompletionFunc("channel", cobra.FixedCompletions([]string{profile.ChannelStable, profile.ChannelBeta}, cobra.ShellCompDirectiveNoFileComp))
 	return cmd
 }
 
@@ -87,12 +96,17 @@ func runUpgrade(app *App, f upgradeFlags) error {
 		return fmt.Errorf("resolve own executable path: %w", err)
 	}
 
+	channel, err := resolveUpgradeChannel(app, f.channel)
+	if err != nil {
+		return err
+	}
+
 	client := selfupdate.NewHTTPClient()
 	th := app.UI.Theme()
 
 	var plan *selfupdate.Plan
 	resolveErr := tui.RunWithSpinner(th, "checking latest release…", func() error {
-		p, err := selfupdate.ResolvePlan(client, selfupdate.DefaultRepo, current, exePath, nil)
+		p, err := selfupdate.ResolvePlanForChannel(client, selfupdate.DefaultRepo, current, exePath, channel, nil)
 		plan = p
 		return err
 	})
@@ -106,6 +120,8 @@ func runUpgrade(app *App, f upgradeFlags) error {
 		UpgradeAvailable: plan.UpgradeAvailable,
 		Homebrew:         plan.Homebrew,
 		DryRun:           f.dryRun,
+		Channel:          plan.Channel,
+		Formula:          plan.Formula,
 	}
 
 	if !plan.UpgradeAvailable || f.dryRun {
@@ -147,7 +163,7 @@ func finishUpgrade(app *App, res upgradeResult) error {
 	case !res.UpgradeAvailable:
 		app.UI.Success("humblskills is already up to date (%s)", versionTag(res.CurrentVersion))
 	case res.DryRun && res.Homebrew:
-		app.UI.Info("%s → %s available — Homebrew-managed install detected; would run `brew upgrade humblskills`", versionTag(res.CurrentVersion), versionTag(res.LatestVersion))
+		app.UI.Info("%s → %s available — Homebrew-managed install detected; would run `brew upgrade %s`", versionTag(res.CurrentVersion), versionTag(res.LatestVersion), brewFormula(res))
 	case res.DryRun:
 		app.UI.Info("%s → %s available — run without --dry-run to upgrade", versionTag(res.CurrentVersion), versionTag(res.LatestVersion))
 	}
@@ -167,10 +183,35 @@ func versionTag(v string) string {
 // applyHomebrewUpgrade defers to `brew upgrade humblskills` instead of
 // self-downloading/swapping, so Homebrew's own Cellar bookkeeping stays
 // correct. Returns the verified installed version on success.
-func applyHomebrewUpgrade(app *App, plan *selfupdate.Plan, exePath string) (string, error) {
-	app.UI.Info("Homebrew-managed install detected — upgrading via `brew upgrade humblskills`")
+func brewFormula(res upgradeResult) string {
+	if res.Formula != "" {
+		return res.Formula
+	}
+	return selfupdate.FormulaForChannel(res.Channel)
+}
 
-	ok, err := app.Prompt.Confirm("Run brew upgrade humblskills now?", true)
+func resolveUpgradeChannel(app *App, flag string) (string, error) {
+	if flag != "" {
+		if flag != profile.ChannelStable && flag != profile.ChannelBeta {
+			return "", fmt.Errorf("invalid --channel %q — valid: stable, beta", flag)
+		}
+		return flag, nil
+	}
+	p, err := profile.Load(app.Config.ProfilePath)
+	if err != nil {
+		return "", fmt.Errorf("load profile: %w", err)
+	}
+	return p.ResolvedChannel(), nil
+}
+
+func applyHomebrewUpgrade(app *App, plan *selfupdate.Plan, exePath string) (string, error) {
+	formula := plan.Formula
+	if formula == "" {
+		formula = selfupdate.FormulaForChannel(plan.Channel)
+	}
+	app.UI.Info("Homebrew-managed install detected — upgrading via `brew upgrade %s`", formula)
+
+	ok, err := app.Prompt.Confirm(fmt.Sprintf("Run brew upgrade %s now?", formula), true)
 	if err != nil {
 		return "", err
 	}
@@ -193,11 +234,11 @@ func applyHomebrewUpgrade(app *App, plan *selfupdate.Plan, exePath string) (stri
 				sink(tui.UpgradeEvent{Step: step})
 			}
 		}
-		if err := selfupdate.Upgrade(context.Background(), brewRunner, stdout, stderr, brewSink); err != nil {
+		if err := selfupdate.Upgrade(context.Background(), brewRunner, stdout, stderr, brewSink, formula); err != nil {
 			if errors.Is(err, selfupdate.ErrBrewNotFound) {
-				return fmt.Errorf("brew not found on PATH — run `brew update && brew upgrade humblskills` yourself: %w", err)
+				return fmt.Errorf("brew not found on PATH — run `brew update && brew upgrade %s` yourself: %w", formula, err)
 			}
-			return fmt.Errorf("brew upgrade humblskills: %w", err)
+			return fmt.Errorf("brew upgrade %s: %w", formula, err)
 		}
 
 		sink(tui.UpgradeEvent{Step: tui.UpgradeStepVerifyingInstall})

--- a/cli/cmd/humblskills/upgrade_test.go
+++ b/cli/cmd/humblskills/upgrade_test.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/jjfantini/humblSKILLS/cli/v2/internal/profile"
 	"github.com/jjfantini/humblSKILLS/cli/v2/internal/selfupdate"
 	"github.com/jjfantini/humblSKILLS/cli/v2/internal/testutil"
 )
@@ -337,5 +338,205 @@ func TestUpgrade_HomebrewDryRun_DoesNotInvokeBrew(t *testing.T) {
 	}
 	if got.Applied {
 		t.Error("expected Applied = false for --dry-run")
+	}
+	if got.Channel != profile.ChannelStable {
+		t.Errorf("Channel = %q, want stable (unset profile default)", got.Channel)
+	}
+}
+
+func startFakePrereleaseAPI(t *testing.T, preVersion, binaryContent string) {
+	t.Helper()
+	assetName, err := selfupdate.CurrentAssetName(preVersion)
+	if err != nil {
+		t.Fatalf("CurrentAssetName: %v", err)
+	}
+	binName := selfupdate.BinaryName(runtime.GOOS)
+	archivePath := buildFakeTarGz(t, binName, binaryContent)
+	archiveBytes, err := os.ReadFile(archivePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sum := sha256Hex(t, archivePath)
+	checksums := sum + "  " + assetName + "\n"
+
+	var srv *httptest.Server
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/"+selfupdate.DefaultRepo+"/releases/latest", func(w http.ResponseWriter, r *http.Request) {
+		t.Error("beta channel must not hit /releases/latest")
+		w.WriteHeader(http.StatusNotFound)
+	})
+	mux.HandleFunc("/repos/"+selfupdate.DefaultRepo+"/releases", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[
+			{
+				"tag_name": "v` + preVersion + `",
+				"prerelease": true,
+				"draft": false,
+				"assets": [
+					{"name": "` + assetName + `", "browser_download_url": "` + srv.URL + `/assets/` + assetName + `"},
+					{"name": "checksums.txt", "browser_download_url": "` + srv.URL + `/assets/checksums.txt"}
+				]
+			}
+		]`))
+	})
+	mux.HandleFunc("/assets/"+assetName, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(archiveBytes)
+	})
+	mux.HandleFunc("/assets/checksums.txt", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(checksums))
+	})
+	srv = httptest.NewServer(mux)
+
+	prev := selfupdate.GitHubAPIBase
+	selfupdate.GitHubAPIBase = srv.URL
+	t.Cleanup(func() {
+		srv.Close()
+		selfupdate.GitHubAPIBase = prev
+	})
+}
+
+func TestUpgrade_ChannelFlag_BetaHitsPrerelease(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	startFakePrereleaseAPI(t, "99.0.0-pre.1", "fake pre binary")
+
+	res := runCLIWithStdoutCapture(t,
+		"upgrade", "--dry-run", "--yes", "--json",
+		"--channel", "beta",
+		"--profile", s.ProfilePath,
+	)
+	if res.RunErr != nil {
+		t.Fatalf("run: %v\nerr: %s", res.RunErr, res.Err)
+	}
+
+	var got upgradeResult
+	if err := json.Unmarshal([]byte(strings.TrimSpace(res.Out)), &got); err != nil {
+		t.Fatalf("unmarshal %q: %v", res.Out, err)
+	}
+	if got.Channel != profile.ChannelBeta {
+		t.Errorf("Channel = %q, want beta", got.Channel)
+	}
+	if got.LatestVersion != "99.0.0-pre.1" {
+		t.Errorf("LatestVersion = %q, want 99.0.0-pre.1", got.LatestVersion)
+	}
+	if !got.UpgradeAvailable {
+		t.Error("expected UpgradeAvailable = true")
+	}
+}
+
+func TestUpgrade_ProfileChannel_BetaDefault(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	if err := profile.Save(s.ProfilePath, &profile.Profile{Channel: profile.ChannelBeta}); err != nil {
+		t.Fatal(err)
+	}
+	startFakePrereleaseAPI(t, "99.0.0-pre.1", "fake pre binary")
+
+	res := runCLIWithStdoutCapture(t,
+		"upgrade", "--dry-run", "--yes", "--json",
+		"--profile", s.ProfilePath,
+	)
+	if res.RunErr != nil {
+		t.Fatalf("run: %v\nerr: %s", res.RunErr, res.Err)
+	}
+
+	var got upgradeResult
+	if err := json.Unmarshal([]byte(strings.TrimSpace(res.Out)), &got); err != nil {
+		t.Fatalf("unmarshal %q: %v", res.Out, err)
+	}
+	if got.Channel != profile.ChannelBeta {
+		t.Errorf("Channel = %q, want beta (from profile)", got.Channel)
+	}
+	if got.LatestVersion != "99.0.0-pre.1" {
+		t.Errorf("LatestVersion = %q, want 99.0.0-pre.1", got.LatestVersion)
+	}
+}
+
+func TestUpgrade_ChannelFlag_OverridesProfile(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	if err := profile.Save(s.ProfilePath, &profile.Profile{Channel: profile.ChannelBeta}); err != nil {
+		t.Fatal(err)
+	}
+	startFakeReleaseAPI(t, "99.0.0", "fake stable")
+
+	res := runCLIWithStdoutCapture(t,
+		"upgrade", "--dry-run", "--yes", "--json",
+		"--channel", "stable",
+		"--profile", s.ProfilePath,
+	)
+	if res.RunErr != nil {
+		t.Fatalf("run: %v\nerr: %s", res.RunErr, res.Err)
+	}
+
+	var got upgradeResult
+	if err := json.Unmarshal([]byte(strings.TrimSpace(res.Out)), &got); err != nil {
+		t.Fatalf("unmarshal %q: %v", res.Out, err)
+	}
+	if got.Channel != profile.ChannelStable {
+		t.Errorf("Channel = %q, want stable (flag overrides profile)", got.Channel)
+	}
+	if got.LatestVersion != "99.0.0" {
+		t.Errorf("LatestVersion = %q, want 99.0.0", got.LatestVersion)
+	}
+}
+
+func TestUpgrade_ChannelFlag_Invalid(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	res := runCLIWithStdoutCapture(t,
+		"upgrade", "--dry-run", "--yes", "--json",
+		"--channel", "nightly",
+		"--profile", s.ProfilePath,
+	)
+	if res.RunErr == nil {
+		t.Fatal("expected error for invalid --channel")
+	}
+}
+
+func TestUpgrade_HomebrewManaged_BetaRunsPreFormula(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	const latest = "99.0.0-pre.1"
+
+	cellarDir := filepath.Join(s.Root, "Cellar", "humblskills-pre", latest, "bin")
+	if err := os.MkdirAll(cellarDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	exePath := filepath.Join(cellarDir, "humblskills")
+	fakeVersionScript(t, exePath, latest)
+	withFakeExecutable(t, exePath)
+	startFakePrereleaseAPI(t, latest, "irrelevant")
+
+	var invocations [][]string
+	prevRunner := brewRunner
+	brewRunner = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		invocations = append(invocations, append([]string{}, args...))
+		return exec.CommandContext(ctx, "true")
+	}
+	t.Cleanup(func() { brewRunner = prevRunner })
+
+	res := runCLIWithStdoutCapture(t,
+		"upgrade", "--yes", "--json",
+		"--channel", "beta",
+		"--profile", s.ProfilePath,
+	)
+	if res.RunErr != nil {
+		t.Fatalf("run: %v\nerr: %s", res.RunErr, res.Err)
+	}
+	if len(invocations) != 2 {
+		t.Fatalf("brew invocations = %v, want 2 calls", invocations)
+	}
+	if len(invocations[1]) != 2 || invocations[1][0] != "upgrade" || invocations[1][1] != selfupdate.FormulaPre {
+		t.Errorf("second brew call = %v, want [upgrade %s]", invocations[1], selfupdate.FormulaPre)
+	}
+
+	var got upgradeResult
+	if err := json.Unmarshal([]byte(strings.TrimSpace(res.Out)), &got); err != nil {
+		t.Fatalf("unmarshal %q: %v", res.Out, err)
+	}
+	if got.Channel != profile.ChannelBeta {
+		t.Errorf("Channel = %q, want beta", got.Channel)
+	}
+	if got.Formula != selfupdate.FormulaPre {
+		t.Errorf("Formula = %q, want %s", got.Formula, selfupdate.FormulaPre)
+	}
+	if !got.Applied {
+		t.Errorf("expected Applied = true, got %+v", got)
 	}
 }

--- a/cli/internal/profile/profile.go
+++ b/cli/internal/profile/profile.go
@@ -36,6 +36,13 @@ const (
 // auto-returning to the dashboard when StatusAutoReturnSeconds is unset.
 const DefaultStatusAutoReturnSeconds = 5
 
+// CLI upgrade channels stored in Profile.Channel. Empty is treated as
+// ChannelStable so existing profile.json files stay on the real version.
+const (
+	ChannelStable = "stable"
+	ChannelBeta   = "beta"
+)
+
 // Profile is the full on-disk document.
 type Profile struct {
 	SchemaVersion    int      `json:"schema_version"`
@@ -65,6 +72,12 @@ type Profile struct {
 	// recommended default. Explicit false restores the legacy flat
 	// registry→role→skills layout.
 	GroupByCategory *bool `json:"group_by_category,omitempty"`
+
+	// Channel selects which CLI release stream `humblskills upgrade` follows.
+	// Empty (unset) and "stable" both mean GitHub /releases/latest and the
+	// `humblskills` brew formula. "beta" means the latest GitHub prerelease
+	// and the `humblskills-pre` formula. Default MUST stay stable.
+	Channel string `json:"channel,omitempty"`
 }
 
 // NamedRegistry is one entry in the multi-registry set (Profile.Registries).
@@ -304,4 +317,24 @@ func (p *Profile) ResolvedGroupByCategory() bool {
 		return true
 	}
 	return *p.GroupByCategory
+}
+
+// IsValidChannel reports whether s is an accepted channel value. "" is
+// accepted as shorthand for the unset/default state — see ResolvedChannel.
+func IsValidChannel(s string) bool {
+	switch s {
+	case "", ChannelStable, ChannelBeta:
+		return true
+	}
+	return false
+}
+
+// ResolvedChannel returns the profile's effective CLI upgrade channel.
+// Unset/empty means ChannelStable — existing profiles and new installs
+// stay on the real version unless the user opts into beta.
+func (p *Profile) ResolvedChannel() string {
+	if p == nil || p.Channel == "" {
+		return ChannelStable
+	}
+	return p.Channel
 }

--- a/cli/internal/profile/profile_test.go
+++ b/cli/internal/profile/profile_test.go
@@ -374,6 +374,40 @@ func TestResolvedGroupByCategory(t *testing.T) {
 	}
 }
 
+func TestResolvedChannel(t *testing.T) {
+	cases := []struct {
+		name string
+		p    *profile.Profile
+		want string
+	}{
+		{"nil profile defaults to stable", nil, profile.ChannelStable},
+		{"unset defaults to stable", &profile.Profile{}, profile.ChannelStable},
+		{"explicit stable", &profile.Profile{Channel: profile.ChannelStable}, profile.ChannelStable},
+		{"explicit beta", &profile.Profile{Channel: profile.ChannelBeta}, profile.ChannelBeta},
+	}
+	for _, c := range cases {
+		if got := c.p.ResolvedChannel(); got != c.want {
+			t.Errorf("%s: ResolvedChannel() = %q, want %q", c.name, got, c.want)
+		}
+	}
+}
+
+func TestIsValidChannel(t *testing.T) {
+	cases := map[string]bool{
+		"":       true,
+		"stable": true,
+		"beta":   true,
+		"BETA":   false,
+		"pre":    false,
+		" nightly": false,
+	}
+	for in, want := range cases {
+		if got := profile.IsValidChannel(in); got != want {
+			t.Errorf("IsValidChannel(%q) = %v, want %v", in, got, want)
+		}
+	}
+}
+
 func TestResolvedScope(t *testing.T) {
 	cases := []struct {
 		name string

--- a/cli/internal/selfupdate/homebrew.go
+++ b/cli/internal/selfupdate/homebrew.go
@@ -14,6 +14,24 @@ import (
 // detected but the brew binary itself isn't on PATH.
 var ErrBrewNotFound = errors.New("brew not found on PATH")
 
+// Homebrew formula names in jjfantini/homebrew-humbl. `humblskills@beta` is
+// illegal (Homebrew only maps `@` + digits to a Ruby class). The pre
+// formula is therefore `humblskills-pre`.
+const (
+	FormulaStable = "humblskills"
+	FormulaPre    = "humblskills-pre"
+)
+
+// FormulaForChannel returns the tap formula `brew upgrade` should run for
+// the given profile channel. Unknown/empty → stable, so users who never
+// set a channel keep today's behaviour.
+func FormulaForChannel(channel string) string {
+	if NormalizeChannel(channel) == ChannelBeta {
+		return FormulaPre
+	}
+	return FormulaStable
+}
+
 // IsHomebrewManaged reports whether exePath resolves (after following
 // symlinks, the way Homebrew's opt/Cellar layout works) into a Homebrew
 // Cellar or Caskroom — the canonical signal that this install is managed by
@@ -33,9 +51,10 @@ func IsHomebrewManaged(exePath string) bool {
 type Runner func(ctx context.Context, name string, args ...string) *exec.Cmd
 
 // Upgrade refreshes Homebrew's local tap metadata (`brew update`) and then
-// runs `brew upgrade humblskills`, streaming both commands' own output to
+// runs `brew upgrade <formula>`, streaming both commands' own output to
 // stdout/stderr live so the user sees Homebrew's real progress instead of a
-// reimplementation of it. run defaults to exec.CommandContext when nil.
+// reimplementation of it. formula defaults to FormulaStable when empty.
+// run defaults to exec.CommandContext when nil.
 //
 // The `brew update` step exists because Homebrew throttles its own
 // opportunistic tap refresh (HOMEBREW_AUTO_UPDATE_SECS, 24h by default) —
@@ -45,9 +64,12 @@ type Runner func(ctx context.Context, name string, args ...string) *exec.Cmd
 // treated as fatal on its own: `brew upgrade` still runs, and the caller's
 // own post-upgrade version check (VerifyInstalledVersion) is what actually
 // decides whether the upgrade succeeded.
-func Upgrade(ctx context.Context, run Runner, stdout, stderr io.Writer, sink EventSink) error {
+func Upgrade(ctx context.Context, run Runner, stdout, stderr io.Writer, sink EventSink, formula string) error {
 	if run == nil {
 		run = exec.CommandContext
+	}
+	if formula == "" {
+		formula = FormulaStable
 	}
 
 	sink.emit(Event{Phase: PhaseBrewUpdating})
@@ -60,7 +82,7 @@ func Upgrade(ctx context.Context, run Runner, stdout, stderr io.Writer, sink Eve
 	}
 
 	sink.emit(Event{Phase: PhaseBrewUpgrading})
-	if err := runBrew(ctx, run, stdout, stderr, "upgrade", "humblskills"); err != nil {
+	if err := runBrew(ctx, run, stdout, stderr, "upgrade", formula); err != nil {
 		sink.emit(Event{Phase: PhaseError, Err: err})
 		return err
 	}

--- a/cli/internal/selfupdate/homebrew_test.go
+++ b/cli/internal/selfupdate/homebrew_test.go
@@ -55,7 +55,7 @@ func TestUpgrade_RunsBrewUpdateBeforeUpgrade(t *testing.T) {
 	runner := stubBrewRunner(t, &invocations, true)
 
 	var stdout, stderr bytes.Buffer
-	if err := Upgrade(context.Background(), runner, &stdout, &stderr, nil); err != nil {
+	if err := Upgrade(context.Background(), runner, &stdout, &stderr, nil, ""); err != nil {
 		t.Fatalf("Upgrade: %v", err)
 	}
 
@@ -90,7 +90,7 @@ func TestUpgrade_BrewUpdateFailureDoesNotBlockUpgrade(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	if err := Upgrade(context.Background(), runner, &stdout, &stderr, nil); err != nil {
+	if err := Upgrade(context.Background(), runner, &stdout, &stderr, nil, ""); err != nil {
 		t.Fatalf("Upgrade should not fail when only brew update fails: %v", err)
 	}
 	if len(invocations) != 2 {
@@ -108,7 +108,7 @@ func TestUpgrade_EmitsBrewUpdatingThenBrewUpgradingPhases(t *testing.T) {
 	var phases []Phase
 	sink := EventSink(func(ev Event) { phases = append(phases, ev.Phase) })
 
-	if err := Upgrade(context.Background(), runner, &bytes.Buffer{}, &bytes.Buffer{}, sink); err != nil {
+	if err := Upgrade(context.Background(), runner, &bytes.Buffer{}, &bytes.Buffer{}, sink, ""); err != nil {
 		t.Fatalf("Upgrade: %v", err)
 	}
 	if len(phases) != 2 || phases[0] != PhaseBrewUpdating || phases[1] != PhaseBrewUpgrading {
@@ -125,9 +125,40 @@ func TestUpgrade_BrewNotFound(t *testing.T) {
 		return exec.CommandContext(ctx, "definitely-not-a-real-binary-xyz")
 	}
 
-	err := Upgrade(context.Background(), runner, &bytes.Buffer{}, &bytes.Buffer{}, nil)
+	err := Upgrade(context.Background(), runner, &bytes.Buffer{}, &bytes.Buffer{}, nil, "")
 	if !errors.Is(err, ErrBrewNotFound) {
 		t.Errorf("expected ErrBrewNotFound, got %v", err)
+	}
+}
+
+func TestFormulaForChannel(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"", FormulaStable},
+		{"stable", FormulaStable},
+		{"nightly", FormulaStable},
+		{"beta", FormulaPre},
+	}
+	for _, c := range cases {
+		if got := FormulaForChannel(c.in); got != c.want {
+			t.Errorf("FormulaForChannel(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestUpgrade_UsesGivenFormula(t *testing.T) {
+	var invocations [][]string
+	runner := stubBrewRunner(t, &invocations, true)
+
+	if err := Upgrade(context.Background(), runner, &bytes.Buffer{}, &bytes.Buffer{}, nil, FormulaPre); err != nil {
+		t.Fatalf("Upgrade: %v", err)
+	}
+	if len(invocations) != 2 {
+		t.Fatalf("invocations = %v, want 2 calls", invocations)
+	}
+	if len(invocations[1]) != 2 || invocations[1][0] != "upgrade" || invocations[1][1] != FormulaPre {
+		t.Errorf("second call = %v, want [upgrade %s]", invocations[1], FormulaPre)
 	}
 }
 
@@ -141,7 +172,7 @@ func TestUpgrade_NonZeroExit(t *testing.T) {
 
 	// Both brew update and brew upgrade fail here, so the overall call must
 	// still surface the (second, fatal) failure.
-	err := Upgrade(context.Background(), runner, &bytes.Buffer{}, &bytes.Buffer{}, nil)
+	err := Upgrade(context.Background(), runner, &bytes.Buffer{}, &bytes.Buffer{}, nil, "")
 	if err == nil {
 		t.Fatal("expected error for non-zero brew exit code")
 	}

--- a/cli/internal/selfupdate/release.go
+++ b/cli/internal/selfupdate/release.go
@@ -44,8 +44,26 @@ type Asset struct {
 // Release is the subset of the GitHub releases API response selfupdate
 // needs.
 type Release struct {
-	TagName string  `json:"tag_name"`
-	Assets  []Asset `json:"assets"`
+	TagName    string  `json:"tag_name"`
+	Draft      bool    `json:"draft"`
+	Prerelease bool    `json:"prerelease"`
+	Assets     []Asset `json:"assets"`
+}
+
+// ChannelStable / ChannelBeta match profile.Channel. Declared here so this
+// package does not import profile (selfupdate is about binaries, not prefs).
+const (
+	ChannelStable = "stable"
+	ChannelBeta   = "beta"
+)
+
+// NormalizeChannel maps empty/unknown values to ChannelStable so a missing
+// profile field never opts a user into prereleases.
+func NormalizeChannel(channel string) string {
+	if channel == ChannelBeta {
+		return ChannelBeta
+	}
+	return ChannelStable
 }
 
 // Version returns the release's bare semver version, stripping the leading
@@ -75,13 +93,72 @@ func NewHTTPClient() *http.Client {
 	return &http.Client{Timeout: DefaultHTTPTimeout}
 }
 
-// LatestRelease fetches https://api.github.com/repos/{repo}/releases/latest.
-// client defaults to NewHTTPClient() when nil.
+// LatestRelease fetches https://api.github.com/repos/{repo}/releases/latest
+// (GitHub's latest non-prerelease). client defaults to NewHTTPClient() when nil.
 func LatestRelease(client *http.Client, repo string) (*Release, error) {
+	return fetchRelease(client, fmt.Sprintf("%s/repos/%s/releases/latest", GitHubAPIBase, repo))
+}
+
+// LatestReleaseForChannel returns the latest stable GitHub release, or the
+// latest prerelease when channel is beta.
+func LatestReleaseForChannel(client *http.Client, repo, channel string) (*Release, error) {
+	if NormalizeChannel(channel) == ChannelBeta {
+		return latestPrerelease(client, repo)
+	}
+	return LatestRelease(client, repo)
+}
+
+func latestPrerelease(client *http.Client, repo string) (*Release, error) {
 	if client == nil {
 		client = NewHTTPClient()
 	}
-	url := fmt.Sprintf("%s/repos/%s/releases/latest", GitHubAPIBase, repo)
+	url := fmt.Sprintf("%s/repos/%s/releases?per_page=40", GitHubAPIBase, repo)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("User-Agent", userAgent)
+	req.Header.Set("Accept", "application/vnd.github+json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetch %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("fetch %s: HTTP %d", url, resp.StatusCode)
+	}
+
+	var rels []Release
+	if err := json.NewDecoder(resp.Body).Decode(&rels); err != nil {
+		return nil, fmt.Errorf("decode releases: %w", err)
+	}
+	for i := range rels {
+		r := &rels[i]
+		if r.Draft || r.TagName == "" {
+			continue
+		}
+		if r.Prerelease || isPreTag(r.TagName) {
+			return r, nil
+		}
+	}
+	return nil, fmt.Errorf("fetch %s: no prerelease found", url)
+}
+
+func isPreTag(tag string) bool {
+	// release-please prerelease-type "pre" → vX.Y.Z-pre or vX.Y.Z-pre.N
+	for i := 0; i < len(tag); i++ {
+		if tag[i] == '-' {
+			return true
+		}
+	}
+	return false
+}
+
+func fetchRelease(client *http.Client, url string) (*Release, error) {
+	if client == nil {
+		client = NewHTTPClient()
+	}
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return nil, fmt.Errorf("build request: %w", err)

--- a/cli/internal/selfupdate/release_test.go
+++ b/cli/internal/selfupdate/release_test.go
@@ -72,3 +72,82 @@ func TestLatestRelease_MissingTagName(t *testing.T) {
 		t.Error("expected error for missing tag_name, got nil")
 	}
 }
+
+func TestNormalizeChannel(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"", ChannelStable},
+		{"stable", ChannelStable},
+		{"nightly", ChannelStable},
+		{"beta", ChannelBeta},
+	}
+	for _, c := range cases {
+		if got := NormalizeChannel(c.in); got != c.want {
+			t.Errorf("NormalizeChannel(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestLatestReleaseForChannel_StableHitsLatest(t *testing.T) {
+	srv := withFakeGitHubAPI(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/repos/jjfantini/humblSKILLS/releases/latest" {
+			t.Errorf("stable channel should hit /releases/latest, got %s", r.URL.Path)
+		}
+		_, _ = w.Write([]byte(`{"tag_name": "v2.51.0", "prerelease": false}`))
+	}))
+	rel, err := LatestReleaseForChannel(srv.Client(), DefaultRepo, ChannelStable)
+	if err != nil {
+		t.Fatalf("LatestReleaseForChannel: %v", err)
+	}
+	if rel.TagName != "v2.51.0" {
+		t.Errorf("TagName = %q, want v2.51.0", rel.TagName)
+	}
+}
+
+func TestLatestReleaseForChannel_BetaSkipsStableAndDrafts(t *testing.T) {
+	srv := withFakeGitHubAPI(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/repos/jjfantini/humblSKILLS/releases" {
+			t.Errorf("beta channel should hit /releases, got %s", r.URL.Path)
+		}
+		_, _ = w.Write([]byte(`[
+			{"tag_name": "v2.52.0", "prerelease": false, "draft": false},
+			{"tag_name": "v2.52.0-pre.2", "prerelease": true, "draft": true},
+			{"tag_name": "v2.52.0-pre.1", "prerelease": true, "draft": false}
+		]`))
+	}))
+	rel, err := LatestReleaseForChannel(srv.Client(), DefaultRepo, ChannelBeta)
+	if err != nil {
+		t.Fatalf("LatestReleaseForChannel: %v", err)
+	}
+	if rel.TagName != "v2.52.0-pre.1" {
+		t.Errorf("TagName = %q, want v2.52.0-pre.1 (skip stable + draft pre)", rel.TagName)
+	}
+}
+
+func TestLatestReleaseForChannel_BetaPicksPreTagWithoutFlag(t *testing.T) {
+	srv := withFakeGitHubAPI(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`[
+			{"tag_name": "v2.51.0", "prerelease": false},
+			{"tag_name": "v2.52.0-pre.1", "prerelease": false}
+		]`))
+	}))
+	rel, err := LatestReleaseForChannel(srv.Client(), DefaultRepo, "beta")
+	if err != nil {
+		t.Fatalf("LatestReleaseForChannel: %v", err)
+	}
+	if rel.TagName != "v2.52.0-pre.1" {
+		t.Errorf("TagName = %q, want v2.52.0-pre.1 (dash in tag)", rel.TagName)
+	}
+}
+
+func TestLatestReleaseForChannel_BetaNoPrerelease(t *testing.T) {
+	srv := withFakeGitHubAPI(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`[
+			{"tag_name": "v2.51.0", "prerelease": false, "draft": false}
+		]`))
+	}))
+	if _, err := LatestReleaseForChannel(srv.Client(), DefaultRepo, ChannelBeta); err == nil {
+		t.Error("expected error when no prerelease exists")
+	}
+}

--- a/cli/internal/selfupdate/run.go
+++ b/cli/internal/selfupdate/run.go
@@ -55,32 +55,46 @@ type Plan struct {
 	LatestTag        string // as published, e.g. "v2.17.0"
 	UpgradeAvailable bool
 	Homebrew         bool
+	Channel          string
+	Formula          string // brew formula when Homebrew; empty otherwise
 	AssetName        string
 	AssetURL         string
 	ChecksumsURL     string
 }
 
-// ResolvePlan fetches the latest release and decides whether an upgrade is
-// available and how it would be applied, without downloading or changing
-// anything. client/repo default to NewHTTPClient()/DefaultRepo when zero.
+// ResolvePlan fetches the latest *stable* release and decides whether an
+// upgrade is available. Equivalent to ResolvePlanForChannel(..., ChannelStable).
 func ResolvePlan(client *http.Client, repo, currentVersion, exePath string, sink EventSink) (*Plan, error) {
+	return ResolvePlanForChannel(client, repo, currentVersion, exePath, ChannelStable, sink)
+}
+
+// ResolvePlanForChannel is ResolvePlan using channel to pick GitHub
+// /releases/latest (stable) or the newest prerelease (beta), and the
+// matching brew formula.
+func ResolvePlanForChannel(client *http.Client, repo, currentVersion, exePath, channel string, sink EventSink) (*Plan, error) {
 	if repo == "" {
 		repo = DefaultRepo
 	}
+	channel = NormalizeChannel(channel)
 	sink.emit(Event{Phase: PhaseCheckingLatest})
-	rel, err := LatestRelease(client, repo)
+	rel, err := LatestReleaseForChannel(client, repo, channel)
 	if err != nil {
 		sink.emit(Event{Phase: PhaseError, Err: err})
 		return nil, err
 	}
 
 	latest := rel.Version()
+	homebrew := IsHomebrewManaged(exePath)
 	plan := &Plan{
 		CurrentVersion:   currentVersion,
 		LatestVersion:    latest,
 		LatestTag:        rel.TagName,
 		UpgradeAvailable: IsUpgradeAvailable(currentVersion, latest),
-		Homebrew:         IsHomebrewManaged(exePath),
+		Homebrew:         homebrew,
+		Channel:          channel,
+	}
+	if homebrew {
+		plan.Formula = FormulaForChannel(channel)
 	}
 	if !plan.UpgradeAvailable {
 		return plan, nil

--- a/cli/internal/selfupdate/run_test.go
+++ b/cli/internal/selfupdate/run_test.go
@@ -131,6 +131,64 @@ func TestResolvePlan_HomebrewDetected(t *testing.T) {
 	if !plan.Homebrew {
 		t.Error("expected Homebrew = true for a Cellar path")
 	}
+	if plan.Channel != ChannelStable {
+		t.Errorf("Channel = %q, want %s", plan.Channel, ChannelStable)
+	}
+	if plan.Formula != FormulaStable {
+		t.Errorf("Formula = %q, want %s", plan.Formula, FormulaStable)
+	}
+}
+
+func TestResolvePlanForChannel_BetaUsesPrereleaseAndPreFormula(t *testing.T) {
+	const pre = "2.52.0-pre.1"
+	assetName, err := CurrentAssetName(pre)
+	if err != nil {
+		t.Fatalf("CurrentAssetName: %v", err)
+	}
+
+	var srv *httptest.Server
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/jjfantini/humblSKILLS/releases/latest", func(w http.ResponseWriter, r *http.Request) {
+		t.Error("beta channel must not hit /releases/latest")
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	mux.HandleFunc("/repos/jjfantini/humblSKILLS/releases", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[
+			{"tag_name": "v` + pre + `", "prerelease": true, "draft": false,
+			 "assets": [
+			   {"name": "` + assetName + `", "browser_download_url": "http://example.invalid/a"},
+			   {"name": "checksums.txt", "browser_download_url": "http://example.invalid/c"}
+			 ]}
+		]`))
+	})
+	srv = httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	prev := GitHubAPIBase
+	GitHubAPIBase = srv.URL
+	t.Cleanup(func() { GitHubAPIBase = prev })
+
+	plan, err := ResolvePlanForChannel(srv.Client(), DefaultRepo, "2.51.0",
+		"/opt/homebrew/Cellar/humblskills-pre/2.51.0/bin/humblskills", ChannelBeta, nil)
+	if err != nil {
+		t.Fatalf("ResolvePlanForChannel: %v", err)
+	}
+	if plan.LatestVersion != "2.52.0-pre.1" {
+		t.Errorf("LatestVersion = %q, want 2.52.0-pre.1", plan.LatestVersion)
+	}
+	if plan.Channel != ChannelBeta {
+		t.Errorf("Channel = %q, want %s", plan.Channel, ChannelBeta)
+	}
+	if !plan.Homebrew {
+		t.Error("expected Homebrew = true")
+	}
+	if plan.Formula != FormulaPre {
+		t.Errorf("Formula = %q, want %s", plan.Formula, FormulaPre)
+	}
+	if !plan.UpgradeAvailable {
+		t.Error("expected UpgradeAvailable from 2.51.0 to 2.52.0-pre.1")
+	}
 }
 
 func TestApply_DownloadsVerifiesAndSwaps(t *testing.T) {

--- a/cli/internal/tui/profile.go
+++ b/cli/internal/tui/profile.go
@@ -238,6 +238,11 @@ func (m profileModel) toggleCurrent() profileModel {
 			m.profile.GroupByCategory = groupByCategoryOpts[m.valueIdx].value
 			m.changed = true
 		}
+	case "channel":
+		if m.valueIdx >= 0 && m.valueIdx < len(channelOpts) {
+			m.profile.Channel = channelOpts[m.valueIdx].value
+			m.changed = true
+		}
 	}
 	return m
 }
@@ -277,6 +282,17 @@ var groupByCategoryOpts = []struct {
 }{
 	{"on (default)", nil},
 	{"off", boolPtr(false)},
+}
+
+// channelOpts is the picker for Profile.Channel. Selecting "stable (default)"
+// writes the explicit stable value so the field is first-class on disk;
+// "beta" follows the latest GitHub prerelease and the humblskills-pre formula.
+var channelOpts = []struct {
+	label string
+	value string
+}{
+	{"stable (default) — latest release", profile.ChannelStable},
+	{"beta — latest pre-release", profile.ChannelBeta},
 }
 
 func intPtr(n int) *int    { return &n }
@@ -324,6 +340,11 @@ func (m profileModel) currentSelectionIndex() int {
 			return 0
 		}
 		return 1
+	case "channel":
+		if m.profile.ResolvedChannel() == profile.ChannelBeta {
+			return 1
+		}
+		return 0
 	}
 	return 0
 }
@@ -348,6 +369,8 @@ func (m profileModel) valueCount() int {
 		return len(autoReturnSettingOpts)
 	case "group_by_category":
 		return len(groupByCategoryOpts)
+	case "channel":
+		return len(channelOpts)
 	}
 	return 0
 }
@@ -372,6 +395,7 @@ var profileSettings = []profileSetting{
 	{key: "scope", label: "default scope", kind: settingRadio},
 	{key: "status_auto_return", label: "status auto-return", kind: settingRadio},
 	{key: "group_by_category", label: "group by category", kind: settingRadio},
+	{key: "channel", label: "install channel", kind: settingRadio},
 }
 
 func (m profileModel) View() string {
@@ -502,6 +526,8 @@ func (m profileModel) renderRight(width int) string {
 		body = append(body, m.renderAutoReturnOptions(bar, width)...)
 	case "group_by_category":
 		body = append(body, m.renderGroupByCategoryOptions(bar, width)...)
+	case "channel":
+		body = append(body, m.renderChannelOptions(bar, width)...)
 	}
 	return strings.Join(body, "\n")
 }
@@ -660,6 +686,42 @@ func (m profileModel) renderGroupByCategoryOptions(bar string, width int) []stri
 	return rows
 }
 
+func (m profileModel) renderChannelOptions(bar string, width int) []string {
+	th := m.theme
+	resolved := m.profile.ResolvedChannel()
+	rows := make([]string, 0, len(channelOpts)+4)
+	rows = append(rows, detailLines(th, bar,
+		"Which CLI build upgrade fetches. Stable is GitHub /releases/latest and the "+
+			"humblskills brew formula (the default). Beta is the latest pre-release "+
+			"and the humblskills-pre formula. Same field Homebrew and `humblskills "+
+			"upgrade --channel` use — nothing else to configure.", width)...)
+	rows = append(rows, bar)
+	rows = append(rows, bar+" "+th.SectionTitle.Render("OPTIONS"))
+	for i, opt := range channelOpts {
+		cursorHere := i == m.valueIdx && m.focus == focusValue
+		isCurrent := opt.value == resolved
+		marker := "( )"
+		if isCurrent {
+			marker = "(●)"
+		}
+		var styled string
+		switch {
+		case cursorHere:
+			styled = th.RowSelected.Render(marker + "  " + opt.label)
+		case isCurrent:
+			styled = th.Success.Render(marker) + "  " + th.RowUnselected.Render(opt.label)
+		default:
+			styled = th.RowDim.Render(marker) + "  " + th.RowUnselected.Render(opt.label)
+		}
+		prefix := bar + "   "
+		if cursorHere {
+			prefix = bar + " " + th.Bullet.Render("▸") + " "
+		}
+		rows = append(rows, prefix+styled)
+	}
+	return rows
+}
+
 func (m profileModel) layoutRow(label, badge string, width int) string {
 	lw := lipgloss.Width(label)
 	bw := lipgloss.Width(badge)
@@ -694,8 +756,21 @@ func (m profileModel) settingBadge(key string) string {
 		return formatAutoReturnBadge(m.profile.StatusAutoReturnSeconds)
 	case "group_by_category":
 		return formatGroupByCategoryBadge(m.profile.GroupByCategory)
+	case "channel":
+		return formatChannelBadge(m.profile.Channel)
 	}
 	return ""
+}
+
+func formatChannelBadge(channel string) string {
+	switch channel {
+	case "":
+		return "stable (default)"
+	case profile.ChannelBeta:
+		return profile.ChannelBeta
+	default:
+		return profile.ChannelStable
+	}
 }
 
 func formatGroupByCategoryBadge(flag *bool) string {

--- a/cli/internal/tui/profile_test.go
+++ b/cli/internal/tui/profile_test.go
@@ -261,6 +261,58 @@ func TestProfileModel_GroupByCategory_DefaultsOn(t *testing.T) {
 	}
 }
 
+func TestProfileModel_Channel_DefaultsStable(t *testing.T) {
+	m := newTestProfileModel(profile.Profile{})
+	m.settingIdx = 4 // install channel — last setting so earlier indexes stay stable
+	if got := m.currentSelectionIndex(); got != 0 {
+		t.Errorf("unset channel should select stable (default), got %d", got)
+	}
+	if got := m.settingBadge("channel"); got != "stable (default)" {
+		t.Errorf("badge = %q, want stable (default)", got)
+	}
+	if m.valueCount() != 2 {
+		t.Errorf("valueCount = %d, want 2", m.valueCount())
+	}
+	if profileSettings[m.settingIdx].key != "channel" {
+		t.Errorf("setting 4 key = %q, want channel", profileSettings[m.settingIdx].key)
+	}
+}
+
+func TestProfileModel_Channel_ToggleBeta(t *testing.T) {
+	m := newTestProfileModel(profile.Profile{})
+	m.settingIdx = 4
+	m.focus = focusValue
+	m.valueIdx = 1 // beta
+
+	out, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updated := out.(profileModel)
+	if updated.profile.Channel != profile.ChannelBeta {
+		t.Errorf("Channel = %q, want %q", updated.profile.Channel, profile.ChannelBeta)
+	}
+	if updated.profile.ResolvedChannel() != profile.ChannelBeta {
+		t.Error("expected ResolvedChannel beta after toggle")
+	}
+	if !updated.changed {
+		t.Error("expected changed=true")
+	}
+	if updated.settingBadge("channel") != profile.ChannelBeta {
+		t.Errorf("badge = %q, want beta", updated.settingBadge("channel"))
+	}
+}
+
+func TestProfileModel_Channel_ToggleStableWritesExplicitValue(t *testing.T) {
+	m := newTestProfileModel(profile.Profile{Channel: profile.ChannelBeta})
+	m.settingIdx = 4
+	m.focus = focusValue
+	m.valueIdx = 0 // stable
+
+	out, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updated := out.(profileModel)
+	if updated.profile.Channel != profile.ChannelStable {
+		t.Errorf("Channel = %q, want %q", updated.profile.Channel, profile.ChannelStable)
+	}
+}
+
 func TestProfileModel_GroupByCategory_ToggleOff(t *testing.T) {
 	m := newTestProfileModel(profile.Profile{})
 	m.settingIdx = 3

--- a/cli/internal/tui/upgrade.go
+++ b/cli/internal/tui/upgrade.go
@@ -36,7 +36,7 @@ const (
 var upgradeStepLabels = map[UpgradeStep]string{
 	UpgradeStepCheckingLatest:    "checking latest release",
 	UpgradeStepBrewUpdating:      "running brew update",
-	UpgradeStepBrewUpgrading:     "running brew upgrade humblskills",
+	UpgradeStepBrewUpgrading:     "running brew upgrade",
 	UpgradeStepDownloading:       "downloading release archive",
 	UpgradeStepVerifyingChecksum: "verifying checksum",
 	UpgradeStepInstalling:        "installing",

--- a/docs/getting_started/installation-agent/SKILL.md
+++ b/docs/getting_started/installation-agent/SKILL.md
@@ -19,6 +19,15 @@ brew install jjfantini/humbl/humblskills
 brew upgrade humblskills
 ```
 
+Pre-releases use a second formula (`humblskills-pre`). Do not use
+`humblskills@beta` — Homebrew only allows `@` + digits. The stable formula is
+never rewritten on a `-pre.N` tag.
+
+```sh
+brew install jjfantini/humbl/humblskills-pre
+brew upgrade humblskills-pre
+```
+
 Tap: [jjfantini/homebrew-humbl](https://github.com/jjfantini/homebrew-humbl).
 
 ### Shell installer (Linux and macOS)
@@ -55,11 +64,20 @@ humblskills doctor
 ### Upgrade the CLI later
 
 ```sh
-humblskills upgrade            # self-update; --dry-run to check only
-brew upgrade humblskills       # equivalent; on brew installs `upgrade` runs this for you
+humblskills upgrade                 # profile channel (stable if unset)
+humblskills upgrade --channel beta  # this run only
+humblskills profile get channel
+humblskills profile set channel beta
+brew upgrade humblskills            # stable formula
+brew upgrade humblskills-pre        # beta formula
 ```
 
+On a brew install, `upgrade` runs `brew upgrade <formula>` for the resolved
+channel. Same `channel` field as `profile.json`. In the TUI: `humblskills` or
+`humblskills profile` → **install channel**.
+
 `upgrade` updates the CLI binary; `update` updates installed skills.
+`humblskills install` installs **skills**, not the CLI.
 
 ## CLI behavior
 

--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -16,9 +16,18 @@ If you use [Homebrew](https://brew.sh), this is the simplest way to install and 
 brew install jjfantini/humbl/humblskills
 ```
 
-Tap and formula live in [`jjfantini/homebrew-humbl`](https://github.com/jjfantini/homebrew-humbl); **stable** releases on `main` bump the formula automatically. Pre-releases from `develop` (`vX.Y.Z-pre.N`) do not.
+Tap and formulas live in [`jjfantini/homebrew-humbl`](https://github.com/jjfantini/homebrew-humbl). **Stable** releases on `main` bump `Formula/humblskills.rb`. Pre-releases from `develop` (`vX.Y.Z-pre.N`) bump a **second** formula, `humblskills-pre`, and never replace the stable one — `brew upgrade humblskills` stays on the last real version.
 
-Upgrade later with:
+Homebrew rejects `humblskills@beta` (`@` is only legal with a numeric version). The pre formula is therefore `humblskills-pre`.
+
+```sh
+brew install jjfantini/humbl/humblskills-pre   # pre-releases only
+brew upgrade humblskills-pre
+```
+
+The two formulas `conflicts_with` each other. Install one, not both.
+
+Upgrade the stable formula later with:
 
 ```sh
 brew upgrade humblskills
@@ -76,17 +85,38 @@ fix that before installing skills.
 ## Staying up to date
 
 ```sh
-humblskills upgrade              # self-update: download, verify, swap the binary
-humblskills upgrade --dry-run    # just show the version you'd move to
+humblskills upgrade                    # self-update on the profile channel (stable by default)
+humblskills upgrade --channel beta     # this run only; does not write the profile
+humblskills upgrade --dry-run          # just show the version you'd move to
 ```
 
-On a Homebrew-managed install, `upgrade` detects that, asks for confirmation, and
-runs `brew update && brew upgrade humblskills` for you, so Homebrew's own Cellar
-bookkeeping stays correct. It only asks you to run brew yourself if `brew` isn't on
-`PATH`. You can of course still do it directly:
+The install channel is one field in `~/.humblskills/profile.json` (`channel`:
+`stable` or `beta`; unset means stable). Homebrew and `humblskills upgrade`
+both read it — no extra config file.
 
 ```sh
-brew upgrade humblskills
+humblskills profile get channel
+humblskills profile set channel beta     # persist; default / "" / stable all mean stable
+humblskills profile show
+```
+
+Or the same TUI editor that already exists (do not look for a second settings
+app): run `humblskills` and open **Profile**, or `humblskills profile`. The
+**install channel** row shows the current value; enter to switch stable ↔ beta.
+
+| Channel | GitHub | Homebrew formula |
+|---------|--------|------------------|
+| `stable` (default) | `/releases/latest` | `humblskills` |
+| `beta` | latest prerelease (`vX.Y.Z-pre.N`) | `humblskills-pre` |
+
+On a Homebrew-managed install, `upgrade` detects that, asks for confirmation, and
+runs `brew update && brew upgrade <formula>` for the resolved channel, so
+Homebrew's own Cellar bookkeeping stays correct. It only asks you to run brew
+yourself if `brew` isn't on `PATH`. You can of course still do it directly:
+
+```sh
+brew upgrade humblskills       # stable
+brew upgrade humblskills-pre   # beta
 ```
 
 `upgrade` updates the **CLI**; `humblskills update` updates your installed

--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -16,7 +16,7 @@ If you use [Homebrew](https://brew.sh), this is the simplest way to install and 
 brew install jjfantini/humbl/humblskills
 ```
 
-Tap and formula live in [`jjfantini/homebrew-humbl`](https://github.com/jjfantini/homebrew-humbl); new releases bump the formula automatically.
+Tap and formula live in [`jjfantini/homebrew-humbl`](https://github.com/jjfantini/homebrew-humbl); **stable** releases on `main` bump the formula automatically. Pre-releases from `develop` (`vX.Y.Z-pre.N`) do not.
 
 Upgrade later with:
 

--- a/docs/getting_started/quickstart.md
+++ b/docs/getting_started/quickstart.md
@@ -85,7 +85,9 @@ newer version waiting.
 humblskills update              # pick which drifted skills to upgrade
 humblskills update --check      # dry run: show what would change
 humblskills update --all --yes  # upgrade everything, no prompts
-humblskills upgrade             # upgrade the humblskills CLI itself
+humblskills upgrade                  # CLI binary; profile channel (stable if unset)
+humblskills upgrade --channel beta   # this run only
+humblskills profile set channel beta # persist; TUI: humblskills → Profile → install channel
 ```
 
 `update` handles skills; `upgrade` handles the binary. Your customizations

--- a/docs/using_humblskills/updating.md
+++ b/docs/using_humblskills/updating.md
@@ -113,20 +113,29 @@ old name, so you can update by the name you now know the skill by.
 ## Upgrading the CLI
 
 ```sh
-humblskills upgrade              # download + verify + swap in the latest release
-humblskills upgrade --dry-run    # just report the version you'd move to
+humblskills upgrade                    # profile channel (stable if unset)
+humblskills upgrade --channel beta     # this run only; does not write the profile
+humblskills upgrade --dry-run
+humblskills profile get channel
+humblskills profile set channel beta
 ```
 
-The upgrade checks GitHub releases, verifies the checksum, and replaces the
-running binary in place.
+The upgrade checks GitHub releases (stable → `/releases/latest`; beta → latest
+prerelease), verifies the checksum, and replaces the running binary in place.
 
-If you installed via Homebrew, `upgrade` detects that and delegates: it confirms with
-you, then runs `brew update && brew upgrade humblskills` itself, so Homebrew's own
-bookkeeping stays correct. It falls back to telling you to run brew by hand only when
-`brew` isn't on `PATH`. Doing it directly works too:
+The channel is the same `profile.json` field Homebrew uses. Change it from the
+existing Profile TUI (`humblskills` → Profile → **install channel**) or
+`profile set` — there is no second settings surface.
+
+If you installed via Homebrew, `upgrade` detects that and delegates: it confirms
+with you, then runs `brew update && brew upgrade <formula>` (`humblskills` or
+`humblskills-pre`) itself, so Homebrew's own bookkeeping stays correct. It falls
+back to telling you to run brew by hand only when `brew` isn't on `PATH`. Doing
+it directly works too:
 
 ```sh
 brew upgrade humblskills
+brew upgrade humblskills-pre
 ```
 
 ## Related topics

--- a/registry.json
+++ b/registry.json
@@ -1,10 +1,10 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-09-01T18:38:32Z",
+  "generated_at": "2026-09-01T18:44:42Z",
   "source": {
     "repo": "github.com/jjfantini/humblSKILLS",
     "ref": "main",
-    "sha": "c8eeaf1976ea4d3d9f0155f32e6412346c2f8699"
+    "sha": "e9b2d8453b82929e8d7caf5714e1e1c636fe2919"
   },
   "skills": [
     {
@@ -765,7 +765,7 @@
         "use-worktree-flow"
       ],
       "path": "skills/smart-worktree-flow",
-      "dir_sha": "46fe97558274ae4e00ca7222732f7a8bfeded492742f606546a1607d018ba1be"
+      "dir_sha": "57d71d4426a3420772045b09ccd303a4bdfd1d3987c5fc3a7d2e870b8550e570"
     }
   ]
 }

--- a/registry.json
+++ b/registry.json
@@ -1,10 +1,10 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-08-20T18:34:12Z",
+  "generated_at": "2026-08-20T18:39:04Z",
   "source": {
     "repo": "github.com/jjfantini/humblSKILLS",
     "ref": "main",
-    "sha": "bbd60c54e7ec17a32327bbcbef0e12f920e40eed"
+    "sha": "ca5c19e7678e2b7ae1fcd3f2c7a6c85edf068061"
   },
   "skills": [
     {
@@ -738,8 +738,8 @@
     },
     {
       "name": "smart-worktree-flow",
-      "version": "1.1.0",
-      "description": "Run a worktree-first development workflow from intent gathering through feature PR, develop merge, main merge, release PR, brew verification, and cleanup. Use when the user says \"worktree flow\", \"start a feature\", \"ship this feature\", \"PR into develop\", \"full dev workflow\", or wants a feature isolated from parallel agents. Do NOT use for atomic commit authoring (use smart-commit) or merge-conflict repair.\n",
+      "version": "1.2.0",
+      "description": "Run a worktree-first development workflow from intent gathering through feature PR, develop merge (pre-release), main merge (stable + brew), and cleanup. Use when the user says \"worktree flow\", \"start a feature\", \"ship this feature\", \"PR into develop\", \"full dev workflow\", or wants a feature isolated from parallel agents. Do NOT use for atomic commit authoring (use smart-commit) or merge-conflict repair.\n",
       "category": "development",
       "tags": [
         "git",
@@ -765,7 +765,7 @@
         "use-worktree-flow"
       ],
       "path": "skills/smart-worktree-flow",
-      "dir_sha": "e849613f62b9615e40c07b69f8e3c8205ec3b20bd2fd4d5c641c217048779da7"
+      "dir_sha": "46fe97558274ae4e00ca7222732f7a8bfeded492742f606546a1607d018ba1be"
     }
   ]
 }

--- a/registry.json
+++ b/registry.json
@@ -1,10 +1,10 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-08-20T18:39:04Z",
+  "generated_at": "2026-09-01T18:38:32Z",
   "source": {
     "repo": "github.com/jjfantini/humblSKILLS",
     "ref": "main",
-    "sha": "ca5c19e7678e2b7ae1fcd3f2c7a6c85edf068061"
+    "sha": "c8eeaf1976ea4d3d9f0155f32e6412346c2f8699"
   },
   "skills": [
     {

--- a/registry.json
+++ b/registry.json
@@ -1,10 +1,10 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-09-01T18:44:42Z",
+  "generated_at": "2026-09-01T18:47:02Z",
   "source": {
     "repo": "github.com/jjfantini/humblSKILLS",
     "ref": "main",
-    "sha": "e9b2d8453b82929e8d7caf5714e1e1c636fe2919"
+    "sha": "5fa43fd871dda05c281c6fd4675506003689bea6"
   },
   "skills": [
     {

--- a/registry.json
+++ b/registry.json
@@ -1,10 +1,10 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-09-01T18:47:02Z",
+  "generated_at": "2026-09-01T18:47:23Z",
   "source": {
     "repo": "github.com/jjfantini/humblSKILLS",
     "ref": "main",
-    "sha": "5fa43fd871dda05c281c6fd4675506003689bea6"
+    "sha": "bd87724b9fa8baa13457e06846ad8a11d5d59020"
   },
   "skills": [
     {
@@ -738,7 +738,7 @@
     },
     {
       "name": "smart-worktree-flow",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "description": "Run a worktree-first development workflow from intent gathering through feature PR, develop merge (pre-release), main merge (stable + brew), and cleanup. Use when the user says \"worktree flow\", \"start a feature\", \"ship this feature\", \"PR into develop\", \"full dev workflow\", or wants a feature isolated from parallel agents. Do NOT use for atomic commit authoring (use smart-commit) or merge-conflict repair.\n",
       "category": "development",
       "tags": [
@@ -765,7 +765,7 @@
         "use-worktree-flow"
       ],
       "path": "skills/smart-worktree-flow",
-      "dir_sha": "57d71d4426a3420772045b09ccd303a4bdfd1d3987c5fc3a7d2e870b8550e570"
+      "dir_sha": "f159804d68d3792401aa6865d37cdea73809a3f8ad1d3aff57c8f9d679837bdf"
     }
   ]
 }

--- a/registry.json
+++ b/registry.json
@@ -1,10 +1,10 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-09-01T18:47:23Z",
+  "generated_at": "2026-09-01T19:04:51Z",
   "source": {
     "repo": "github.com/jjfantini/humblSKILLS",
     "ref": "main",
-    "sha": "bd87724b9fa8baa13457e06846ad8a11d5d59020"
+    "sha": "1e4799ac5a9ba6773ff29d68e96bffb67fc34fe6"
   },
   "skills": [
     {

--- a/release-please-config.develop.json
+++ b/release-please-config.develop.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "go",
-  "skip-github-pull-request": false,
   "include-component-in-tag": false,
   "prerelease": true,
   "versioning": "prerelease",

--- a/release-please-config.develop.json
+++ b/release-please-config.develop.json
@@ -3,10 +3,12 @@
   "release-type": "go",
   "skip-github-pull-request": false,
   "include-component-in-tag": false,
-  "prerelease": false,
-  "versioning": "default",
+  "prerelease": true,
+  "versioning": "prerelease",
+  "prerelease-type": "pre",
   "commit-search-depth": 200,
   "release-search-depth": 50,
+  "pull-request-header": ":construction: Pre-release from `develop`. Tags `vX.Y.Z-pre.N` and marks the GitHub Release as a pre-release. Does **not** update the Homebrew tap. Promote by merging `develop` into `main` (merge commit, never squash).",
   "packages": {
     ".": {
       "package-name": "humblskills"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "go",
-  "skip-github-pull-request": false,
   "include-component-in-tag": false,
   "prerelease": false,
   "versioning": "default",

--- a/scripts/guard-major-bump.sh
+++ b/scripts/guard-major-bump.sh
@@ -1,31 +1,36 @@
 #!/usr/bin/env bash
 # Decide whether a release-please PR is safe to auto-merge.
 #
-# Auto-merge lands release PRs unattended, which is fine for minors and
-# patches and wrong for a major: on 2026-07-30 release-please lost track of
-# the latest release, re-derived the version from a `feat!` months old, and
-# a phantom 3.0.0 was merged 16 seconds after it opened and shipped to the
-# Homebrew tap before anyone saw it. A major is rare and worth a human.
+# Minors and patches (including vX.Y.Z-pre.N) auto-merge. A major does not:
+# it is rare, and on 2026-07-30 a phantom 3.0.0 shipped to the Homebrew tap
+# 16 seconds after the release PR opened.
 #
 # Reads the version from `.release-please-manifest.json` on both refs rather
 # than parsing the PR title, so a change to release-please's title format
-# cannot quietly disable the guard.
+# cannot quietly disable the guard. Prerelease suffixes are stripped before
+# comparing majors (`2.52.0-pre.1` → `2.52.0`).
 #
 # Usage:
-#   guard-major-bump.sh <repo> <head-sha>   # exit 0 = safe, 1 = needs a human
+#   guard-major-bump.sh <repo> <head-sha> [base-ref]  # exit 0 = safe, 1 = human
 #   guard-major-bump.sh --self-test
 set -euo pipefail
 
 MANIFEST=".release-please-manifest.json"
 
-# Exits 0 when cur -> next is a same-major bump. Anything it cannot read as
-# two dotted numbers is treated as unsafe: a guard that fails open is not a
-# guard, and "releases paused" is a loud failure while "major shipped" is not.
+# Numeric core of a semver: strip a -prerelease suffix, then require dotted
+# digits only. Anything else is unreadable → unsafe (fail closed).
+version_core() {
+  local v="${1%%-*}"
+  case "$v" in '' | *[!0-9.]*) return 1 ;; esac
+  printf '%s' "$v"
+}
+
+# Exits 0 when cur -> next is a same-major bump.
 same_major() {
-  local cur="${1:-}" next="${2:-}"
-  case "$cur" in '' | *[!0-9.]*) return 1 ;; esac
-  case "$next" in '' | *[!0-9.]*) return 1 ;; esac
-  [ "${cur%%.*}" = "${next%%.*}" ]
+  local cur next
+  cur="$(version_core "${1:-}" || true)"
+  next="$(version_core "${2:-}" || true)"
+  [ -n "$cur" ] && [ -n "$next" ] && [ "${cur%%.*}" = "${next%%.*}" ]
 }
 
 manifest_version() {
@@ -39,14 +44,18 @@ self_test() {
     if same_major "$2" "$3"; then got=safe; else got=blocked; fi
     [ "$got" = "$1" ] || { echo "FAIL: same_major('$2','$3') = $got, want $1"; exit 1; }
   }
-  check safe    2.44.0 2.44.1     # patch
-  check safe    2.44.1 2.45.0     # minor
-  check safe    0.1.0  0.2.0      # pre-1.0 minor
-  check blocked 2.44.1 3.0.0      # the incident
-  check blocked 3.0.0  2.42.0     # rollback, also a human's call
-  check blocked 2.44.1 ''         # unreadable next -> fail closed
-  check blocked ''     3.0.0      # unreadable current -> fail closed
-  check blocked 2.44.1 'v3.0.0'   # unexpected format -> fail closed
+  check safe    2.44.0 2.44.1        # patch
+  check safe    2.44.1 2.45.0        # minor
+  check safe    0.1.0  0.2.0         # pre-1.0 minor
+  check safe    2.51.0 2.52.0-pre.1  # develop pre
+  check safe    2.52.0-pre.1 2.52.0  # graduate pre → stable
+  check safe    2.52.0-pre.1 2.52.0-pre.2
+  check blocked 2.44.1 3.0.0         # the incident
+  check blocked 2.51.0 3.0.0-pre.1   # major pre
+  check blocked 3.0.0  2.42.0        # rollback
+  check blocked 2.44.1 ''            # unreadable next
+  check blocked ''     3.0.0         # unreadable current
+  check blocked 2.44.1 'v3.0.0'      # unexpected format
   echo "guard-major-bump: all checks passed"
 }
 
@@ -55,10 +64,11 @@ if [ "${1:-}" = "--self-test" ]; then
   exit 0
 fi
 
-repo="${1:?usage: guard-major-bump.sh <repo> <head-sha>}"
-head="${2:?usage: guard-major-bump.sh <repo> <head-sha>}"
+repo="${1:?usage: guard-major-bump.sh <repo> <head-sha> [base-ref]}"
+head="${2:?usage: guard-major-bump.sh <repo> <head-sha> [base-ref]}"
+base="${3:-main}"
 
-current="$(manifest_version "$repo" main || true)"
+current="$(manifest_version "$repo" "$base" || true)"
 next="$(manifest_version "$repo" "$head" || true)"
 
 if same_major "$current" "$next"; then

--- a/skills/smart-worktree-flow/SKILL.md
+++ b/skills/smart-worktree-flow/SKILL.md
@@ -11,7 +11,7 @@ license: MIT
 compatibility: "Requires git 2.5+, GitHub CLI (`gh`) for PR/check operations, and network access for remote sync, CI, releases, and Homebrew verification."
 metadata:
   author: jjfantini
-  version: "1.2.0"
+  version: "1.2.1"
   previous_names: ["use-worktree-flow"]
   category: development
   tags: [git, worktree, pull-requests, release, workflow, humblskill]
@@ -62,7 +62,8 @@ Before implementation, ask the user the questions in
 `references/wiki/flow/setup/intent-gathering.md`. If they defer, use these
 defaults: Vibe mode, worktree isolation, auto-merge develop to main on green,
 auto-merge both release PRs (develop pre-release and main stable) on green,
-`brew upgrade` as a post-check after the main stable only, and clean stale
+`brew upgrade humblskills` as a post-check after the main stable only (testers
+can `brew upgrade humblskills-pre` after a develop pre-release), and clean stale
 worktrees and branches.
 
 Also inspect reality before choosing the path: run `git status`,
@@ -79,8 +80,8 @@ the workspace is dirty.
 3. PR the feature branch into `develop`; merge only after tests, lint,
    verifications, and CI/CD are green.
 4. After `develop` is green, wait for the **pre-release** PR (tag
-   `vX.Y.Z-pre.N`, GitHub pre-release, no brew). Merge it on green if the user
-   chose that path.
+   `vX.Y.Z-pre.N`, GitHub pre-release, `humblskills-pre` formula only). Merge it
+   on green if the user chose that path.
 5. PR `develop` into `main` or `master`; follow the upfront Vibe or HITL
    decision. Prefer merge commits when release tooling reads conventional
    commits. Wait for the **stable** release PR (tag `vX.Y.Z` + Homebrew tap).
@@ -89,9 +90,11 @@ the workspace is dirty.
 
 **Confirm how each branch releases before choosing a base.** Check
 `.github/workflows/release.yml` rather than assuming. In this repo `develop`
-feeds a GitHub pre-release (`vX.Y.Z-pre.N`) only. `main` feeds the real
-`vX.Y.Z` and the Homebrew tap. There is no develop brew channel — `brew
-upgrade` is a post-check after the main stable release, never after develop.
+feeds a GitHub pre-release (`vX.Y.Z-pre.N`) and the `humblskills-pre` formula
+only. `main` feeds the real `vX.Y.Z` and `Formula/humblskills.rb`. Develop
+never rewrites the stable formula — `brew upgrade humblskills` is a post-check
+after the main stable release. Testers who opted into beta use
+`brew upgrade humblskills-pre` or `humblskills upgrade --channel beta`.
 
 A single-commit fix may go straight to the production branch instead of steps
 3-4, if the user says so. Then `develop` must be brought back to it, or the
@@ -135,8 +138,8 @@ Actions:
    release PR auto-merge, cleanup enabled.
 2. Create `feat-add-data` and `feat/add-data` from `origin/develop`.
 3. Implement, verify, PR into `develop`, merge on green, handle the develop
-   pre-release PR (no brew), PR `develop` into `main`, handle the stable
-   release PR, post-check with `brew upgrade humblskills`, cleanup.
+   pre-release PR (`humblskills-pre` only), PR `develop` into `main`, handle
+   the stable release PR, post-check with `brew upgrade humblskills`, cleanup.
 
 Result: The feature ships through release with no stale branch or worktree.
 

--- a/skills/smart-worktree-flow/SKILL.md
+++ b/skills/smart-worktree-flow/SKILL.md
@@ -61,7 +61,9 @@ _Full spec: `references/_brain.md`._
 Before implementation, ask the user the questions in
 `references/wiki/flow/setup/intent-gathering.md`. If they defer, use these
 defaults: Vibe mode, worktree isolation, auto-merge develop to main on green,
-auto-merge release PR on green, and clean stale worktrees and branches.
+auto-merge both release PRs (develop pre-release and main stable) on green,
+`brew upgrade` as a post-check after the main stable only, and clean stale
+worktrees and branches.
 
 Also inspect reality before choosing the path: run `git status`,
 `git worktree list`, check current branch tracking, and look for other active
@@ -85,10 +87,11 @@ the workspace is dirty.
 6. Sync local branches with upstream, remove the worktree, and delete stale
    local and remote feature branches unless the user opted out.
 
-**Confirm how each branch releases before choosing a base.** In this repo,
-`develop` cuts pre-releases and `main` cuts the real version plus the brew
-formula. Work that never reaches `main` is a pre-release only — `brew upgrade`
-will not see it. Check `.github/workflows/release.yml` rather than assuming.
+**Confirm how each branch releases before choosing a base.** Check
+`.github/workflows/release.yml` rather than assuming. In this repo `develop`
+feeds a GitHub pre-release (`vX.Y.Z-pre.N`) only. `main` feeds the real
+`vX.Y.Z` and the Homebrew tap. There is no develop brew channel — `brew
+upgrade` is a post-check after the main stable release, never after develop.
 
 A single-commit fix may go straight to the production branch instead of steps
 3-4, if the user says so. Then `develop` must be brought back to it, or the
@@ -132,8 +135,8 @@ Actions:
    release PR auto-merge, cleanup enabled.
 2. Create `feat-add-data` and `feat/add-data` from `origin/develop`.
 3. Implement, verify, PR into `develop`, merge on green, handle the develop
-   pre-release PR, PR `develop` into `main`, handle the stable release PR,
-   verify `brew upgrade humblskills`, cleanup.
+   pre-release PR (no brew), PR `develop` into `main`, handle the stable
+   release PR, post-check with `brew upgrade humblskills`, cleanup.
 
 Result: The feature ships through release with no stale branch or worktree.
 

--- a/skills/smart-worktree-flow/SKILL.md
+++ b/skills/smart-worktree-flow/SKILL.md
@@ -2,7 +2,7 @@
 name: smart-worktree-flow
 description: >
   Run a worktree-first development workflow from intent gathering through
-  feature PR, develop merge, main merge, release PR, brew verification, and
+  feature PR, develop merge (pre-release), main merge (stable + brew), and
   cleanup. Use when the user says "worktree flow", "start a feature",
   "ship this feature", "PR into develop", "full dev workflow", or wants a
   feature isolated from parallel agents. Do NOT use for atomic commit authoring
@@ -11,7 +11,7 @@ license: MIT
 compatibility: "Requires git 2.5+, GitHub CLI (`gh`) for PR/check operations, and network access for remote sync, CI, releases, and Homebrew verification."
 metadata:
   author: jjfantini
-  version: "1.1.0"
+  version: "1.2.0"
   previous_names: ["use-worktree-flow"]
   category: development
   tags: [git, worktree, pull-requests, release, workflow, humblskill]
@@ -27,7 +27,8 @@ metadata:
 # Worktree Flow
 
 Use this when shipping code through an isolated worktree: feature branch to
-`develop`, `develop` to `main` or `master`, release PR, local sync, and cleanup.
+`develop` (GitHub pre-release), `develop` to `main` or `master` (stable release
++ Homebrew tap), local sync, and cleanup.
 
 ## Brain Protocol (read BEFORE creating anything)
 
@@ -75,18 +76,19 @@ the workspace is dirty.
    branch `feat/add-data`.
 3. PR the feature branch into `develop`; merge only after tests, lint,
    verifications, and CI/CD are green.
-4. PR `develop` into `main` or `master`; follow the upfront Vibe or HITL
+4. After `develop` is green, wait for the **pre-release** PR (tag
+   `vX.Y.Z-pre.N`, GitHub pre-release, no brew). Merge it on green if the user
+   chose that path.
+5. PR `develop` into `main` or `master`; follow the upfront Vibe or HITL
    decision. Prefer merge commits when release tooling reads conventional
-   commits from main.
-5. Handle the generated release PR if the repo has release automation. Merge
-   it on green only if the user chose that path.
+   commits. Wait for the **stable** release PR (tag `vX.Y.Z` + Homebrew tap).
 6. Sync local branches with upstream, remove the worktree, and delete stale
    local and remote feature branches unless the user opted out.
 
-**Confirm which branch releases before choosing a base.** Release automation
-watches one branch. Work merged anywhere else is finished, green, and unshipped
-— the quietest failure in this whole flow, because nothing reports an error.
-Check the release workflow's trigger rather than assuming `develop` feeds it.
+**Confirm how each branch releases before choosing a base.** In this repo,
+`develop` cuts pre-releases and `main` cuts the real version plus the brew
+formula. Work that never reaches `main` is a pre-release only — `brew upgrade`
+will not see it. Check `.github/workflows/release.yml` rather than assuming.
 
 A single-commit fix may go straight to the production branch instead of steps
 3-4, if the user says so. Then `develop` must be brought back to it, or the
@@ -112,7 +114,7 @@ Read `references/wiki/flow/pr/develop-gate.md`.
 **Gate develop into main or master:**
 Read `references/wiki/flow/pr/main-gate.md`.
 
-**Handle release automation:**
+**Handle pre-release (develop) and stable release (main):**
 Read `references/wiki/flow/release/release-pr.md`.
 
 **Sync and cleanup after release:**
@@ -129,8 +131,9 @@ Actions:
 1. Apply default choices: Vibe mode, worktree isolation, auto-merge on green,
    release PR auto-merge, cleanup enabled.
 2. Create `feat-add-data` and `feat/add-data` from `origin/develop`.
-3. Implement, verify, PR into `develop`, merge on green, PR `develop` into
-   `main`, handle release PR, verify brew upgrade, cleanup.
+3. Implement, verify, PR into `develop`, merge on green, handle the develop
+   pre-release PR, PR `develop` into `main`, handle the stable release PR,
+   verify `brew upgrade humblskills`, cleanup.
 
 Result: The feature ships through release with no stale branch or worktree.
 

--- a/skills/smart-worktree-flow/references/decisions.md
+++ b/skills/smart-worktree-flow/references/decisions.md
@@ -16,11 +16,18 @@ Entry shape:
 
 ---
 
+### 2026-09-01 | release-please pre channel, not a second goreleaser workflow
+- Context: Jennings wants develop to cut GitHub pre-releases and main to cut the real version + brew. Two honest implementations exist.
+- Options: (A) release-please `prerelease` + `versioning: prerelease` + `prerelease-type: pre` on develop, same goreleaser job, `skip_upload: auto`, (B) a dedicated develop workflow that invents the next `-pre` tag and calls goreleaser itself.
+- Chose: A.
+- Why: release-please already documents pre-release branches that graduate on merge to main. goreleaser already consumes a semver `-pre.N` suffix (`prerelease: auto`, `skip_upload: auto`). B would add a version-computation script and a second source of truth. Tags `vX.Y.Z-pre.N` cannot equal `vX.Y.Z`, GitHub `/releases/latest` and `go install @latest` ignore prereleases, and brew stays on the last main formula. No develop Homebrew channel.
+- Result: TBD after first develop pre-release lands.
+
 ### 2026-09-01 | Two-branch release: develop is pre, main is stable + brew
-- Context: The repo's release automation previously watched only `main`, so work on `develop` was green and unshipped until a human promoted it, and the skill's "which branch releases?" warning assumed a single release branch.
-- Options: (A) keep documenting a single release-please-on-main path, (B) document develop pre-release (`vX.Y.Z-pre.N`) and main stable + Homebrew as the real path.
+- Context: The live repo watched only `main` (`release.yml` `on.push.branches: [main]`). The canonical skill described feature→develop→main plus a third release-please PR on main, then `brew upgrade` as a post-check — not GitHub prereleases on develop.
+- Options: (A) keep documenting that single-release-branch path, (B) document develop pre-release (`vX.Y.Z-pre.N`) and main stable + Homebrew as the new path, keep brew as a post-check after main only.
 - Chose: B - match `.github/workflows/release.yml` and `release-please-config.develop.json`.
-- Why: Jennings' intended product flow is develop → pre-release, main → real version + `brew upgrade`. The skill must not tell agents to ignore develop or to expect brew after a develop merge.
+- Why: Jennings' new ask is develop → pre-release, main → real version + tap. The skill must not tell agents develop does not release, or that brew follows develop.
 - Result: TBD after first develop pre-release lands.
 
 ### 2026-06-12 | Default to worktrees and Vibe mode on deferral

--- a/skills/smart-worktree-flow/references/decisions.md
+++ b/skills/smart-worktree-flow/references/decisions.md
@@ -16,6 +16,13 @@ Entry shape:
 
 ---
 
+### 2026-09-01 | second brew formula + first-class profile channel
+- Context: Jennings wants a pre-release *install* path, then made the beta vs stable channel first-class in the CLI and the existing TUI — not a hidden profile.json key.
+- Options: (A) mutate `Formula/humblskills.rb` on develop, (B) `humblskills@beta` versioned formula, (C) second formula `humblskills-pre` plus one `channel` field on the existing profile, wired to `profile get`/`set`, `upgrade --channel`, and the Profile TUI.
+- Chose: C.
+- Why: A would make `brew upgrade humblskills` jump to `-pre.N`. B is an illegal Homebrew class (`@` only maps with digits). One profile field is the source of truth Homebrew, `upgrade`, and the existing settings TUI already share — no extra config file, no second TUI.
+- Result: TBD after first `humblskills-pre` tap commit.
+
 ### 2026-09-01 | release-please pre channel, not a second goreleaser workflow
 - Context: Jennings wants develop to cut GitHub pre-releases and main to cut the real version + brew. Two honest implementations exist.
 - Options: (A) release-please `prerelease` + `versioning: prerelease` + `prerelease-type: pre` on develop, same goreleaser job, `skip_upload: auto`, (B) a dedicated develop workflow that invents the next `-pre` tag and calls goreleaser itself.

--- a/skills/smart-worktree-flow/references/decisions.md
+++ b/skills/smart-worktree-flow/references/decisions.md
@@ -16,6 +16,13 @@ Entry shape:
 
 ---
 
+### 2026-09-01 | Two-branch release: develop is pre, main is stable + brew
+- Context: The repo's release automation previously watched only `main`, so work on `develop` was green and unshipped until a human promoted it, and the skill's "which branch releases?" warning assumed a single release branch.
+- Options: (A) keep documenting a single release-please-on-main path, (B) document develop pre-release (`vX.Y.Z-pre.N`) and main stable + Homebrew as the real path.
+- Chose: B - match `.github/workflows/release.yml` and `release-please-config.develop.json`.
+- Why: Jennings' intended product flow is develop → pre-release, main → real version + `brew upgrade`. The skill must not tell agents to ignore develop or to expect brew after a develop merge.
+- Result: TBD after first develop pre-release lands.
+
 ### 2026-06-12 | Default to worktrees and Vibe mode on deferral
 - Context: The skill needs safe defaults when the user says "I defer to you" but still must avoid clobbering parallel local work.
 - Options: (A) in-place branches by default, (B) worktrees by default, (C) always stop until the user chooses.

--- a/skills/smart-worktree-flow/references/log.md
+++ b/skills/smart-worktree-flow/references/log.md
@@ -34,4 +34,10 @@ Entry shape:
 [QUERY 2026-09-01] Two-branch release path (develop pre, main stable + brew).
   - Updated SKILL.md steps 4–6, release-pr.md, main-gate.md, version 1.2.0
 
+[QUERY 2026-09-01] Ground truth: skill was main-only + brew post-check; Jennings wants develop pre-releases.
+  - Chose release-please pre channel over a second goreleaser workflow
+  - Vibe still auto-merges develop→main and both release PRs; brew post-check after main only
+
+[LINT 2026-09-01] 6 wiki, 1 raw. Hard: 0, Soft: 0. Regenerated _index.md.
+
 [LINT 2026-09-01] 6 wiki, 1 raw. Hard: 0, Soft: 0. Regenerated _index.md.

--- a/skills/smart-worktree-flow/references/log.md
+++ b/skills/smart-worktree-flow/references/log.md
@@ -30,3 +30,8 @@ Entry shape:
 [LINT 2026-08-04] 6 wiki, 1 raw. Hard: 0, Soft: 0. Regenerated _index.md.
 
 [LINT 2026-08-04] 6 wiki, 1 raw. Hard: 0, Soft: 0. Regenerated _index.md.
+
+[QUERY 2026-09-01] Two-branch release path (develop pre, main stable + brew).
+  - Updated SKILL.md steps 4–6, release-pr.md, main-gate.md, version 1.2.0
+
+[LINT 2026-09-01] 6 wiki, 1 raw. Hard: 0, Soft: 0. Regenerated _index.md.

--- a/skills/smart-worktree-flow/references/log.md
+++ b/skills/smart-worktree-flow/references/log.md
@@ -41,3 +41,10 @@ Entry shape:
 [LINT 2026-09-01] 6 wiki, 1 raw. Hard: 0, Soft: 0. Regenerated _index.md.
 
 [LINT 2026-09-01] 6 wiki, 1 raw. Hard: 0, Soft: 0. Regenerated _index.md.
+
+[LINT 2026-09-01] 6 wiki, 1 raw. Hard: 0, Soft: 0. Regenerated _index.md.
+
+[QUERY 2026-09-01] First-class beta channel: second brew formula + profile field.
+  - humblskills-pre on pre tags only; stable formula never jumps to -pre.N
+  - Same profile.channel for profile get/set, TUI install channel, upgrade --channel
+  - Skill version 1.2.1

--- a/skills/smart-worktree-flow/references/wiki/flow/pr/develop-gate.md
+++ b/skills/smart-worktree-flow/references/wiki/flow/pr/develop-gate.md
@@ -7,7 +7,7 @@ description: "Merge feature work into develop only after local verification and 
 tags: pull-request, develop, ci, verification
 sources:
   - "references/raw/user-request.md"
-last_ingested: 2026-06-12
+last_ingested: 2026-09-01
 ---
 
 ## Develop Gate
@@ -40,6 +40,9 @@ gh pr merge --merge
 
 If checks fail, investigate the root cause in the failing logs and fix the
 feature branch. Do not bypass checks or merge a red PR.
+
+A green merge into `develop` is what starts the pre-release (`vX.Y.Z-pre.N`).
+See `release/release-pr.md`. It does not update Homebrew.
 
 ## Sources
 

--- a/skills/smart-worktree-flow/references/wiki/flow/pr/develop-gate.md
+++ b/skills/smart-worktree-flow/references/wiki/flow/pr/develop-gate.md
@@ -42,7 +42,8 @@ If checks fail, investigate the root cause in the failing logs and fix the
 feature branch. Do not bypass checks or merge a red PR.
 
 A green merge into `develop` is what starts the pre-release (`vX.Y.Z-pre.N`).
-See `release/release-pr.md`. It does not update Homebrew.
+See `release/release-pr.md`. It updates `humblskills-pre` only — not the
+stable `humblskills` formula.
 
 ## Sources
 

--- a/skills/smart-worktree-flow/references/wiki/flow/pr/main-gate.md
+++ b/skills/smart-worktree-flow/references/wiki/flow/pr/main-gate.md
@@ -7,7 +7,7 @@ description: "Honor auto-merge versus human review before production branch merg
 tags: pull-request, main, master, auto-merge, hitl
 sources:
   - "references/raw/user-request.md"
-last_ingested: 2026-06-12
+last_ingested: 2026-09-01
 ---
 
 ## Main Gate
@@ -37,6 +37,10 @@ gh pr checks --watch
 Prefer merge commits when release tooling such as release-please needs the
 original conventional commits on the production branch. Avoid squash-merging
 away the `feat:` or `fix:` commit that should drive the version bump.
+
+Merging `develop` into `main` is what promotes the pre-release
+(`vX.Y.Z-pre.N`) to the stable version and updates the Homebrew tap. The
+stable release PR appears after this merge; see `release/release-pr.md`.
 
 ## Sources
 

--- a/skills/smart-worktree-flow/references/wiki/flow/release/release-pr.md
+++ b/skills/smart-worktree-flow/references/wiki/flow/release/release-pr.md
@@ -44,10 +44,11 @@ gh pr merge <release-pr-number> --merge
 ```
 
 After the **develop** release PR merges, verify the `vX.Y.Z-pre.N` tag and that
-the GitHub Release is marked pre-release. Do not expect `brew upgrade`.
+the GitHub Release is marked pre-release. Do not run `brew upgrade` — there is
+no develop Homebrew channel.
 
-After the **main** release PR merges, verify the stable tag, release artifacts,
-and that
+After the **main** release PR merges, verify the stable tag and artifacts, then
+run `brew upgrade humblskills` as a **post-check**. Confirm
 [homebrew-humbl](https://github.com/jjfantini/homebrew-humbl) `Formula/humblskills.rb`
 matches that version before claiming the release is available.
 

--- a/skills/smart-worktree-flow/references/wiki/flow/release/release-pr.md
+++ b/skills/smart-worktree-flow/references/wiki/flow/release/release-pr.md
@@ -3,27 +3,36 @@ title: "Handle Generated Release PRs"
 context: flow
 category: release
 concept: release-pr
-description: "Decide whether the agent or user owns the release PR before the main merge"
-tags: release, release-please, version, brew
+description: "Develop cuts a pre-release; main cuts the stable version and updates brew"
+tags: release, release-please, version, brew, prerelease
 sources:
   - "references/raw/user-request.md"
-last_ingested: 2026-06-12
+last_ingested: 2026-09-01
 ---
 
-## Release PR
+## Two release PRs
 
-Some repos generate a release PR after `main` or `master` receives a
-conventional commit. The release PR usually updates changelog and version files;
-merging it cuts the tag and starts artifact publication.
+humblSKILLS release-please runs on both integration branches. Each opens its
+own release PR (changelog + `.release-please-manifest.json`). Merging the PR
+is what creates the tag and starts GoReleaser.
 
-Ask up front whether the user wants the agent to merge this PR on green checks.
-If they choose manual release review, stop after the release PR is ready and
+| Base | Tag | GitHub Release | Homebrew tap |
+|---|---|---|---|
+| `develop` | `vX.Y.Z-pre.N` | pre-release | not updated |
+| `main` | `vX.Y.Z` | latest / stable | `jjfantini/homebrew-humbl` formula bumped |
+
+Ask up front whether the user wants the agent to merge these PRs on green
+checks. If they choose manual release review, stop after each PR is ready and
 report its URL plus check state.
+
+Same-major bumps auto-merge when repo automation is enabled. A major bump
+(`2.x` → `3.0.0` or `3.0.0-pre.1`) is left for a human.
 
 **Incorrect:**
 
 ```bash
-# Main was merged, a release PR appeared, and the agent silently ignores it.
+# develop was merged, a pre-release PR appeared, and the agent silently ignores it.
+# Or: main was merged and brew is claimed updated before the stable release PR landed.
 ```
 
 **Correct:**
@@ -34,8 +43,13 @@ gh pr checks --watch <release-pr-number>
 gh pr merge <release-pr-number> --merge
 ```
 
-After the release PR merges, verify the tag, release workflow, package
-artifacts, and Homebrew tap update before claiming the release is available.
+After the **develop** release PR merges, verify the `vX.Y.Z-pre.N` tag and that
+the GitHub Release is marked pre-release. Do not expect `brew upgrade`.
+
+After the **main** release PR merges, verify the stable tag, release artifacts,
+and that
+[homebrew-humbl](https://github.com/jjfantini/homebrew-humbl) `Formula/humblskills.rb`
+matches that version before claiming the release is available.
 
 ## Sources
 

--- a/skills/smart-worktree-flow/references/wiki/flow/release/release-pr.md
+++ b/skills/smart-worktree-flow/references/wiki/flow/release/release-pr.md
@@ -18,8 +18,8 @@ is what creates the tag and starts GoReleaser.
 
 | Base | Tag | GitHub Release | Homebrew tap |
 |---|---|---|---|
-| `develop` | `vX.Y.Z-pre.N` | pre-release | not updated |
-| `main` | `vX.Y.Z` | latest / stable | `jjfantini/homebrew-humbl` formula bumped |
+| `develop` | `vX.Y.Z-pre.N` | pre-release | `humblskills-pre` only |
+| `main` | `vX.Y.Z` | latest / stable | `humblskills` (stable formula) |
 
 Ask up front whether the user wants the agent to merge these PRs on green
 checks. If they choose manual release review, stop after each PR is ready and
@@ -44,13 +44,20 @@ gh pr merge <release-pr-number> --merge
 ```
 
 After the **develop** release PR merges, verify the `vX.Y.Z-pre.N` tag and that
-the GitHub Release is marked pre-release. Do not run `brew upgrade` — there is
-no develop Homebrew channel.
+the GitHub Release is marked pre-release. Optional tester check:
+`brew upgrade humblskills-pre` (or `humblskills upgrade --channel beta`). Do
+**not** run `brew upgrade humblskills` — that formula must stay on the last
+stable.
 
 After the **main** release PR merges, verify the stable tag and artifacts, then
 run `brew upgrade humblskills` as a **post-check**. Confirm
 [homebrew-humbl](https://github.com/jjfantini/homebrew-humbl) `Formula/humblskills.rb`
 matches that version before claiming the release is available.
+
+Users switch channels with the same profile field Homebrew and `upgrade` read:
+`humblskills profile set channel beta`, `profile get channel`, or the existing
+Profile TUI (`humblskills` → Profile → **install channel**). Unset means
+stable.
 
 ## Sources
 

--- a/skills/smart-worktree-flow/references/wiki/flow/setup/intent-gathering.md
+++ b/skills/smart-worktree-flow/references/wiki/flow/setup/intent-gathering.md
@@ -7,7 +7,7 @@ description: "Ask the routing questions once so the agent can execute without gu
 tags: intent, vibe, hitl, defaults
 sources:
   - "references/raw/user-request.md"
-last_ingested: 2026-06-12
+last_ingested: 2026-09-01
 ---
 
 ## Intent Gathering
@@ -22,11 +22,15 @@ Ask these questions before work:
 2. Is parallel work happening in this repo, including other Codex, Claude, or
    Cursor agents?
 3. Should the `develop` -> `main` or `master` PR auto-merge on green checks?
-4. Should the generated release PR auto-merge on green checks?
+4. Should the generated release PRs auto-merge on green checks? There are two:
+   develop cuts `vX.Y.Z-pre.N` (GitHub pre-release, no brew); main cuts the
+   real `vX.Y.Z` and updates the Homebrew tap. `brew upgrade` is a post-check
+   after the main stable only.
 5. Should stale worktrees and branches be cleaned up at the end?
 
 If the user defers, use: Vibe mode, worktree isolation, auto-merge on green,
-release PR auto-merge on green, cleanup enabled.
+both release PRs auto-merge on green, brew post-check after main, cleanup
+enabled.
 
 **Incorrect:**
 
@@ -38,7 +42,8 @@ I'll just start coding and figure out the merge path after CI.
 
 ```markdown
 Defaulting because you deferred: Vibe mode, worktree isolation, auto-merge
-main and release PR on green checks, cleanup enabled.
+develop→main and both release PRs on green checks, brew post-check after
+main only, cleanup enabled.
 ```
 
 Before finalizing the worktree choice, also inspect local reality with

--- a/skills/smart-worktree-flow/references/wiki/flow/setup/intent-gathering.md
+++ b/skills/smart-worktree-flow/references/wiki/flow/setup/intent-gathering.md
@@ -23,9 +23,9 @@ Ask these questions before work:
    Cursor agents?
 3. Should the `develop` -> `main` or `master` PR auto-merge on green checks?
 4. Should the generated release PRs auto-merge on green checks? There are two:
-   develop cuts `vX.Y.Z-pre.N` (GitHub pre-release, no brew); main cuts the
-   real `vX.Y.Z` and updates the Homebrew tap. `brew upgrade` is a post-check
-   after the main stable only.
+   develop cuts `vX.Y.Z-pre.N` (GitHub pre-release + `humblskills-pre` formula);
+   main cuts the real `vX.Y.Z` and updates the stable `humblskills` formula.
+   `brew upgrade humblskills` is a post-check after the main stable only.
 5. Should stale worktrees and branches be cleaned up at the end?
 
 If the user defers, use: Vibe mode, worktree isolation, auto-merge on green,


### PR DESCRIPTION
## Summary
- One `release.yml`, two release-please configs, one manifest: `develop` cuts `vX.Y.Z-pre.N` GitHub pre-releases (archives only, no Homebrew); `main` cuts stable `vX.Y.Z` + binaries + `jjfantini/homebrew-humbl`.
- Dropped `last-release-sha` and unused `skip-github-pull-request`. Kept the major-bump auto-merge guard, PAT retrigger, sibling `cli/v*` tags, and `sync-develop`.
- In-repo `smart-worktree-flow` now matches this path. Brew stays a post-check after main.

## Why
Today all shipping is main-only. `develop` produced no tags. The tap was already automated on stables; the mess was incident glue around a phantom v3.0.0 and bots committing on main.

## Test plan
- [ ] After merge to `develop`, confirm release-please opens a `v2.52.0-pre…` PR (live test)
- [ ] Merge that pre-release PR: GitHub Release is prerelease, no tap commit
- [ ] `brew info jjfantini/humbl/humblskills` still on the last stable
- [ ] Promote `develop` → `main` (merge commit) only when the pre line should become real and move brew
- [ ] CI runs on `push: develop`