### PR TITLE
fix(upgrade): beta channel picks highest semver, not latest pre

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,14 @@ brew upgrade humblskills-pre
 ```
 
 The CLI install channel is one field in `~/.humblskills/profile.json`
-(`channel`: `stable` or `beta`; unset means stable). Read or change it with
-`humblskills profile get channel` / `profile set channel beta`, the existing
-Profile TUI (`humblskills` → Profile → **install channel**), or a one-shot
-`humblskills upgrade --channel beta`. Same field Homebrew and `upgrade` use.
+(`channel`: `stable` or `beta`; unset means stable). **beta** is always the
+newest version (higher of latest stable vs latest prerelease) — not
+prereleases only. After a stable graduates, a Homebrew `humblskills-pre`
+install is switched with `brew uninstall humblskills-pre && brew install
+humblskills`. Read or change the field with `humblskills profile get channel`
+/ `profile set channel beta`, the existing Profile TUI (`humblskills` →
+Profile → **install channel**), or a one-shot `humblskills upgrade --channel
+beta`.
 
 Formulas live in [`jjfantini/homebrew-humbl`](https://github.com/jjfantini/homebrew-humbl)
 and are bumped by GoReleaser: `humblskills` on stable tags, `humblskills-pre`

--- a/cli/cmd/humblskills/cli_testutil_test.go
+++ b/cli/cmd/humblskills/cli_testutil_test.go
@@ -8,8 +8,17 @@ import (
 	"testing"
 
 	"github.com/jjfantini/humblSKILLS/cli/v2/internal/registry"
+	"github.com/jjfantini/humblSKILLS/cli/v2/internal/selfupdate"
 	"github.com/jjfantini/humblSKILLS/cli/v2/internal/testutil"
 )
+
+// TestMain disables GitHub notice checks for the rest of the command
+// suite. Tests that exercise the notice re-enable the network and point
+// GitHubAPIBase at an httptest server.
+func TestMain(m *testing.M) {
+	selfupdate.SkipNetwork = true
+	os.Exit(m.Run())
+}
 
 // execResult captures stdout/stderr and the error Cobra surfaced.
 type execResult struct {

--- a/cli/cmd/humblskills/doctor.go
+++ b/cli/cmd/humblskills/doctor.go
@@ -64,6 +64,7 @@ func runDoctor(app *App) error {
 				return err
 			}
 			if !rerun {
+				app.printUpgradeNotice()
 				break
 			}
 			report, err = tui.RunWithLoading(app.UI.Theme(), "rescanning…", func() (doctorReport, error) {
@@ -74,6 +75,7 @@ func runDoctor(app *App) error {
 			}
 		}
 	} else {
+		app.printUpgradeNotice()
 		printDoctorStatic(app, report)
 	}
 

--- a/cli/cmd/humblskills/list.go
+++ b/cli/cmd/humblskills/list.go
@@ -59,6 +59,7 @@ func runList(app *App, fromDashboard bool) error {
 	if tui.ShouldUseTUI(app.Config.JSON, app.Config.Quiet, app.Config.Yes) {
 		return runListTUI(app, m, fromDashboard)
 	}
+	app.printUpgradeNotice()
 	renderListTable(app, installs, avail)
 	return nil
 }

--- a/cli/cmd/humblskills/notice.go
+++ b/cli/cmd/humblskills/notice.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"github.com/jjfantini/humblSKILLS/cli/v2/internal/profile"
+	"github.com/jjfantini/humblSKILLS/cli/v2/internal/selfupdate"
+	"github.com/jjfantini/humblSKILLS/cli/v2/internal/tui"
+)
+
+// checkUpgradeNotice resolves the profile/--channel stream the same way
+// upgrade does and asks selfupdate.Check whether a newer GitHub release
+// exists. JSON and quiet stay silent; failures stay silent.
+func (a *App) checkUpgradeNotice() selfupdate.Notice {
+	if a == nil || a.Config.JSON || a.Config.Quiet {
+		return selfupdate.Notice{}
+	}
+	exePath, err := osExecutable()
+	if err != nil {
+		return selfupdate.Notice{}
+	}
+	return selfupdate.Check(selfupdate.CheckOptions{
+		Client:         selfupdate.NewNoticeHTTPClient(),
+		CurrentVersion: resolveVersion().Version,
+		ExePath:        exePath,
+		Channel:        a.resolvedNoticeChannel(),
+		CacheDir:       a.Config.CacheDir,
+	})
+}
+
+// resolvedNoticeChannel is upgrade --channel → profile → stable. Profile
+// load errors fall back to stable so a notice check never fails a command.
+func (a *App) resolvedNoticeChannel() string {
+	if flag := a.upgradeChannelFlag(); flag != "" {
+		return flag
+	}
+	p, err := profile.Load(a.Config.ProfilePath)
+	if err != nil || p == nil {
+		return profile.ChannelStable
+	}
+	return p.ResolvedChannel()
+}
+
+// upgradeChannelFlag is the persistent --channel override when present.
+// Empty means "use the profile".
+func (a *App) upgradeChannelFlag() string {
+	return a.Config.Channel
+}
+
+// printUpgradeNotice writes the CLI banner to stderr (via Warn) when a
+// newer channel release exists. --json and --quiet suppress it.
+func (a *App) printUpgradeNotice() {
+	n := a.checkUpgradeNotice()
+	if !n.Available {
+		return
+	}
+	a.UI.Warn("%s", n.CLILine())
+}
+
+// tuiVersionNotice is the dashboard banner payload, or nil when quiet.
+func (a *App) tuiVersionNotice() *tui.VersionNotice {
+	n := a.checkUpgradeNotice()
+	if !n.Available {
+		return nil
+	}
+	return &tui.VersionNotice{
+		Current: selfupdate.DisplayVersion(n.CurrentVersion),
+		Latest:  selfupdate.DisplayVersion(n.LatestVersion),
+		Channel: n.Channel,
+		Command: n.UpdateCommand(),
+	}
+}

--- a/cli/cmd/humblskills/notice_test.go
+++ b/cli/cmd/humblskills/notice_test.go
@@ -1,0 +1,163 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jjfantini/humblSKILLS/cli/v2/internal/profile"
+	"github.com/jjfantini/humblSKILLS/cli/v2/internal/selfupdate"
+	"github.com/jjfantini/humblSKILLS/cli/v2/internal/testutil"
+	"github.com/jjfantini/humblSKILLS/cli/v2/internal/ui"
+)
+
+func withNoticeNetwork(t *testing.T) {
+	t.Helper()
+	prev := selfupdate.SkipNetwork
+	selfupdate.SkipNetwork = false
+	t.Cleanup(func() { selfupdate.SkipNetwork = prev })
+}
+
+func TestNotice_VersionStderr_StableBehind(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	withNoticeNetwork(t)
+	startFakeReleaseAPI(t, "99.0.0", "fake")
+
+	res := runCLIWithStdoutCapture(t, "version", "--profile", s.ProfilePath, "--cache-dir", s.CacheDir)
+	if res.RunErr != nil {
+		t.Fatalf("run: %v\nerr: %s", res.RunErr, res.Err)
+	}
+	if !strings.Contains(res.Err, "newer version available") {
+		t.Errorf("stderr missing notice:\n%s", res.Err)
+	}
+	if !strings.Contains(res.Err, "humblskills upgrade") {
+		t.Errorf("stderr missing upgrade command:\n%s", res.Err)
+	}
+	if strings.Contains(res.Out, "newer version available") {
+		t.Error("notice must go to stderr, not stdout")
+	}
+}
+
+func TestNotice_JSONStaysQuiet(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	withNoticeNetwork(t)
+	startFakeReleaseAPI(t, "99.0.0", "fake")
+
+	res := runCLIWithStdoutCapture(t, "version", "--json", "--profile", s.ProfilePath, "--cache-dir", s.CacheDir)
+	if res.RunErr != nil {
+		t.Fatalf("run: %v\nerr: %s", res.RunErr, res.Err)
+	}
+	if strings.Contains(res.Err, "newer version available") {
+		t.Errorf("--json must stay quiet, stderr:\n%s", res.Err)
+	}
+	var info versionInfo
+	if err := json.Unmarshal([]byte(strings.TrimSpace(res.Out)), &info); err != nil {
+		t.Fatalf("version --json: %v", err)
+	}
+}
+
+func TestNotice_ChannelFlag_BetaPicksStableWinner(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	withNoticeNetwork(t)
+	startFakeChannelAPI(t, "2.52.0", "2.52.0-pre.1")
+	withFakeExecutable(t, "/opt/homebrew/Cellar/humblskills-pre/2.52.0-pre.1/bin/humblskills")
+
+	res := runCLIWithStdoutCapture(t,
+		"version", "--channel", "beta",
+		"--profile", s.ProfilePath, "--cache-dir", s.CacheDir,
+	)
+	if res.RunErr != nil {
+		t.Fatalf("run: %v\nerr: %s", res.RunErr, res.Err)
+	}
+	if !strings.Contains(res.Err, "v2.52.0") {
+		t.Errorf("beta notice should pick stable 2.52.0:\n%s", res.Err)
+	}
+	if !strings.Contains(res.Err, "brew uninstall humblskills-pre && brew install humblskills") {
+		t.Errorf("beta notice should document the brew formula switch:\n%s", res.Err)
+	}
+	if strings.Contains(res.Err, "brew upgrade humblskills-pre") {
+		t.Errorf("must not recommend brew upgrade pre when stable won:\n%s", res.Err)
+	}
+}
+
+func TestNotice_ProfileChannel_BetaPicksNewerPre(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	if err := profile.Save(s.ProfilePath, &profile.Profile{Channel: profile.ChannelBeta}); err != nil {
+		t.Fatal(err)
+	}
+	withNoticeNetwork(t)
+	startFakeChannelAPI(t, "2.52.0", "2.53.0-pre.1")
+
+	res := runCLIWithStdoutCapture(t,
+		"version", "--profile", s.ProfilePath, "--cache-dir", s.CacheDir,
+	)
+	if res.RunErr != nil {
+		t.Fatalf("run: %v\nerr: %s", res.RunErr, res.Err)
+	}
+	if !strings.Contains(res.Err, "2.53.0-pre.1") {
+		t.Errorf("profile beta should pick newer pre:\n%s", res.Err)
+	}
+}
+
+func TestNotice_DoctorUsesSameResolver(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	withNoticeNetwork(t)
+	startFakeReleaseAPI(t, "99.0.0", "fake")
+
+	res := runCLIWithStdoutCapture(t, "doctor", "--yes", "--profile", s.ProfilePath, "--cache-dir", s.CacheDir)
+	if res.RunErr != nil {
+		t.Fatalf("run: %v\nerr: %s", res.RunErr, res.Err)
+	}
+	if !strings.Contains(res.Err, "newer version available") {
+		t.Errorf("doctor stderr missing notice:\n%s", res.Err)
+	}
+}
+
+func TestTuiVersionNotice_UsesResolver(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	withNoticeNetwork(t)
+	startFakeChannelAPI(t, "2.52.0", "2.52.0-pre.1")
+	exe := filepath.Join(s.Root, "Cellar", "humblskills-pre", "2.52.0-pre.1", "bin", "humblskills")
+	if err := os.MkdirAll(filepath.Dir(exe), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(exe, []byte("x"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	withFakeExecutable(t, exe)
+
+	app := &App{
+		UI: ui.New(ui.Options{}),
+		Config: Config{
+			ProfilePath: s.ProfilePath,
+			CacheDir:    s.CacheDir,
+			Channel:     profile.ChannelBeta,
+		},
+	}
+	n := app.tuiVersionNotice()
+	if n == nil {
+		t.Fatal("expected dashboard notice")
+	}
+	if n.Latest != "v2.52.0" {
+		t.Errorf("Latest = %q, want v2.52.0", n.Latest)
+	}
+	if n.Channel != profile.ChannelBeta {
+		t.Errorf("Channel = %q, want beta", n.Channel)
+	}
+	if n.Command != "brew uninstall humblskills-pre && brew install humblskills" {
+		t.Errorf("Command = %q", n.Command)
+	}
+}
+
+func TestNotice_SkipNetworkKeepsQuiet(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	res := runCLIWithStdoutCapture(t, "version", "--profile", s.ProfilePath)
+	if res.RunErr != nil {
+		t.Fatalf("run: %v", res.RunErr)
+	}
+	if strings.Contains(res.Err, "newer version available") {
+		t.Errorf("SkipNetwork should keep version quiet:\n%s", res.Err)
+	}
+}

--- a/cli/cmd/humblskills/notice_test.go
+++ b/cli/cmd/humblskills/notice_test.go
@@ -62,7 +62,14 @@ func TestNotice_ChannelFlag_BetaPicksStableWinner(t *testing.T) {
 	s := testutil.NewSandbox(t)
 	withNoticeNetwork(t)
 	startFakeChannelAPI(t, "2.52.0", "2.52.0-pre.1")
-	withFakeExecutable(t, "/opt/homebrew/Cellar/humblskills-pre/2.52.0-pre.1/bin/humblskills")
+	exe := filepath.Join(s.Root, "Cellar", "humblskills-pre", "2.52.0-pre.1", "bin", "humblskills")
+	if err := os.MkdirAll(filepath.Dir(exe), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(exe, []byte("x"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	withFakeExecutable(t, exe)
 
 	res := runCLIWithStdoutCapture(t,
 		"version", "--channel", "beta",
@@ -74,8 +81,16 @@ func TestNotice_ChannelFlag_BetaPicksStableWinner(t *testing.T) {
 	if !strings.Contains(res.Err, "v2.52.0") {
 		t.Errorf("beta notice should pick stable 2.52.0:\n%s", res.Err)
 	}
-	if !strings.Contains(res.Err, "brew uninstall humblskills-pre && brew install humblskills") {
-		t.Errorf("beta notice should document the brew formula switch:\n%s", res.Err)
+	// Homebrew detection looks for "/Cellar/" — filepath.Join uses backslash
+	// on Windows, so that install is a GitHub binary there. Assert the
+	// command the same helper production uses, not a brew string on Windows.
+	want := selfupdate.RecommendedUpgradeCommand(
+		selfupdate.IsHomebrewManaged(exe),
+		selfupdate.InstalledFormula(exe),
+		selfupdate.FormulaForVersion("2.52.0"),
+	)
+	if !strings.Contains(res.Err, want) {
+		t.Errorf("notice missing %q:\n%s", want, res.Err)
 	}
 	if strings.Contains(res.Err, "brew upgrade humblskills-pre") {
 		t.Errorf("must not recommend brew upgrade pre when stable won:\n%s", res.Err)
@@ -146,8 +161,16 @@ func TestTuiVersionNotice_UsesResolver(t *testing.T) {
 	if n.Channel != profile.ChannelBeta {
 		t.Errorf("Channel = %q, want beta", n.Channel)
 	}
-	if n.Command != "brew uninstall humblskills-pre && brew install humblskills" {
-		t.Errorf("Command = %q", n.Command)
+	// filepath.Join(s.Root, "Cellar", ...) is Homebrew on Unix ("/Cellar/")
+	// and a plain GitHub install on Windows ("\Cellar\"). Same helper
+	// upgrade/notices use — don't assert brew commands where brew isn't.
+	want := selfupdate.RecommendedUpgradeCommand(
+		selfupdate.IsHomebrewManaged(exe),
+		selfupdate.InstalledFormula(exe),
+		selfupdate.FormulaForVersion("2.52.0"),
+	)
+	if n.Command != want {
+		t.Errorf("Command = %q, want %q", n.Command, want)
 	}
 }
 

--- a/cli/cmd/humblskills/profile.go
+++ b/cli/cmd/humblskills/profile.go
@@ -155,6 +155,7 @@ func runProfileShow(app *App) error {
 	if app.Config.JSON {
 		return app.UI.JSON(p)
 	}
+	app.printUpgradeNotice()
 	th := app.UI.Theme()
 	app.UI.Header("profile")
 	app.UI.Section("Defaults")
@@ -416,8 +417,9 @@ func formatGroupByCategory(flag *bool) string {
 }
 
 // parseChannel parses `profile set channel`: "default"/"" resets to unset
-// (stable), "stable" stores the explicit stable value, "beta" follows
-// prereleases. Same field Homebrew and `upgrade --channel` read.
+// (stable), "stable" stores the explicit stable value, "beta" follows the
+// newer of latest stable vs latest prerelease. Same field Homebrew and
+// `upgrade --channel` read.
 func parseChannel(value string) (string, error) {
 	switch strings.ToLower(strings.TrimSpace(value)) {
 	case "default", "":

--- a/cli/cmd/humblskills/root.go
+++ b/cli/cmd/humblskills/root.go
@@ -57,6 +57,10 @@ type Config struct {
 	Quiet         bool
 	Yes           bool
 	Fullscreen    bool
+	// Channel is the --channel override (stable|beta). Empty means use
+	// the profile field (itself stable when unset) — the same resolution
+	// `upgrade` already uses.
+	Channel string
 }
 
 type globalFlags struct {
@@ -71,6 +75,7 @@ type globalFlags struct {
 	quiet      bool
 	yes        bool
 	fullscreen bool
+	channel    string
 }
 
 func newRootCmd() *cobra.Command {
@@ -107,6 +112,8 @@ func newRootCmd() *cobra.Command {
 	f.BoolVarP(&g.quiet, "quiet", "q", false, "suppress non-error output")
 	f.BoolVarP(&g.yes, "yes", "y", false, "skip confirmation prompts (auto-accept)")
 	f.BoolVar(&g.fullscreen, "fullscreen", false, "open the interactive dashboard in full-screen TUI mode")
+	f.StringVar(&g.channel, "channel", "", "release channel for this run: stable|beta (default: profile channel, itself stable unless set)")
+	_ = cmd.RegisterFlagCompletionFunc("channel", cobra.FixedCompletions([]string{profile.ChannelStable, profile.ChannelBeta}, cobra.ShellCompDirectiveNoFileComp))
 
 	cmd.AddCommand(
 		newStartCmd(app),
@@ -134,6 +141,9 @@ func newRootCmd() *cobra.Command {
 func configureApp(_ *cobra.Command, app *App, g globalFlags) error {
 	if g.quiet && g.verbose {
 		return fmt.Errorf("--quiet and --verbose are mutually exclusive")
+	}
+	if g.channel != "" && g.channel != profile.ChannelStable && g.channel != profile.ChannelBeta {
+		return fmt.Errorf("invalid --channel %q — valid: stable, beta", g.channel)
 	}
 
 	level := ui.LevelNormal
@@ -186,6 +196,7 @@ func configureApp(_ *cobra.Command, app *App, g globalFlags) error {
 		Quiet:         g.quiet,
 		Yes:           g.yes,
 		Fullscreen:    g.fullscreen,
+		Channel:       g.channel,
 	}
 
 	cacheDir, err := resolveCacheDir(textutil.FirstNonEmpty(g.cacheDir, os.Getenv("HUMBLSKILLS_CACHE_DIR")))

--- a/cli/cmd/humblskills/search.go
+++ b/cli/cmd/humblskills/search.go
@@ -88,6 +88,7 @@ func newSearchCmd(app *App) *cobra.Command {
 				}{query, category, role, hits})
 			}
 			if len(hits) == 0 {
+				app.printUpgradeNotice()
 				app.UI.Warn("no skills matched %q", query)
 				return nil
 			}
@@ -99,6 +100,7 @@ func newSearchCmd(app *App) *cobra.Command {
 				return runSearchTUI(app, hits, false)
 			}
 
+			app.printUpgradeNotice()
 			app.UI.Println(renderSearchResults(app.UI.Theme(), hits, query))
 			return nil
 		},

--- a/cli/cmd/humblskills/start.go
+++ b/cli/cmd/humblskills/start.go
@@ -67,6 +67,9 @@ func runStart(app *App) error {
 			Version: resolveVersion().Version,
 			Status:  status,
 			Tiles:   tui.DefaultDashboardTiles(),
+			CheckNotice: func() *tui.VersionNotice {
+				return app.tuiVersionNotice()
+			},
 		}
 		res, err := tui.RunDashboard(cfg)
 		if err != nil {
@@ -249,6 +252,7 @@ func (a *App) headerMeta(fallback string) string {
 }
 
 func printStartFallback(app *App) error {
+	app.printUpgradeNotice()
 	th := app.UI.Theme()
 	out := app.UI.Out()
 	fmt.Fprintln(out)

--- a/cli/cmd/humblskills/upgrade.go
+++ b/cli/cmd/humblskills/upgrade.go
@@ -37,13 +37,14 @@ var applyPhaseSteps = map[selfupdate.Phase]tui.UpgradeStep{
 	selfupdate.PhaseDownloading:   tui.UpgradeStepDownloading,
 	selfupdate.PhaseVerifyingSum:  tui.UpgradeStepVerifyingChecksum,
 	selfupdate.PhaseInstalling:    tui.UpgradeStepInstalling,
-	selfupdate.PhaseBrewUpdating:  tui.UpgradeStepBrewUpdating,
-	selfupdate.PhaseBrewUpgrading: tui.UpgradeStepBrewUpgrading,
+	selfupdate.PhaseBrewUpdating:     tui.UpgradeStepBrewUpdating,
+	selfupdate.PhaseBrewUpgrading:    tui.UpgradeStepBrewUpgrading,
+	selfupdate.PhaseBrewUninstalling: tui.UpgradeStepBrewUninstalling,
+	selfupdate.PhaseBrewInstalling:   tui.UpgradeStepBrewInstalling,
 }
 
 type upgradeFlags struct {
-	dryRun  bool
-	channel string // one-shot override; empty means use the profile (default stable)
+	dryRun bool
 }
 
 // upgradeResult is both the --json payload and the source of truth the
@@ -60,6 +61,7 @@ type upgradeResult struct {
 	InstalledVersion string `json:"installedVersion,omitempty"`
 	Channel          string `json:"channel"`
 	Formula          string `json:"formula,omitempty"`
+	BrewHint         string `json:"brewHint,omitempty"`
 }
 
 func newUpgradeCmd(app *App) *cobra.Command {
@@ -69,13 +71,16 @@ func newUpgradeCmd(app *App) *cobra.Command {
 		Short: "Upgrade the humblskills CLI itself to the latest release",
 		Long: "upgrade checks GitHub releases for a newer humblskills CLI build, " +
 			"downloads it, verifies its checksum, and swaps it onto the running " +
-			"binary's path. Installs managed by Homebrew are upgraded via " +
-			"`brew upgrade <formula>` instead, so Homebrew's own bookkeeping " +
-			"stays correct. The formula and GitHub endpoint come from the " +
-			"profile channel (stable by default): stable → /releases/latest + " +
-			"`humblskills`; beta → latest prerelease + `humblskills-pre`. " +
-			"--channel overrides the profile for this run only. --dry-run " +
-			"reports the version you'd upgrade to without changing anything.\n\n" +
+			"binary's path. Installs managed by Homebrew are upgraded via brew " +
+			"instead, so Homebrew's own bookkeeping stays correct. The profile " +
+			"channel (stable by default) picks the GitHub release: stable → " +
+			"/releases/latest only; beta → the higher semver of latest stable " +
+			"vs latest prerelease. The brew formula follows that winner — " +
+			"`brew upgrade humblskills` / `humblskills-pre`, or " +
+			"`brew uninstall humblskills-pre && brew install humblskills` " +
+			"when beta's winner is a graduated stable. --channel overrides " +
+			"the profile for this run only. --dry-run reports the version " +
+			"you'd upgrade to without changing anything.\n\n" +
 			"This upgrades the CLI binary itself. To upgrade installed skills, " +
 			"use `humblskills update`.",
 		Args: cobra.NoArgs,
@@ -84,8 +89,6 @@ func newUpgradeCmd(app *App) *cobra.Command {
 		},
 	}
 	cmd.Flags().BoolVar(&f.dryRun, "dry-run", false, "show the version you'd upgrade to without changing anything")
-	cmd.Flags().StringVar(&f.channel, "channel", "", "release channel for this run: stable|beta (default: profile channel, itself stable unless set)")
-	_ = cmd.RegisterFlagCompletionFunc("channel", cobra.FixedCompletions([]string{profile.ChannelStable, profile.ChannelBeta}, cobra.ShellCompDirectiveNoFileComp))
 	return cmd
 }
 
@@ -96,7 +99,7 @@ func runUpgrade(app *App, f upgradeFlags) error {
 		return fmt.Errorf("resolve own executable path: %w", err)
 	}
 
-	channel, err := resolveUpgradeChannel(app, f.channel)
+	channel, err := resolveUpgradeChannel(app)
 	if err != nil {
 		return err
 	}
@@ -122,6 +125,7 @@ func runUpgrade(app *App, f upgradeFlags) error {
 		DryRun:           f.dryRun,
 		Channel:          plan.Channel,
 		Formula:          plan.Formula,
+		BrewHint:         plan.BrewHint,
 	}
 
 	if !plan.UpgradeAvailable || f.dryRun {
@@ -144,6 +148,7 @@ func runUpgrade(app *App, f upgradeFlags) error {
 
 	res.Applied = true
 	res.InstalledVersion = installed
+	selfupdate.InvalidateNoticeCache(app.Config.CacheDir)
 	return finishUpgrade(app, res)
 }
 
@@ -163,7 +168,7 @@ func finishUpgrade(app *App, res upgradeResult) error {
 	case !res.UpgradeAvailable:
 		app.UI.Success("humblskills is already up to date (%s)", versionTag(res.CurrentVersion))
 	case res.DryRun && res.Homebrew:
-		app.UI.Info("%s → %s available — Homebrew-managed install detected; would run `brew upgrade %s`", versionTag(res.CurrentVersion), versionTag(res.LatestVersion), brewFormula(res))
+		app.UI.Info("%s → %s available — Homebrew-managed install detected; would run `%s`", versionTag(res.CurrentVersion), versionTag(res.LatestVersion), brewHint(res))
 	case res.DryRun:
 		app.UI.Info("%s → %s available — run without --dry-run to upgrade", versionTag(res.CurrentVersion), versionTag(res.LatestVersion))
 	}
@@ -187,15 +192,19 @@ func brewFormula(res upgradeResult) string {
 	if res.Formula != "" {
 		return res.Formula
 	}
-	return selfupdate.FormulaForChannel(res.Channel)
+	return selfupdate.FormulaForVersion(res.LatestVersion)
 }
 
-func resolveUpgradeChannel(app *App, flag string) (string, error) {
-	if flag != "" {
-		if flag != profile.ChannelStable && flag != profile.ChannelBeta {
-			return "", fmt.Errorf("invalid --channel %q — valid: stable, beta", flag)
-		}
-		return flag, nil
+func brewHint(res upgradeResult) string {
+	if res.BrewHint != "" {
+		return res.BrewHint
+	}
+	return selfupdate.RecommendedUpgradeCommand(res.Homebrew, "", brewFormula(res))
+}
+
+func resolveUpgradeChannel(app *App) (string, error) {
+	if app.Config.Channel != "" {
+		return app.Config.Channel, nil
 	}
 	p, err := profile.Load(app.Config.ProfilePath)
 	if err != nil {
@@ -207,11 +216,17 @@ func resolveUpgradeChannel(app *App, flag string) (string, error) {
 func applyHomebrewUpgrade(app *App, plan *selfupdate.Plan, exePath string) (string, error) {
 	formula := plan.Formula
 	if formula == "" {
-		formula = selfupdate.FormulaForChannel(plan.Channel)
+		formula = selfupdate.FormulaForVersion(plan.LatestVersion)
 	}
-	app.UI.Info("Homebrew-managed install detected — upgrading via `brew upgrade %s`", formula)
+	action := selfupdate.PlanBrewAction(plan.CurrentFormula, formula)
+	hint := action.Hint()
+	if plan.SwitchFormula {
+		app.UI.Info("Homebrew-managed install detected — switching %s → %s via `%s`", plan.CurrentFormula, formula, hint)
+	} else {
+		app.UI.Info("Homebrew-managed install detected — upgrading via `%s`", hint)
+	}
 
-	ok, err := app.Prompt.Confirm(fmt.Sprintf("Run brew upgrade %s now?", formula), true)
+	ok, err := app.Prompt.Confirm(fmt.Sprintf("Run `%s` now?", hint), true)
 	if err != nil {
 		return "", err
 	}
@@ -220,6 +235,9 @@ func applyHomebrewUpgrade(app *App, plan *selfupdate.Plan, exePath string) (stri
 	}
 
 	steps := []tui.UpgradeStep{tui.UpgradeStepBrewUpdating, tui.UpgradeStepBrewUpgrading, tui.UpgradeStepVerifyingInstall}
+	if action.NeedsSwitch() {
+		steps = []tui.UpgradeStep{tui.UpgradeStepBrewUpdating, tui.UpgradeStepBrewUninstalling, tui.UpgradeStepBrewInstalling, tui.UpgradeStepVerifyingInstall}
+	}
 	useTUI := tui.ShouldUseTUI(app.Config.JSON, app.Config.Quiet, app.Config.Yes)
 
 	var installed string
@@ -234,15 +252,21 @@ func applyHomebrewUpgrade(app *App, plan *selfupdate.Plan, exePath string) (stri
 				sink(tui.UpgradeEvent{Step: step})
 			}
 		}
-		if err := selfupdate.Upgrade(context.Background(), brewRunner, stdout, stderr, brewSink, formula); err != nil {
+		if err := selfupdate.ApplyBrew(context.Background(), brewRunner, stdout, stderr, brewSink, action); err != nil {
 			if errors.Is(err, selfupdate.ErrBrewNotFound) {
-				return fmt.Errorf("brew not found on PATH — run `brew update && brew upgrade %s` yourself: %w", formula, err)
+				return fmt.Errorf("brew not found on PATH — run `%s` yourself: %w", hint, err)
 			}
-			return fmt.Errorf("brew upgrade %s: %w", formula, err)
+			return fmt.Errorf("%s: %w", hint, err)
 		}
 
 		sink(tui.UpgradeEvent{Step: tui.UpgradeStepVerifyingInstall})
-		v, err := selfupdate.VerifyInstalledVersion(exePath)
+		verifyPath := exePath
+		if action.NeedsSwitch() {
+			if linked := selfupdate.HomebrewLinkedBinary(exePath); linked != "" {
+				verifyPath = linked
+			}
+		}
+		v, err := selfupdate.VerifyInstalledVersion(verifyPath)
 		if err != nil {
 			return fmt.Errorf("verify installed version: %w", err)
 		}

--- a/cli/cmd/humblskills/upgrade_test.go
+++ b/cli/cmd/humblskills/upgrade_test.go
@@ -362,7 +362,6 @@ func startFakePrereleaseAPI(t *testing.T, preVersion, binaryContent string) {
 	var srv *httptest.Server
 	mux := http.NewServeMux()
 	mux.HandleFunc("/repos/"+selfupdate.DefaultRepo+"/releases/latest", func(w http.ResponseWriter, r *http.Request) {
-		t.Error("beta channel must not hit /releases/latest")
 		w.WriteHeader(http.StatusNotFound)
 	})
 	mux.HandleFunc("/repos/"+selfupdate.DefaultRepo+"/releases", func(w http.ResponseWriter, r *http.Request) {
@@ -535,6 +534,183 @@ func TestUpgrade_HomebrewManaged_BetaRunsPreFormula(t *testing.T) {
 	}
 	if got.Formula != selfupdate.FormulaPre {
 		t.Errorf("Formula = %q, want %s", got.Formula, selfupdate.FormulaPre)
+	}
+	if !got.Applied {
+		t.Errorf("expected Applied = true, got %+v", got)
+	}
+}
+
+func startFakeChannelAPI(t *testing.T, stableVersion, preVersion string) {
+	t.Helper()
+	stableAsset, err := selfupdate.CurrentAssetName(stableVersion)
+	if err != nil {
+		t.Fatalf("CurrentAssetName stable: %v", err)
+	}
+	preAsset, err := selfupdate.CurrentAssetName(preVersion)
+	if err != nil {
+		t.Fatalf("CurrentAssetName pre: %v", err)
+	}
+	var srv *httptest.Server
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/"+selfupdate.DefaultRepo+"/releases/latest", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"tag_name": "v` + stableVersion + `",
+			"prerelease": false,
+			"assets": [
+				{"name": "` + stableAsset + `", "browser_download_url": "` + srv.URL + `/assets/` + stableAsset + `"},
+				{"name": "checksums.txt", "browser_download_url": "` + srv.URL + `/assets/checksums.txt"}
+			]
+		}`))
+	})
+	mux.HandleFunc("/repos/"+selfupdate.DefaultRepo+"/releases", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[
+			{"tag_name": "v` + stableVersion + `", "prerelease": false, "draft": false,
+			 "assets": [
+			   {"name": "` + stableAsset + `", "browser_download_url": "` + srv.URL + `/assets/` + stableAsset + `"},
+			   {"name": "checksums.txt", "browser_download_url": "` + srv.URL + `/assets/checksums.txt"}
+			 ]},
+			{"tag_name": "v` + preVersion + `", "prerelease": true, "draft": false,
+			 "assets": [
+			   {"name": "` + preAsset + `", "browser_download_url": "` + srv.URL + `/assets/` + preAsset + `"},
+			   {"name": "checksums.txt", "browser_download_url": "` + srv.URL + `/assets/checksums.txt"}
+			 ]}
+		]`))
+	})
+	mux.HandleFunc("/assets/", func(w http.ResponseWriter, r *http.Request) {})
+	srv = httptest.NewServer(mux)
+	prev := selfupdate.GitHubAPIBase
+	selfupdate.GitHubAPIBase = srv.URL
+	t.Cleanup(func() {
+		srv.Close()
+		selfupdate.GitHubAPIBase = prev
+	})
+}
+
+func TestUpgrade_ChannelBeta_PicksStableWhenNewerThanPre(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	startFakeChannelAPI(t, "2.52.0", "2.52.0-pre.1")
+
+	res := runCLIWithStdoutCapture(t,
+		"upgrade", "--dry-run", "--yes", "--json",
+		"--channel", "beta",
+		"--profile", s.ProfilePath,
+	)
+	if res.RunErr != nil {
+		t.Fatalf("run: %v\nerr: %s", res.RunErr, res.Err)
+	}
+	var got upgradeResult
+	if err := json.Unmarshal([]byte(strings.TrimSpace(res.Out)), &got); err != nil {
+		t.Fatalf("unmarshal %q: %v", res.Out, err)
+	}
+	if got.Channel != profile.ChannelBeta {
+		t.Errorf("Channel = %q, want beta", got.Channel)
+	}
+	if got.LatestVersion != "2.52.0" {
+		t.Errorf("LatestVersion = %q, want 2.52.0 (stable > 2.52.0-pre.1)", got.LatestVersion)
+	}
+}
+
+func TestUpgrade_ChannelBeta_PicksPreWhenNewerThanStable(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	startFakeChannelAPI(t, "2.52.0", "2.53.0-pre.1")
+
+	res := runCLIWithStdoutCapture(t,
+		"upgrade", "--dry-run", "--yes", "--json",
+		"--channel", "beta",
+		"--profile", s.ProfilePath,
+	)
+	if res.RunErr != nil {
+		t.Fatalf("run: %v\nerr: %s", res.RunErr, res.Err)
+	}
+	var got upgradeResult
+	if err := json.Unmarshal([]byte(strings.TrimSpace(res.Out)), &got); err != nil {
+		t.Fatalf("unmarshal %q: %v", res.Out, err)
+	}
+	if got.LatestVersion != "2.53.0-pre.1" {
+		t.Errorf("LatestVersion = %q, want 2.53.0-pre.1", got.LatestVersion)
+	}
+}
+
+func TestUpgrade_ChannelStable_IgnoresNewerPre(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	startFakeChannelAPI(t, "2.52.0", "2.53.0-pre.1")
+
+	res := runCLIWithStdoutCapture(t,
+		"upgrade", "--dry-run", "--yes", "--json",
+		"--channel", "stable",
+		"--profile", s.ProfilePath,
+	)
+	if res.RunErr != nil {
+		t.Fatalf("run: %v\nerr: %s", res.RunErr, res.Err)
+	}
+	var got upgradeResult
+	if err := json.Unmarshal([]byte(strings.TrimSpace(res.Out)), &got); err != nil {
+		t.Fatalf("unmarshal %q: %v", res.Out, err)
+	}
+	if got.Channel != profile.ChannelStable {
+		t.Errorf("Channel = %q, want stable", got.Channel)
+	}
+	if got.LatestVersion != "2.52.0" {
+		t.Errorf("LatestVersion = %q, want 2.52.0 (stable ignores pre)", got.LatestVersion)
+	}
+}
+
+func TestUpgrade_HomebrewManaged_BetaSwitchesPreToStable(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	const current = "2.52.0-pre.1"
+	const latest = "2.52.0"
+
+	cellarDir := filepath.Join(s.Root, "Cellar", "humblskills-pre", current, "bin")
+	if err := os.MkdirAll(cellarDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	exePath := filepath.Join(cellarDir, "humblskills")
+	fakeVersionScript(t, exePath, latest)
+	linkedDir := filepath.Join(s.Root, "bin")
+	if err := os.MkdirAll(linkedDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	fakeVersionScript(t, filepath.Join(linkedDir, "humblskills"), latest)
+	withFakeExecutable(t, exePath)
+	startFakeChannelAPI(t, latest, current)
+
+	var invocations [][]string
+	prevRunner := brewRunner
+	brewRunner = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		invocations = append(invocations, append([]string{}, args...))
+		return exec.CommandContext(ctx, "true")
+	}
+	t.Cleanup(func() { brewRunner = prevRunner })
+
+	res := runCLIWithStdoutCapture(t,
+		"upgrade", "--yes", "--json",
+		"--channel", "beta",
+		"--profile", s.ProfilePath,
+	)
+	if res.RunErr != nil {
+		t.Fatalf("run: %v\nerr: %s", res.RunErr, res.Err)
+	}
+	if len(invocations) != 3 {
+		t.Fatalf("brew invocations = %v, want 3 (update, uninstall, install)", invocations)
+	}
+	if len(invocations[1]) != 2 || invocations[1][0] != "uninstall" || invocations[1][1] != selfupdate.FormulaPre {
+		t.Errorf("second brew call = %v, want [uninstall %s]", invocations[1], selfupdate.FormulaPre)
+	}
+	if len(invocations[2]) != 2 || invocations[2][0] != "install" || invocations[2][1] != selfupdate.FormulaStable {
+		t.Errorf("third brew call = %v, want [install %s]", invocations[2], selfupdate.FormulaStable)
+	}
+
+	var got upgradeResult
+	if err := json.Unmarshal([]byte(strings.TrimSpace(res.Out)), &got); err != nil {
+		t.Fatalf("unmarshal %q: %v", res.Out, err)
+	}
+	if got.Formula != selfupdate.FormulaStable {
+		t.Errorf("Formula = %q, want %s", got.Formula, selfupdate.FormulaStable)
+	}
+	if got.BrewHint != "brew uninstall humblskills-pre && brew install humblskills" {
+		t.Errorf("BrewHint = %q", got.BrewHint)
 	}
 	if !got.Applied {
 		t.Errorf("expected Applied = true, got %+v", got)

--- a/cli/cmd/humblskills/version.go
+++ b/cli/cmd/humblskills/version.go
@@ -54,6 +54,7 @@ func runVersion(app *App) error {
 	}
 
 	// Non-TTY fallback — preserves the existing pipe-friendly output.
+	app.printUpgradeNotice()
 	th := app.UI.Theme()
 	suffix := ""
 	if info.Dirty {

--- a/cli/internal/profile/profile.go
+++ b/cli/internal/profile/profile.go
@@ -75,8 +75,10 @@ type Profile struct {
 
 	// Channel selects which CLI release stream `humblskills upgrade` follows.
 	// Empty (unset) and "stable" both mean GitHub /releases/latest and the
-	// `humblskills` brew formula. "beta" means the latest GitHub prerelease
-	// and the `humblskills-pre` formula. Default MUST stay stable.
+	// `humblskills` brew formula. "beta" means the newer of latest stable
+	// vs latest prerelease (always the newest version). The brew formula
+	// follows that winner — a graduated stable switches pre users onto
+	// `humblskills`. Default MUST stay stable.
 	Channel string `json:"channel,omitempty"`
 }
 

--- a/cli/internal/selfupdate/homebrew.go
+++ b/cli/internal/selfupdate/homebrew.go
@@ -22,14 +22,137 @@ const (
 	FormulaPre    = "humblskills-pre"
 )
 
-// FormulaForChannel returns the tap formula `brew upgrade` should run for
-// the given profile channel. Unknown/empty → stable, so users who never
-// set a channel keep today's behaviour.
+// FormulaForChannel is the *default* tap formula for a channel when no
+// release has been resolved yet. Beta's default is the pre formula, but
+// the winning beta release may be a stable — callers that already have a
+// version must use FormulaForVersion so Homebrew users are not told to
+// `brew upgrade humblskills-pre` when that formula cannot reach it.
 func FormulaForChannel(channel string) string {
 	if NormalizeChannel(channel) == ChannelBeta {
 		return FormulaPre
 	}
 	return FormulaStable
+}
+
+// FormulaForVersion returns the tap formula that publishes version.
+// Prerelease tags (`vX.Y.Z-pre.N`) map to humblskills-pre; everything
+// else maps to humblskills. Channel is not consulted — the winning
+// release decides, so beta can land on the stable formula.
+func FormulaForVersion(version string) string {
+	if isPreTag(version) {
+		return FormulaPre
+	}
+	return FormulaStable
+}
+
+// FormulaForRelease is FormulaForVersion using the GitHub prerelease
+// flag or a `-pre` tag.
+func FormulaForRelease(rel *Release) string {
+	if rel == nil {
+		return FormulaStable
+	}
+	if rel.Prerelease || isPreTag(rel.TagName) {
+		return FormulaPre
+	}
+	return FormulaStable
+}
+
+// InstalledFormula returns the Homebrew formula name encoded in a
+// Cellar/Caskroom path, or "" when exePath is not brew-managed.
+// `/opt/homebrew/Cellar/humblskills-pre/2.52.0-pre/bin/humblskills` →
+// `humblskills-pre`.
+func InstalledFormula(exePath string) string {
+	resolved, err := filepath.EvalSymlinks(exePath)
+	if err != nil {
+		resolved = exePath
+	}
+	if f := formulaInPath(resolved, "/Cellar/"); f != "" {
+		return f
+	}
+	return formulaInPath(resolved, "/Caskroom/")
+}
+
+func formulaInPath(path, marker string) string {
+	i := strings.Index(path, marker)
+	if i < 0 {
+		return ""
+	}
+	rest := path[i+len(marker):]
+	formula, _, ok := strings.Cut(rest, "/")
+	if !ok || formula == "" {
+		return ""
+	}
+	return formula
+}
+
+// HomebrewLinkedBinary is the brew prefix `bin/` symlink for a Cellar
+// install (`…/Cellar/humblskills-pre/2.52.0-pre/bin/humblskills` →
+// `…/bin/humblskills`). After a formula switch the old Cellar path is
+// gone; this is the path that still exists.
+func HomebrewLinkedBinary(exePath string) string {
+	resolved, err := filepath.EvalSymlinks(exePath)
+	if err != nil {
+		resolved = exePath
+	}
+	for _, marker := range []string{"/Cellar/", "/Caskroom/"} {
+		i := strings.Index(resolved, marker)
+		if i < 0 {
+			continue
+		}
+		return filepath.Join(resolved[:i], "bin", filepath.Base(resolved))
+	}
+	return ""
+}
+
+// BrewAction is the Homebrew work an upgrade (or a notice) should run.
+// Same-formula: `brew upgrade <target>`. Cross-formula (beta picked a
+// stable while the user is on humblskills-pre, or the reverse):
+// `brew uninstall <replace> && brew install <target>`.
+type BrewAction struct {
+	Target  string
+	Replace string
+}
+
+// NeedsSwitch reports whether the user must change formulas to reach Target.
+func (a BrewAction) NeedsSwitch() bool {
+	return a.Replace != "" && a.Target != "" && a.Replace != a.Target
+}
+
+// Hint is the exact shell the notice / dry-run / confirm prompt prints.
+func (a BrewAction) Hint() string {
+	target := a.Target
+	if target == "" {
+		target = FormulaStable
+	}
+	if a.NeedsSwitch() {
+		return fmt.Sprintf("brew uninstall %s && brew install %s", a.Replace, target)
+	}
+	return "brew upgrade " + target
+}
+
+// PlanBrewAction builds the Homebrew action for a resolved target formula
+// and the formula currently installed (if any).
+func PlanBrewAction(currentFormula, targetFormula string) BrewAction {
+	if targetFormula == "" {
+		targetFormula = FormulaStable
+	}
+	a := BrewAction{Target: targetFormula}
+	if currentFormula != "" && currentFormula != targetFormula {
+		a.Replace = currentFormula
+	}
+	return a
+}
+
+// RecommendedUpgradeCommand is the command notices, the dashboard banner,
+// and upgrade --dry-run all print. One source of truth: GitHub installs
+// get `humblskills upgrade`; brew stays on `brew upgrade <formula>` unless
+// the winning version lives on the other formula, in which case it tells
+// the user to uninstall/install.
+func RecommendedUpgradeCommand(homebrew bool, currentFormula, targetFormula string) string {
+	if !homebrew {
+		return "humblskills upgrade"
+	}
+	return PlanBrewAction(currentFormula, targetFormula).Hint()
 }
 
 // IsHomebrewManaged reports whether exePath resolves (after following
@@ -65,11 +188,18 @@ type Runner func(ctx context.Context, name string, args ...string) *exec.Cmd
 // own post-upgrade version check (VerifyInstalledVersion) is what actually
 // decides whether the upgrade succeeded.
 func Upgrade(ctx context.Context, run Runner, stdout, stderr io.Writer, sink EventSink, formula string) error {
+	return ApplyBrew(ctx, run, stdout, stderr, sink, BrewAction{Target: formula})
+}
+
+// ApplyBrew runs `brew update` then either `brew upgrade <target>` or
+// `brew uninstall <replace> && brew install <target>` when the winning
+// version lives on the other formula.
+func ApplyBrew(ctx context.Context, run Runner, stdout, stderr io.Writer, sink EventSink, action BrewAction) error {
 	if run == nil {
 		run = exec.CommandContext
 	}
-	if formula == "" {
-		formula = FormulaStable
+	if action.Target == "" {
+		action.Target = FormulaStable
 	}
 
 	sink.emit(Event{Phase: PhaseBrewUpdating})
@@ -78,11 +208,29 @@ func Upgrade(ctx context.Context, run Runner, stdout, stderr io.Writer, sink Eve
 			sink.emit(Event{Phase: PhaseError, Err: err})
 			return err
 		}
-		fmt.Fprintf(stderr, "warning: brew update failed, continuing with brew upgrade anyway: %v\n", err)
+		next := "brew upgrade"
+		if action.NeedsSwitch() {
+			next = "the formula switch"
+		}
+		fmt.Fprintf(stderr, "warning: brew update failed, continuing with %s anyway: %v\n", next, err)
+	}
+
+	if action.NeedsSwitch() {
+		sink.emit(Event{Phase: PhaseBrewUninstalling})
+		if err := runBrew(ctx, run, stdout, stderr, "uninstall", action.Replace); err != nil {
+			sink.emit(Event{Phase: PhaseError, Err: err})
+			return err
+		}
+		sink.emit(Event{Phase: PhaseBrewInstalling})
+		if err := runBrew(ctx, run, stdout, stderr, "install", action.Target); err != nil {
+			sink.emit(Event{Phase: PhaseError, Err: err})
+			return err
+		}
+		return nil
 	}
 
 	sink.emit(Event{Phase: PhaseBrewUpgrading})
-	if err := runBrew(ctx, run, stdout, stderr, "upgrade", formula); err != nil {
+	if err := runBrew(ctx, run, stdout, stderr, "upgrade", action.Target); err != nil {
 		sink.emit(Event{Phase: PhaseError, Err: err})
 		return err
 	}

--- a/cli/internal/selfupdate/homebrew_test.go
+++ b/cli/internal/selfupdate/homebrew_test.go
@@ -147,6 +147,86 @@ func TestFormulaForChannel(t *testing.T) {
 	}
 }
 
+func TestFormulaForVersion(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"2.52.0", FormulaStable},
+		{"v2.52.0", FormulaStable},
+		{"2.52.0-pre.1", FormulaPre},
+		{"v2.52.0-pre", FormulaPre},
+		{"2.53.0-pre.1", FormulaPre},
+	}
+	for _, c := range cases {
+		if got := FormulaForVersion(c.in); got != c.want {
+			t.Errorf("FormulaForVersion(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestFormulaForRelease(t *testing.T) {
+	if got := FormulaForRelease(&Release{TagName: "v2.52.0"}); got != FormulaStable {
+		t.Errorf("stable release formula = %q", got)
+	}
+	if got := FormulaForRelease(&Release{TagName: "v2.52.0-pre.1", Prerelease: true}); got != FormulaPre {
+		t.Errorf("pre release formula = %q", got)
+	}
+	if got := FormulaForRelease(nil); got != FormulaStable {
+		t.Errorf("nil release formula = %q", got)
+	}
+}
+
+func TestInstalledFormula(t *testing.T) {
+	cases := []struct {
+		path, want string
+	}{
+		{"/opt/homebrew/Cellar/humblskills-pre/2.52.0-pre/bin/humblskills", FormulaPre},
+		{"/opt/homebrew/Cellar/humblskills/2.52.0/bin/humblskills", FormulaStable},
+		{"/usr/local/bin/humblskills", ""},
+	}
+	for _, c := range cases {
+		if got := InstalledFormula(c.path); got != c.want {
+			t.Errorf("InstalledFormula(%q) = %q, want %q", c.path, got, c.want)
+		}
+	}
+}
+
+func TestRecommendedUpgradeCommand(t *testing.T) {
+	if got := RecommendedUpgradeCommand(false, "", FormulaStable); got != "humblskills upgrade" {
+		t.Errorf("github = %q", got)
+	}
+	if got := RecommendedUpgradeCommand(true, FormulaPre, FormulaPre); got != "brew upgrade humblskills-pre" {
+		t.Errorf("same pre formula = %q", got)
+	}
+	if got := RecommendedUpgradeCommand(true, FormulaPre, FormulaStable); got != "brew uninstall humblskills-pre && brew install humblskills" {
+		t.Errorf("pre → stable = %q", got)
+	}
+	if got := RecommendedUpgradeCommand(true, FormulaStable, FormulaPre); got != "brew uninstall humblskills && brew install humblskills-pre" {
+		t.Errorf("stable → pre = %q", got)
+	}
+}
+
+func TestApplyBrew_SwitchesFormula(t *testing.T) {
+	var invocations [][]string
+	runner := stubBrewRunner(t, &invocations, true)
+	action := PlanBrewAction(FormulaPre, FormulaStable)
+	if err := ApplyBrew(context.Background(), runner, &bytes.Buffer{}, &bytes.Buffer{}, nil, action); err != nil {
+		t.Fatalf("ApplyBrew: %v", err)
+	}
+	if len(invocations) != 3 {
+		t.Fatalf("invocations = %v, want 3 (update, uninstall, install)", invocations)
+	}
+	if len(invocations[0]) != 1 || invocations[0][0] != "update" {
+		t.Errorf("first = %v, want [update]", invocations[0])
+	}
+	if len(invocations[1]) != 2 || invocations[1][0] != "uninstall" || invocations[1][1] != FormulaPre {
+		t.Errorf("second = %v, want [uninstall %s]", invocations[1], FormulaPre)
+	}
+	if len(invocations[2]) != 2 || invocations[2][0] != "install" || invocations[2][1] != FormulaStable {
+		t.Errorf("third = %v, want [install %s]", invocations[2], FormulaStable)
+	}
+}
+
 func TestUpgrade_UsesGivenFormula(t *testing.T) {
 	var invocations [][]string
 	runner := stubBrewRunner(t, &invocations, true)

--- a/cli/internal/selfupdate/notice.go
+++ b/cli/internal/selfupdate/notice.go
@@ -1,0 +1,275 @@
+package selfupdate
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+// NoticeHeadline is the CLI lead-in when a newer channel release exists.
+// The full line is "{NoticeHeadline}: {current} → {latest} ({channel}) — run `{cmd}`".
+const NoticeHeadline = "newer version available"
+
+// NoticeCacheTTL is how long a GitHub latest-release snapshot stays fresh
+// on disk. Long enough that doctor/start/list in the same day don't each
+// hit the API; short enough that a real release shows up the next day.
+const NoticeCacheTTL = 12 * time.Hour
+
+// NoticeHTTPTimeout is the fail-fast budget for a background/CLI notice
+// check. Upgrade itself keeps DefaultHTTPTimeout; a hung notice must
+// never stall a normal command.
+const NoticeHTTPTimeout = 3 * time.Second
+
+const (
+	noticeCacheFilePrefix = "latest-"
+	noticeCacheFileSuffix = ".json"
+)
+
+// Notice is a "newer version available" result built from the same
+// channel resolution upgrade uses (LatestReleaseForChannel +
+// IsUpgradeAvailable + FormulaForVersion + RecommendedUpgradeCommand).
+// Available=false means stay quiet — current, failed check, or skipped.
+type Notice struct {
+	CurrentVersion string
+	LatestVersion  string
+	LatestTag      string
+	Channel        string
+	Homebrew       bool
+	Formula        string
+	CurrentFormula string
+	Available      bool
+}
+
+// UpdateCommand is the exact command the notice tells the user to run.
+// Same helper upgrade --dry-run uses: brew stays on `brew upgrade
+// <formula>` unless beta's winner lives on the other formula, in which
+// case it is `brew uninstall <old> && brew install <new>`.
+func (n Notice) UpdateCommand() string {
+	return RecommendedUpgradeCommand(n.Homebrew, n.CurrentFormula, n.Formula)
+}
+
+// CLILine is the user-visible CLI notice. Empty when nothing is available.
+func (n Notice) CLILine() string {
+	if !n.Available {
+		return ""
+	}
+	return fmt.Sprintf("%s: %s → %s (%s) — run `%s`",
+		NoticeHeadline,
+		DisplayVersion(n.CurrentVersion),
+		DisplayVersion(n.LatestVersion),
+		NormalizeChannel(n.Channel),
+		n.UpdateCommand())
+}
+
+// CheckOptions configures Check. Zero-value client/TTL/Now use defaults.
+type CheckOptions struct {
+	Client         *http.Client
+	Repo           string
+	CurrentVersion string
+	ExePath        string
+	Channel        string
+	CacheDir       string
+	TTL            time.Duration
+	Now            func() time.Time
+}
+
+type noticeSnapshot struct {
+	Channel       string    `json:"channel"`
+	LatestVersion string    `json:"latest_version"`
+	LatestTag     string    `json:"latest_tag"`
+	CheckedAt     time.Time `json:"checked_at"`
+}
+
+type noticeMemKey struct {
+	cacheDir string
+	channel  string
+}
+
+var (
+	noticeMemMu sync.Mutex
+	noticeMem   = map[noticeMemKey]noticeSnapshot{}
+)
+
+// NewNoticeHTTPClient is the short-timeout client notice checks use so a
+// slow GitHub never blocks doctor/start/list the way upgrade may.
+func NewNoticeHTTPClient() *http.Client {
+	return &http.Client{Timeout: NoticeHTTPTimeout}
+}
+
+// SkipNetwork, when true, makes Check return a quiet Notice without
+// touching GitHub. Command-level tests that aren't exercising the notice
+// flip this so doctor/list/start don't each wait on the network.
+var SkipNetwork bool
+
+// Check looks up the latest release for channel and reports whether the
+// running binary is behind it. Failures (network, decode, empty cache
+// dir) return a quiet Notice — no error is surfaced to the caller.
+//
+// Latest-release bytes are cached in memory (once per process + cache
+// dir + channel) and on disk under cacheDir/selfupdate/latest-<channel>.json
+// for NoticeCacheTTL. The comparison against CurrentVersion is always
+// live so a just-upgraded binary does not keep advertising itself.
+func Check(opts CheckOptions) Notice {
+	channel := NormalizeChannel(opts.Channel)
+	n := Notice{
+		CurrentVersion: opts.CurrentVersion,
+		Channel:        channel,
+	}
+	if SkipNetwork {
+		return n
+	}
+	if opts.ExePath != "" {
+		n.Homebrew = IsHomebrewManaged(opts.ExePath)
+		if n.Homebrew {
+			n.CurrentFormula = InstalledFormula(opts.ExePath)
+		}
+	}
+
+	snap, ok := loadNoticeSnapshot(opts, channel)
+	if !ok {
+		return n
+	}
+	n.LatestVersion = snap.LatestVersion
+	n.LatestTag = snap.LatestTag
+	n.Formula = FormulaForVersion(snap.LatestVersion)
+	n.Available = IsUpgradeAvailable(opts.CurrentVersion, snap.LatestVersion)
+	return n
+}
+
+// InvalidateNoticeCache drops the in-memory and on-disk snapshots for
+// cacheDir so the next Check refetches. Called after a successful
+// upgrade so the notice does not keep advertising the version we just
+// installed.
+func InvalidateNoticeCache(cacheDir string) {
+	if cacheDir == "" {
+		return
+	}
+	noticeMemMu.Lock()
+	for k := range noticeMem {
+		if k.cacheDir == cacheDir {
+			delete(noticeMem, k)
+		}
+	}
+	noticeMemMu.Unlock()
+	for _, ch := range []string{ChannelStable, ChannelBeta} {
+		_ = os.Remove(noticeCachePath(cacheDir, ch))
+	}
+}
+
+func loadNoticeSnapshot(opts CheckOptions, channel string) (noticeSnapshot, bool) {
+	now := time.Now
+	if opts.Now != nil {
+		now = opts.Now
+	}
+	ttl := opts.TTL
+	if ttl <= 0 {
+		ttl = NoticeCacheTTL
+	}
+
+	key := noticeMemKey{cacheDir: opts.CacheDir, channel: channel}
+	noticeMemMu.Lock()
+	if snap, ok := noticeMem[key]; ok && !noticeSnapshotExpired(snap, now(), ttl) {
+		noticeMemMu.Unlock()
+		return snap, true
+	}
+	noticeMemMu.Unlock()
+
+	if disk, ok := readNoticeCache(opts.CacheDir, channel); ok {
+		if !noticeSnapshotExpired(disk, now(), ttl) {
+			storeNoticeMem(key, disk)
+			return disk, true
+		}
+		// Stale disk is a fallback if the network check fails.
+		if snap, ok := fetchNoticeSnapshot(opts, channel, now()); ok {
+			writeNoticeCache(opts.CacheDir, snap)
+			storeNoticeMem(key, snap)
+			return snap, true
+		}
+		storeNoticeMem(key, disk)
+		return disk, true
+	}
+
+	snap, ok := fetchNoticeSnapshot(opts, channel, now())
+	if !ok {
+		return noticeSnapshot{}, false
+	}
+	writeNoticeCache(opts.CacheDir, snap)
+	storeNoticeMem(key, snap)
+	return snap, true
+}
+
+func fetchNoticeSnapshot(opts CheckOptions, channel string, now time.Time) (noticeSnapshot, bool) {
+	client := opts.Client
+	if client == nil {
+		client = NewNoticeHTTPClient()
+	}
+	repo := opts.Repo
+	if repo == "" {
+		repo = DefaultRepo
+	}
+	rel, err := LatestReleaseForChannel(client, repo, channel)
+	if err != nil || rel == nil || rel.TagName == "" {
+		return noticeSnapshot{}, false
+	}
+	return noticeSnapshot{
+		Channel:       channel,
+		LatestVersion: rel.Version(),
+		LatestTag:     rel.TagName,
+		CheckedAt:     now.UTC(),
+	}, true
+}
+
+func storeNoticeMem(key noticeMemKey, snap noticeSnapshot) {
+	noticeMemMu.Lock()
+	defer noticeMemMu.Unlock()
+	noticeMem[key] = snap
+}
+
+func noticeSnapshotExpired(snap noticeSnapshot, now time.Time, ttl time.Duration) bool {
+	if snap.CheckedAt.IsZero() || snap.LatestVersion == "" {
+		return true
+	}
+	return now.Sub(snap.CheckedAt) >= ttl
+}
+
+func noticeCachePath(cacheDir, channel string) string {
+	return filepath.Join(cacheDir, "selfupdate", noticeCacheFilePrefix+NormalizeChannel(channel)+noticeCacheFileSuffix)
+}
+
+func readNoticeCache(cacheDir, channel string) (noticeSnapshot, bool) {
+	if cacheDir == "" {
+		return noticeSnapshot{}, false
+	}
+	data, err := os.ReadFile(noticeCachePath(cacheDir, channel))
+	if err != nil {
+		return noticeSnapshot{}, false
+	}
+	var snap noticeSnapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return noticeSnapshot{}, false
+	}
+	if snap.LatestVersion == "" {
+		return noticeSnapshot{}, false
+	}
+	snap.Channel = NormalizeChannel(snap.Channel)
+	return snap, true
+}
+
+func writeNoticeCache(cacheDir string, snap noticeSnapshot) {
+	if cacheDir == "" || snap.LatestVersion == "" {
+		return
+	}
+	path := noticeCachePath(cacheDir, snap.Channel)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return
+	}
+	data, err := json.Marshal(snap)
+	if err != nil {
+		return
+	}
+	_ = os.WriteFile(path, data, 0o644)
+}

--- a/cli/internal/selfupdate/notice_test.go
+++ b/cli/internal/selfupdate/notice_test.go
@@ -1,0 +1,416 @@
+package selfupdate
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestDisplayVersion(t *testing.T) {
+	cases := map[string]string{
+		"2.17.0":       "v2.17.0",
+		"2.52.0-pre.1": "v2.52.0-pre.1",
+		"v2.17.0":      "v2.17.0",
+		"dev":          "dev",
+		"":             "",
+	}
+	for in, want := range cases {
+		if got := DisplayVersion(in); got != want {
+			t.Errorf("DisplayVersion(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestNotice_CLILine_GitHubAndHomebrew(t *testing.T) {
+	gh := Notice{
+		CurrentVersion: "2.15.0",
+		LatestVersion:  "2.17.0",
+		Channel:        ChannelStable,
+		Available:      true,
+	}
+	wantGH := "newer version available: v2.15.0 → v2.17.0 (stable) — run `humblskills upgrade`"
+	if got := gh.CLILine(); got != wantGH {
+		t.Errorf("github CLILine = %q, want %q", got, wantGH)
+	}
+
+	brew := Notice{
+		CurrentVersion: "2.15.0",
+		LatestVersion:  "2.17.0",
+		Channel:        ChannelStable,
+		Homebrew:       true,
+		Formula:        FormulaStable,
+		Available:      true,
+	}
+	wantBrew := "newer version available: v2.15.0 → v2.17.0 (stable) — run `brew upgrade humblskills`"
+	if got := brew.CLILine(); got != wantBrew {
+		t.Errorf("brew CLILine = %q, want %q", got, wantBrew)
+	}
+
+	brewBeta := Notice{
+		CurrentVersion: "2.51.0",
+		LatestVersion:  "2.52.0-pre.1",
+		Channel:        ChannelBeta,
+		Homebrew:       true,
+		Formula:        FormulaPre,
+		CurrentFormula: FormulaPre,
+		Available:      true,
+	}
+	wantBeta := "newer version available: v2.51.0 → v2.52.0-pre.1 (beta) — run `brew upgrade humblskills-pre`"
+	if got := brewBeta.CLILine(); got != wantBeta {
+		t.Errorf("brew beta CLILine = %q, want %q", got, wantBeta)
+	}
+
+	switchNotice := Notice{
+		CurrentVersion: "2.52.0-pre.1",
+		LatestVersion:  "2.52.0",
+		Channel:        ChannelBeta,
+		Homebrew:       true,
+		Formula:        FormulaStable,
+		CurrentFormula: FormulaPre,
+		Available:      true,
+	}
+	wantSwitch := "newer version available: v2.52.0-pre.1 → v2.52.0 (beta) — run `brew uninstall humblskills-pre && brew install humblskills`"
+	if got := switchNotice.CLILine(); got != wantSwitch {
+		t.Errorf("brew switch CLILine = %q, want %q", got, wantSwitch)
+	}
+
+	quiet := Notice{CurrentVersion: "2.17.0", LatestVersion: "2.17.0", Available: false}
+	if got := quiet.CLILine(); got != "" {
+		t.Errorf("current CLILine should be empty, got %q", got)
+	}
+}
+
+func TestNotice_UpdateCommand(t *testing.T) {
+	if got := (Notice{}).UpdateCommand(); got != "humblskills upgrade" {
+		t.Errorf("default UpdateCommand = %q", got)
+	}
+	if got := (Notice{Homebrew: true, Formula: FormulaPre, CurrentFormula: FormulaPre}).UpdateCommand(); got != "brew upgrade humblskills-pre" {
+		t.Errorf("beta brew UpdateCommand = %q", got)
+	}
+	if got := (Notice{Homebrew: true, Formula: FormulaStable, CurrentFormula: FormulaPre}).UpdateCommand(); got != "brew uninstall humblskills-pre && brew install humblskills" {
+		t.Errorf("switch UpdateCommand = %q", got)
+	}
+}
+
+func TestCheck_DefaultStableHitsLatest(t *testing.T) {
+	hits := newReleaseCounter(t, "2.17.0", "", false)
+	n := Check(CheckOptions{
+		Client:         hits.client,
+		CurrentVersion: "2.15.0",
+		ExePath:        "/usr/local/bin/humblskills",
+		CacheDir:       t.TempDir(),
+	})
+	if !n.Available {
+		t.Fatalf("expected available, got %+v", n)
+	}
+	if n.Channel != ChannelStable {
+		t.Errorf("Channel = %q, want stable", n.Channel)
+	}
+	if n.LatestVersion != "2.17.0" {
+		t.Errorf("LatestVersion = %q", n.LatestVersion)
+	}
+	if n.Homebrew {
+		t.Error("plain /usr/local path should not be Homebrew")
+	}
+	if n.CLILine() != "newer version available: v2.15.0 → v2.17.0 (stable) — run `humblskills upgrade`" {
+		t.Errorf("CLILine = %q", n.CLILine())
+	}
+	if hits.latest.Load() != 1 {
+		t.Errorf("/releases/latest hits = %d, want 1", hits.latest.Load())
+	}
+	if hits.list.Load() != 0 {
+		t.Errorf("stable must not list releases, got %d", hits.list.Load())
+	}
+}
+
+func TestCheck_BetaPicksStableWhenNewerThanPre(t *testing.T) {
+	// Jennings dry-run: 2.52.0 > 2.52.0-pre.1, so beta must recommend the
+	// stable and tell a brew-pre user to switch formulas.
+	hits := newChannelReleases(t, "2.52.0", "2.52.0-pre.1")
+	n := Check(CheckOptions{
+		Client:         hits.client,
+		CurrentVersion: "2.52.0-pre",
+		Channel:        ChannelBeta,
+		ExePath:        "/opt/homebrew/Cellar/humblskills-pre/2.52.0-pre/bin/humblskills",
+		CacheDir:       t.TempDir(),
+	})
+	if !n.Available {
+		t.Fatalf("expected available, got %+v", n)
+	}
+	if n.LatestVersion != "2.52.0" {
+		t.Errorf("LatestVersion = %q, want 2.52.0", n.LatestVersion)
+	}
+	if n.Formula != FormulaStable {
+		t.Errorf("Formula = %q, want %s", n.Formula, FormulaStable)
+	}
+	if n.CurrentFormula != FormulaPre {
+		t.Errorf("CurrentFormula = %q, want %s", n.CurrentFormula, FormulaPre)
+	}
+	want := "newer version available: v2.52.0-pre → v2.52.0 (beta) — run `brew uninstall humblskills-pre && brew install humblskills`"
+	if n.CLILine() != want {
+		t.Errorf("CLILine = %q, want %q", n.CLILine(), want)
+	}
+	if hits.latest.Load() != 1 || hits.list.Load() != 1 {
+		t.Errorf("beta must hit both endpoints, latest=%d list=%d", hits.latest.Load(), hits.list.Load())
+	}
+}
+
+func TestCheck_BetaPicksPreWhenNewerThanStable(t *testing.T) {
+	hits := newChannelReleases(t, "2.52.0", "2.53.0-pre.1")
+	n := Check(CheckOptions{
+		Client:         hits.client,
+		CurrentVersion: "2.52.0",
+		Channel:        ChannelBeta,
+		ExePath:        "/opt/homebrew/Cellar/humblskills-pre/2.52.0/bin/humblskills",
+		CacheDir:       t.TempDir(),
+	})
+	if n.LatestVersion != "2.53.0-pre.1" {
+		t.Errorf("LatestVersion = %q, want 2.53.0-pre.1", n.LatestVersion)
+	}
+	if n.Formula != FormulaPre {
+		t.Errorf("Formula = %q, want %s", n.Formula, FormulaPre)
+	}
+	if n.UpdateCommand() != "brew upgrade humblskills-pre" {
+		t.Errorf("UpdateCommand = %q", n.UpdateCommand())
+	}
+}
+
+func TestCheck_StableNeverPicksPre(t *testing.T) {
+	hits := newChannelReleases(t, "2.52.0", "2.53.0-pre.1")
+	n := Check(CheckOptions{
+		Client:         hits.client,
+		CurrentVersion: "2.51.0",
+		Channel:        ChannelStable,
+		CacheDir:       t.TempDir(),
+	})
+	if n.LatestVersion != "2.52.0" {
+		t.Errorf("LatestVersion = %q, want 2.52.0", n.LatestVersion)
+	}
+	if hits.list.Load() != 0 {
+		t.Errorf("stable must not list releases, got %d", hits.list.Load())
+	}
+}
+
+func TestCheck_CurrentIsQuiet(t *testing.T) {
+	hits := newReleaseCounter(t, "2.17.0", "", false)
+	n := Check(CheckOptions{
+		Client:         hits.client,
+		CurrentVersion: "2.17.0",
+		CacheDir:       t.TempDir(),
+	})
+	if n.Available {
+		t.Errorf("current should be quiet, got %+v", n)
+	}
+	if n.CLILine() != "" {
+		t.Errorf("CLILine should be empty, got %q", n.CLILine())
+	}
+	if n.LatestVersion != "2.17.0" {
+		t.Errorf("LatestVersion still recorded = %q", n.LatestVersion)
+	}
+}
+
+func TestCheck_CacheSkipsRefetch(t *testing.T) {
+	hits := newReleaseCounter(t, "2.17.0", "", false)
+	dir := t.TempDir()
+	opts := CheckOptions{
+		Client:         hits.client,
+		CurrentVersion: "2.15.0",
+		CacheDir:       dir,
+	}
+	first := Check(opts)
+	if !first.Available {
+		t.Fatalf("first check: %+v", first)
+	}
+	second := Check(opts)
+	if !second.Available || second.LatestVersion != "2.17.0" {
+		t.Fatalf("second check: %+v", second)
+	}
+	if hits.latest.Load() != 1 {
+		t.Errorf("expected one fetch, got %d", hits.latest.Load())
+	}
+}
+
+func TestCheck_DiskCacheSurvivesProcessMemory(t *testing.T) {
+	hits := newReleaseCounter(t, "2.17.0", "", false)
+	dir := t.TempDir()
+	opts := CheckOptions{
+		Client:         hits.client,
+		CurrentVersion: "2.15.0",
+		CacheDir:       dir,
+	}
+	if n := Check(opts); !n.Available {
+		t.Fatalf("warm: %+v", n)
+	}
+	InvalidateNoticeCache(dir)
+	if n := Check(opts); !n.Available {
+		t.Fatalf("rewarm: %+v", n)
+	}
+	if hits.latest.Load() != 2 {
+		t.Fatalf("rewarm hits = %d, want 2", hits.latest.Load())
+	}
+	noticeMemMu.Lock()
+	delete(noticeMem, noticeMemKey{cacheDir: dir, channel: ChannelStable})
+	noticeMemMu.Unlock()
+	if n := Check(opts); !n.Available {
+		t.Fatalf("disk hit: %+v", n)
+	}
+	if hits.latest.Load() != 2 {
+		t.Errorf("disk cache should not refetch, hits = %d", hits.latest.Load())
+	}
+}
+
+func TestCheck_TTLExpiryRefetches(t *testing.T) {
+	hits := newReleaseCounter(t, "2.17.0", "", false)
+	dir := t.TempDir()
+	now := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	opts := CheckOptions{
+		Client:         hits.client,
+		CurrentVersion: "2.15.0",
+		CacheDir:       dir,
+		TTL:            time.Hour,
+		Now:            func() time.Time { return now },
+	}
+	if n := Check(opts); !n.Available {
+		t.Fatalf("first: %+v", n)
+	}
+	now = now.Add(2 * time.Hour)
+	if n := Check(opts); !n.Available {
+		t.Fatalf("expired: %+v", n)
+	}
+	if hits.latest.Load() != 2 {
+		t.Errorf("expired TTL should refetch, hits = %d", hits.latest.Load())
+	}
+}
+
+func TestCheck_FetchFailureStaysQuiet(t *testing.T) {
+	prev := GitHubAPIBase
+	GitHubAPIBase = "http://127.0.0.1:0"
+	t.Cleanup(func() { GitHubAPIBase = prev })
+
+	n := Check(CheckOptions{
+		Client:         &http.Client{Timeout: 50 * time.Millisecond},
+		CurrentVersion: "2.15.0",
+		CacheDir:       t.TempDir(),
+	})
+	if n.Available || n.CLILine() != "" {
+		t.Errorf("failed check must stay quiet, got %+v %q", n, n.CLILine())
+	}
+}
+
+func TestCheck_HomebrewFormula(t *testing.T) {
+	hits := newReleaseCounter(t, "2.17.0", "", false)
+	n := Check(CheckOptions{
+		Client:         hits.client,
+		CurrentVersion: "2.15.0",
+		ExePath:        "/opt/homebrew/Cellar/humblskills/2.15.0/bin/humblskills",
+		CacheDir:       t.TempDir(),
+	})
+	if !n.Homebrew {
+		t.Fatal("expected Homebrew detection")
+	}
+	if n.Formula != FormulaStable {
+		t.Errorf("Formula = %q", n.Formula)
+	}
+	if n.UpdateCommand() != "brew upgrade humblskills" {
+		t.Errorf("UpdateCommand = %q", n.UpdateCommand())
+	}
+}
+
+func TestCheck_UnknownChannelDefaultsStable(t *testing.T) {
+	hits := newReleaseCounter(t, "2.17.0", "", false)
+	n := Check(CheckOptions{
+		Client:         hits.client,
+		CurrentVersion: "2.15.0",
+		Channel:        "nightly",
+		CacheDir:       t.TempDir(),
+	})
+	if n.Channel != ChannelStable {
+		t.Errorf("Channel = %q, want stable", n.Channel)
+	}
+	if hits.latest.Load() != 1 {
+		t.Error("unknown channel should hit /releases/latest")
+	}
+}
+
+type releaseHits struct {
+	client *http.Client
+	latest atomic.Int32
+	list   atomic.Int32
+}
+
+func newReleaseCounter(t *testing.T, latest, pre string, prerelease bool) *releaseHits {
+	t.Helper()
+	h := &releaseHits{}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/jjfantini/humblSKILLS/releases/latest", func(w http.ResponseWriter, r *http.Request) {
+		h.latest.Add(1)
+		_, _ = w.Write([]byte(`{"tag_name": "v` + latest + `", "prerelease": false}`))
+	})
+	mux.HandleFunc("/repos/jjfantini/humblSKILLS/releases", func(w http.ResponseWriter, r *http.Request) {
+		h.list.Add(1)
+		tag := latest
+		flag := "false"
+		if prerelease {
+			flag = "true"
+		}
+		if pre != "" {
+			tag = pre
+			flag = "true"
+		}
+		_, _ = w.Write([]byte(`[{"tag_name": "v` + tag + `", "prerelease": ` + flag + `, "draft": false}]`))
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	prev := GitHubAPIBase
+	GitHubAPIBase = srv.URL
+	t.Cleanup(func() { GitHubAPIBase = prev })
+	h.client = srv.Client()
+	return h
+}
+
+func newChannelReleases(t *testing.T, stable, pre string) *releaseHits {
+	t.Helper()
+	h := &releaseHits{}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/jjfantini/humblSKILLS/releases/latest", func(w http.ResponseWriter, r *http.Request) {
+		h.latest.Add(1)
+		if stable == "" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		_, _ = w.Write([]byte(`{"tag_name": "v` + stable + `", "prerelease": false}`))
+	})
+	mux.HandleFunc("/repos/jjfantini/humblSKILLS/releases", func(w http.ResponseWriter, r *http.Request) {
+		h.list.Add(1)
+		body := `[`
+		if stable != "" {
+			body += `{"tag_name": "v` + stable + `", "prerelease": false, "draft": false}`
+		}
+		if pre != "" {
+			if stable != "" {
+				body += `,`
+			}
+			body += `{"tag_name": "v` + pre + `", "prerelease": true, "draft": false}`
+		}
+		body += `]`
+		_, _ = w.Write([]byte(body))
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	prev := GitHubAPIBase
+	GitHubAPIBase = srv.URL
+	t.Cleanup(func() { GitHubAPIBase = prev })
+	h.client = srv.Client()
+	return h
+}
+
+func TestNoticeCachePath(t *testing.T) {
+	got := noticeCachePath("/tmp/cache", ChannelBeta)
+	want := filepath.Join("/tmp/cache", "selfupdate", "latest-beta.json")
+	if got != want {
+		t.Errorf("path = %q, want %q", got, want)
+	}
+}

--- a/cli/internal/selfupdate/release.go
+++ b/cli/internal/selfupdate/release.go
@@ -99,13 +99,39 @@ func LatestRelease(client *http.Client, repo string) (*Release, error) {
 	return fetchRelease(client, fmt.Sprintf("%s/repos/%s/releases/latest", GitHubAPIBase, repo))
 }
 
-// LatestReleaseForChannel returns the latest stable GitHub release, or the
-// latest prerelease when channel is beta.
+// LatestReleaseForChannel is the single source of truth for "what is latest
+// on this channel."
+//
+//   - stable (default): GitHub /releases/latest only — never a prerelease.
+//   - beta: compares the latest stable against the latest prerelease and
+//     returns the higher semver. A graduated stable (v2.52.0) beats its
+//     own pre (v2.52.0-pre.1); a newer pre (v2.53.0-pre.1) beats the last
+//     stable. If only one side exists, that side wins.
 func LatestReleaseForChannel(client *http.Client, repo, channel string) (*Release, error) {
 	if NormalizeChannel(channel) == ChannelBeta {
-		return latestPrerelease(client, repo)
+		return latestBeta(client, repo)
 	}
 	return LatestRelease(client, repo)
+}
+
+// latestBeta picks max(latest stable, latest prerelease) by semver.
+func latestBeta(client *http.Client, repo string) (*Release, error) {
+	stable, stableErr := LatestRelease(client, repo)
+	pre, preErr := latestPrerelease(client, repo)
+	switch {
+	case stableErr != nil && preErr != nil:
+		return nil, fmt.Errorf("beta channel: no usable release (stable: %v; prerelease: %v)", stableErr, preErr)
+	case preErr != nil:
+		return stable, nil
+	case stableErr != nil:
+		return pre, nil
+	}
+	// Equal or stable newer → stable. A graduated tag always beats its
+	// own -pre.N (2.52.0 > 2.52.0-pre.1).
+	if Compare(stable.Version(), pre.Version()) >= 0 {
+		return stable, nil
+	}
+	return pre, nil
 }
 
 func latestPrerelease(client *http.Client, repo string) (*Release, error) {

--- a/cli/internal/selfupdate/release_test.go
+++ b/cli/internal/selfupdate/release_test.go
@@ -105,49 +105,113 @@ func TestLatestReleaseForChannel_StableHitsLatest(t *testing.T) {
 	}
 }
 
-func TestLatestReleaseForChannel_BetaSkipsStableAndDrafts(t *testing.T) {
+func TestLatestReleaseForChannel_BetaPicksStableWhenNewerThanPre(t *testing.T) {
+	// Jennings dry-run: 2.52.0 > 2.52.0-pre.1, so beta must pick the stable.
 	srv := withFakeGitHubAPI(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/repos/jjfantini/humblSKILLS/releases" {
-			t.Errorf("beta channel should hit /releases, got %s", r.URL.Path)
+		switch r.URL.Path {
+		case "/repos/jjfantini/humblSKILLS/releases/latest":
+			_, _ = w.Write([]byte(`{"tag_name": "v2.52.0", "prerelease": false}`))
+		case "/repos/jjfantini/humblSKILLS/releases":
+			_, _ = w.Write([]byte(`[
+				{"tag_name": "v2.52.0", "prerelease": false, "draft": false},
+				{"tag_name": "v2.52.0-pre.2", "prerelease": true, "draft": true},
+				{"tag_name": "v2.52.0-pre.1", "prerelease": true, "draft": false}
+			]`))
+		default:
+			t.Errorf("unexpected path: %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
 		}
-		_, _ = w.Write([]byte(`[
-			{"tag_name": "v2.52.0", "prerelease": false, "draft": false},
-			{"tag_name": "v2.52.0-pre.2", "prerelease": true, "draft": true},
-			{"tag_name": "v2.52.0-pre.1", "prerelease": true, "draft": false}
-		]`))
 	}))
 	rel, err := LatestReleaseForChannel(srv.Client(), DefaultRepo, ChannelBeta)
 	if err != nil {
 		t.Fatalf("LatestReleaseForChannel: %v", err)
 	}
-	if rel.TagName != "v2.52.0-pre.1" {
-		t.Errorf("TagName = %q, want v2.52.0-pre.1 (skip stable + draft pre)", rel.TagName)
+	if rel.TagName != "v2.52.0" {
+		t.Errorf("TagName = %q, want v2.52.0 (stable > 2.52.0-pre.1)", rel.TagName)
+	}
+}
+
+func TestLatestReleaseForChannel_BetaPicksPreWhenNewerThanStable(t *testing.T) {
+	srv := withFakeGitHubAPI(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/jjfantini/humblSKILLS/releases/latest":
+			_, _ = w.Write([]byte(`{"tag_name": "v2.52.0", "prerelease": false}`))
+		case "/repos/jjfantini/humblSKILLS/releases":
+			_, _ = w.Write([]byte(`[
+				{"tag_name": "v2.53.0-pre.1", "prerelease": true, "draft": false},
+				{"tag_name": "v2.52.0", "prerelease": false, "draft": false}
+			]`))
+		default:
+			t.Errorf("unexpected path: %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	rel, err := LatestReleaseForChannel(srv.Client(), DefaultRepo, ChannelBeta)
+	if err != nil {
+		t.Fatalf("LatestReleaseForChannel: %v", err)
+	}
+	if rel.TagName != "v2.53.0-pre.1" {
+		t.Errorf("TagName = %q, want v2.53.0-pre.1 (pre > 2.52.0)", rel.TagName)
+	}
+}
+
+func TestLatestReleaseForChannel_StableNeverPicksPre(t *testing.T) {
+	srv := withFakeGitHubAPI(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/repos/jjfantini/humblSKILLS/releases/latest" {
+			t.Errorf("stable channel should hit /releases/latest, got %s", r.URL.Path)
+		}
+		_, _ = w.Write([]byte(`{"tag_name": "v2.52.0", "prerelease": false}`))
+	}))
+	rel, err := LatestReleaseForChannel(srv.Client(), DefaultRepo, ChannelStable)
+	if err != nil {
+		t.Fatalf("LatestReleaseForChannel: %v", err)
+	}
+	if rel.TagName != "v2.52.0" {
+		t.Errorf("TagName = %q, want v2.52.0", rel.TagName)
 	}
 }
 
 func TestLatestReleaseForChannel_BetaPicksPreTagWithoutFlag(t *testing.T) {
 	srv := withFakeGitHubAPI(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, _ = w.Write([]byte(`[
-			{"tag_name": "v2.51.0", "prerelease": false},
-			{"tag_name": "v2.52.0-pre.1", "prerelease": false}
-		]`))
+		switch r.URL.Path {
+		case "/repos/jjfantini/humblSKILLS/releases/latest":
+			_, _ = w.Write([]byte(`{"tag_name": "v2.51.0", "prerelease": false}`))
+		case "/repos/jjfantini/humblSKILLS/releases":
+			_, _ = w.Write([]byte(`[
+				{"tag_name": "v2.51.0", "prerelease": false},
+				{"tag_name": "v2.52.0-pre.1", "prerelease": false}
+			]`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
 	}))
 	rel, err := LatestReleaseForChannel(srv.Client(), DefaultRepo, "beta")
 	if err != nil {
 		t.Fatalf("LatestReleaseForChannel: %v", err)
 	}
 	if rel.TagName != "v2.52.0-pre.1" {
-		t.Errorf("TagName = %q, want v2.52.0-pre.1 (dash in tag)", rel.TagName)
+		t.Errorf("TagName = %q, want v2.52.0-pre.1 (dash in tag beats 2.51.0)", rel.TagName)
 	}
 }
 
-func TestLatestReleaseForChannel_BetaNoPrerelease(t *testing.T) {
+func TestLatestReleaseForChannel_BetaFallsBackToStableWhenNoPre(t *testing.T) {
 	srv := withFakeGitHubAPI(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, _ = w.Write([]byte(`[
-			{"tag_name": "v2.51.0", "prerelease": false, "draft": false}
-		]`))
+		switch r.URL.Path {
+		case "/repos/jjfantini/humblSKILLS/releases/latest":
+			_, _ = w.Write([]byte(`{"tag_name": "v2.51.0", "prerelease": false}`))
+		case "/repos/jjfantini/humblSKILLS/releases":
+			_, _ = w.Write([]byte(`[
+				{"tag_name": "v2.51.0", "prerelease": false, "draft": false}
+			]`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
 	}))
-	if _, err := LatestReleaseForChannel(srv.Client(), DefaultRepo, ChannelBeta); err == nil {
-		t.Error("expected error when no prerelease exists")
+	rel, err := LatestReleaseForChannel(srv.Client(), DefaultRepo, ChannelBeta)
+	if err != nil {
+		t.Fatalf("beta with only a stable should pick it, got %v", err)
+	}
+	if rel.TagName != "v2.51.0" {
+		t.Errorf("TagName = %q, want v2.51.0", rel.TagName)
 	}
 }

--- a/cli/internal/selfupdate/run.go
+++ b/cli/internal/selfupdate/run.go
@@ -19,11 +19,15 @@ const (
 	PhaseVerifyingSum   Phase = "verifying_checksum"
 	PhaseInstalling     Phase = "installing"
 	// PhaseBrewUpdating fires while refreshing Homebrew's local tap
-	// metadata (`brew update`), before PhaseBrewUpgrading.
+	// metadata (`brew update`), before PhaseBrewUpgrading or a formula switch.
 	PhaseBrewUpdating Phase = "brew_updating"
-	// PhaseBrewUpgrading fires while running `brew upgrade humblskills`.
+	// PhaseBrewUpgrading fires while running `brew upgrade <formula>`.
 	PhaseBrewUpgrading Phase = "brew_upgrading"
-	PhaseError         Phase = "error"
+	// PhaseBrewUninstalling / PhaseBrewInstalling fire when beta's winning
+	// version lives on the other formula (pre → stable or stable → pre).
+	PhaseBrewUninstalling Phase = "brew_uninstalling"
+	PhaseBrewInstalling   Phase = "brew_installing"
+	PhaseError            Phase = "error"
 )
 
 // Event is a single progress notification emitted while running
@@ -56,7 +60,10 @@ type Plan struct {
 	UpgradeAvailable bool
 	Homebrew         bool
 	Channel          string
-	Formula          string // brew formula when Homebrew; empty otherwise
+	Formula          string // target brew formula when Homebrew; empty otherwise
+	CurrentFormula   string // installed brew formula when detected
+	BrewHint         string // exact brew (or CLI) command notices/dry-run print
+	SwitchFormula    bool
 	AssetName        string
 	AssetURL         string
 	ChecksumsURL     string
@@ -68,9 +75,9 @@ func ResolvePlan(client *http.Client, repo, currentVersion, exePath string, sink
 	return ResolvePlanForChannel(client, repo, currentVersion, exePath, ChannelStable, sink)
 }
 
-// ResolvePlanForChannel is ResolvePlan using channel to pick GitHub
-// /releases/latest (stable) or the newest prerelease (beta), and the
-// matching brew formula.
+// ResolvePlanForChannel is ResolvePlan using LatestReleaseForChannel so
+// beta picks the higher of latest stable vs latest prerelease. The brew
+// formula follows that winner, not the channel name.
 func ResolvePlanForChannel(client *http.Client, repo, currentVersion, exePath, channel string, sink EventSink) (*Plan, error) {
 	if repo == "" {
 		repo = DefaultRepo
@@ -85,6 +92,12 @@ func ResolvePlanForChannel(client *http.Client, repo, currentVersion, exePath, c
 
 	latest := rel.Version()
 	homebrew := IsHomebrewManaged(exePath)
+	target := FormulaForRelease(rel)
+	currentFormula := ""
+	if homebrew {
+		currentFormula = InstalledFormula(exePath)
+	}
+	action := PlanBrewAction(currentFormula, target)
 	plan := &Plan{
 		CurrentVersion:   currentVersion,
 		LatestVersion:    latest,
@@ -92,9 +105,12 @@ func ResolvePlanForChannel(client *http.Client, repo, currentVersion, exePath, c
 		UpgradeAvailable: IsUpgradeAvailable(currentVersion, latest),
 		Homebrew:         homebrew,
 		Channel:          channel,
+		BrewHint:         RecommendedUpgradeCommand(homebrew, currentFormula, target),
 	}
 	if homebrew {
-		plan.Formula = FormulaForChannel(channel)
+		plan.Formula = target
+		plan.CurrentFormula = currentFormula
+		plan.SwitchFormula = action.NeedsSwitch()
 	}
 	if !plan.UpgradeAvailable {
 		return plan, nil

--- a/cli/internal/selfupdate/run_test.go
+++ b/cli/internal/selfupdate/run_test.go
@@ -149,8 +149,7 @@ func TestResolvePlanForChannel_BetaUsesPrereleaseAndPreFormula(t *testing.T) {
 	var srv *httptest.Server
 	mux := http.NewServeMux()
 	mux.HandleFunc("/repos/jjfantini/humblSKILLS/releases/latest", func(w http.ResponseWriter, r *http.Request) {
-		t.Error("beta channel must not hit /releases/latest")
-		w.WriteHeader(http.StatusInternalServerError)
+		w.WriteHeader(http.StatusNotFound)
 	})
 	mux.HandleFunc("/repos/jjfantini/humblSKILLS/releases", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -186,8 +185,60 @@ func TestResolvePlanForChannel_BetaUsesPrereleaseAndPreFormula(t *testing.T) {
 	if plan.Formula != FormulaPre {
 		t.Errorf("Formula = %q, want %s", plan.Formula, FormulaPre)
 	}
+	if plan.SwitchFormula {
+		t.Error("same-formula upgrade should not switch")
+	}
+	if plan.BrewHint != "brew upgrade humblskills-pre" {
+		t.Errorf("BrewHint = %q", plan.BrewHint)
+	}
 	if !plan.UpgradeAvailable {
 		t.Error("expected UpgradeAvailable from 2.51.0 to 2.52.0-pre.1")
+	}
+}
+
+func TestResolvePlanForChannel_BetaFormulaFollowsStableWinner(t *testing.T) {
+	const stable = "2.52.0"
+	assetName, err := CurrentAssetName(stable)
+	if err != nil {
+		t.Fatalf("CurrentAssetName: %v", err)
+	}
+	var srv *httptest.Server
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/jjfantini/humblSKILLS/releases/latest", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"tag_name": "v` + stable + `", "prerelease": false,
+			"assets": [
+				{"name": "` + assetName + `", "browser_download_url": "http://example.invalid/a"},
+				{"name": "checksums.txt", "browser_download_url": "http://example.invalid/c"}
+			]
+		}`))
+	})
+	mux.HandleFunc("/repos/jjfantini/humblSKILLS/releases", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`[{"tag_name": "v2.52.0-pre.1", "prerelease": true, "draft": false}]`))
+	})
+	srv = httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	prev := GitHubAPIBase
+	GitHubAPIBase = srv.URL
+	t.Cleanup(func() { GitHubAPIBase = prev })
+
+	plan, err := ResolvePlanForChannel(srv.Client(), DefaultRepo, "2.52.0-pre.1",
+		"/opt/homebrew/Cellar/humblskills-pre/2.52.0-pre.1/bin/humblskills", ChannelBeta, nil)
+	if err != nil {
+		t.Fatalf("ResolvePlanForChannel: %v", err)
+	}
+	if plan.LatestVersion != "2.52.0" {
+		t.Errorf("LatestVersion = %q, want 2.52.0", plan.LatestVersion)
+	}
+	if plan.Formula != FormulaStable {
+		t.Errorf("Formula = %q, want %s", plan.Formula, FormulaStable)
+	}
+	if !plan.SwitchFormula {
+		t.Error("expected SwitchFormula when brew-pre user should move to stable")
+	}
+	if plan.BrewHint != "brew uninstall humblskills-pre && brew install humblskills" {
+		t.Errorf("BrewHint = %q", plan.BrewHint)
 	}
 }
 

--- a/cli/internal/selfupdate/version.go
+++ b/cli/internal/selfupdate/version.go
@@ -11,6 +11,16 @@ func Normalize(v string) string {
 	return "v" + v
 }
 
+// DisplayVersion renders a version for humans: "v2.17.0" for ordinary
+// semver, but the bare string for non-numeric local builds ("dev") so
+// notices don't read as the slightly silly "vdev".
+func DisplayVersion(v string) string {
+	if v != "" && v[0] >= '0' && v[0] <= '9' {
+		return "v" + v
+	}
+	return v
+}
+
 // Compare reports the relative order of current vs. latest: negative when
 // current < latest (an upgrade is available), zero when equal, positive
 // when current is newer (e.g. a pre-release build). semver.Compare already

--- a/cli/internal/selfupdate/version_test.go
+++ b/cli/internal/selfupdate/version_test.go
@@ -14,6 +14,9 @@ func TestCompare(t *testing.T) {
 		{"2.18.0", "2.17.0", +1}, // local build ahead of latest release
 		{"dev", "2.17.0", -1},    // unparseable current always upgradable
 		{"", "2.17.0", -1},
+		{"2.52.0-pre.1", "2.52.0", -1}, // graduated stable beats its own pre
+		{"2.52.0", "2.53.0-pre.1", -1}, // newer pre beats last stable
+		{"2.52.0", "2.52.0-pre.1", +1},
 	}
 	for _, c := range cases {
 		got := Compare(c.current, c.latest)

--- a/cli/internal/tui/dashboard.go
+++ b/cli/internal/tui/dashboard.go
@@ -41,12 +41,32 @@ type DashboardStatus struct {
 	Skills    int // installed skills (unique)
 }
 
+// VersionNotice is the dashboard "newer version available" banner.
+// Shown on the main launcher when the channel has a newer GitHub
+// release than the running binary. Command is the same string upgrade
+// --dry-run prints (humblskills upgrade, brew upgrade <formula>, or
+// brew uninstall/install when beta switches formulas).
+type VersionNotice struct {
+	Current string // already display-formatted, e.g. "v2.15.0"
+	Latest  string
+	Channel string // "stable" or "beta"
+	Command string
+}
+
+// VersionNoticeHeadline is the TUI banner title.
+const VersionNoticeHeadline = "Newer version available"
+
 // DashboardConfig bundles everything RunDashboard needs.
 type DashboardConfig struct {
 	Theme   *ui.Theme
 	Version string
 	Status  DashboardStatus
 	Tiles   []DashboardTile
+	// Notice, when non-nil, is shown immediately. CheckNotice runs once
+	// from Init in the background so a slow GitHub lookup never blocks
+	// the first frame.
+	Notice      *VersionNotice
+	CheckNotice func() *VersionNotice
 }
 
 // RunDashboard opens the full-screen launcher (bubbletea alt-screen) and
@@ -57,6 +77,7 @@ func RunDashboard(cfg DashboardConfig) (DashboardResult, error) {
 	}
 	m := dashboardModel{
 		cfg:      cfg,
+		notice:   cfg.Notice,
 		cursor:   0,
 		searchOn: false,
 	}
@@ -106,12 +127,30 @@ type dashboardModel struct {
 	width, height int
 	done          bool
 	result        DashboardResult
+
+	notice *VersionNotice
 }
 
-func (m dashboardModel) Init() tea.Cmd { return nil }
+type versionNoticeMsg struct {
+	notice *VersionNotice
+}
+
+func (m dashboardModel) Init() tea.Cmd {
+	if m.notice != nil || m.cfg.CheckNotice == nil {
+		return nil
+	}
+	check := m.cfg.CheckNotice
+	return func() tea.Msg {
+		return versionNoticeMsg{notice: check()}
+	}
+}
 
 func (m dashboardModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
+	case versionNoticeMsg:
+		m.notice = msg.notice
+		m = m.resizeViewport()
+		return m, nil
 	case tea.WindowSizeMsg:
 		m.width, m.height = msg.Width, msg.Height
 		m = m.resizeViewport()
@@ -304,13 +343,21 @@ func (m dashboardModel) cols() int {
 
 // gridHeight is the number of rows available to the scrollable grid view.
 // Total vertical budget = height. Non-grid lines: header(2) + blank(1) +
-// search(3) + blank(1) + footer(2) = 9. So grid gets whatever is left.
+// search(3) + blank(1) + footer(2) = 9, plus the notice banner when present.
 func (m dashboardModel) gridHeight() int {
-	h := m.height - 9
+	h := m.height - 9 - m.bannerHeight()
 	if h < 3 {
 		h = 3
 	}
 	return h
+}
+
+// bannerHeight is the notice panel plus the blank line under it, or 0.
+func (m dashboardModel) bannerHeight() int {
+	if m.notice == nil {
+		return 0
+	}
+	return versionNoticeDisplayHeight + 1
 }
 
 // syncViewport rebuilds the grid content, resizes if needed, and scrolls so
@@ -373,6 +420,10 @@ func (m dashboardModel) View() string {
 	footer := Footer(th, m.hints(), right, m.width)
 
 	search := indentBlock(m.renderSearchBar(), 2)
+	banner := ""
+	if m.notice != nil {
+		banner = indentBlock(renderVersionNotice(th, *m.notice, m.bodyWidth()), 2) + "\n"
+	}
 
 	gridView := ""
 	if m.ready {
@@ -389,7 +440,7 @@ func (m dashboardModel) View() string {
 	// clamp as well as pad or that one extra row scrolls the header away.
 	gridView = fitToHeight(gridView, m.gridHeight())
 
-	return header + "\n\n" + search + "\n\n" + gridView + "\n" + footer
+	return header + "\n\n" + banner + search + "\n\n" + gridView + "\n" + footer
 }
 
 func (m dashboardModel) focusedLabel() string {
@@ -507,6 +558,37 @@ func (m dashboardModel) renderSearchBar() string {
 		Padding(0, 1).
 		Width(inner).
 		Render(line)
+}
+
+// versionNoticeDisplayHeight is the boxed banner: border(2) + title(1) +
+// versions+command(1) = 4.
+const versionNoticeDisplayHeight = 4
+
+// renderVersionNotice draws the dashboard "newer version available" panel.
+// Line 1 is the headline; line 2 is current → latest (channel) and the
+// exact update command (including brew formula switch).
+func renderVersionNotice(th *ui.Theme, n VersionNotice, width int) string {
+	if th == nil {
+		th = ui.DefaultTheme()
+	}
+	inner := width - 4
+	if inner < 20 {
+		inner = 20
+	}
+	title := th.Warn.Render(VersionNoticeHeadline)
+	versions := fmt.Sprintf("%s → %s (%s)", n.Current, n.Latest, n.Channel)
+	action := "run `" + n.Command + "`"
+	if n.Command == "humblskills upgrade" {
+		action += "  ·  press U"
+	}
+	line2 := th.Name.Render(versions) + th.Crumb.Render("  ·  ") + th.Detail.Render(action)
+	body := title + "\n" + truncateDisplay(line2, inner)
+	return lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(th.Palette.Yellow).
+		Padding(0, 1).
+		Width(width - 2).
+		Render(body)
 }
 
 // tileDisplayHeight is the fixed rendered height of every tile, in lines:

--- a/cli/internal/tui/dashboard_test.go
+++ b/cli/internal/tui/dashboard_test.go
@@ -267,6 +267,119 @@ func TestVersionScreenModel_View_EmptyBeforeSize(t *testing.T) {
 	}
 }
 
+func TestRenderVersionNotice_GitHubAndHomebrew(t *testing.T) {
+	th := ui.DefaultTheme()
+	got := renderVersionNotice(th, VersionNotice{
+		Current: "v2.15.0",
+		Latest:  "v2.17.0",
+		Channel: "stable",
+		Command: "humblskills upgrade",
+	}, 80)
+	for _, want := range []string{
+		VersionNoticeHeadline,
+		"v2.15.0",
+		"v2.17.0",
+		"stable",
+		"humblskills upgrade",
+		"press U",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("banner missing %q:\n%s", want, got)
+		}
+	}
+
+	brew := renderVersionNotice(th, VersionNotice{
+		Current: "v2.51.0",
+		Latest:  "v2.52.0-pre.1",
+		Channel: "beta",
+		Command: "brew upgrade humblskills-pre",
+	}, 80)
+	if !strings.Contains(brew, "brew upgrade humblskills-pre") {
+		t.Errorf("brew banner missing formula:\n%s", brew)
+	}
+	if strings.Contains(brew, "press U") {
+		t.Error("Homebrew banner should not tell users to press U")
+	}
+
+	switchBanner := renderVersionNotice(th, VersionNotice{
+		Current: "v2.52.0-pre.1",
+		Latest:  "v2.52.0",
+		Channel: "beta",
+		Command: "brew uninstall humblskills-pre && brew install humblskills",
+	}, 100)
+	if !strings.Contains(switchBanner, "brew uninstall humblskills-pre && brew install humblskills") {
+		t.Errorf("switch banner missing brew commands:\n%s", switchBanner)
+	}
+}
+
+func TestDashboardModel_View_ShowsNoticeBanner(t *testing.T) {
+	m := dashboardModel{
+		cfg: DashboardConfig{
+			Theme:   ui.DefaultTheme(),
+			Version: "2.15.0",
+			Tiles:   DefaultDashboardTiles(),
+		},
+		notice: &VersionNotice{
+			Current: "v2.15.0",
+			Latest:  "v2.17.0",
+			Channel: "stable",
+			Command: "humblskills upgrade",
+		},
+		width:  100,
+		height: 30,
+	}
+	m.rebuildVisible()
+	m = m.resizeViewport()
+	view := m.View()
+	if !strings.Contains(view, VersionNoticeHeadline) {
+		t.Errorf("dashboard missing banner headline:\n%s", view)
+	}
+	if !strings.Contains(view, "humblskills upgrade") {
+		t.Errorf("dashboard missing update command:\n%s", view)
+	}
+}
+
+func TestDashboardModel_View_QuietWithoutNotice(t *testing.T) {
+	m := dashboardModel{
+		cfg:    DashboardConfig{Theme: ui.DefaultTheme(), Tiles: DefaultDashboardTiles()},
+		width:  100,
+		height: 30,
+	}
+	m.rebuildVisible()
+	m = m.resizeViewport()
+	if strings.Contains(m.View(), VersionNoticeHeadline) {
+		t.Error("current dashboard should not show a version banner")
+	}
+}
+
+func TestDashboardModel_Init_CheckNoticeOnce(t *testing.T) {
+	var calls int
+	m := dashboardModel{
+		cfg: DashboardConfig{
+			Theme: ui.DefaultTheme(),
+			Tiles: DefaultDashboardTiles(),
+			CheckNotice: func() *VersionNotice {
+				calls++
+				return &VersionNotice{Current: "v1", Latest: "v2", Channel: "stable", Command: "humblskills upgrade"}
+			},
+		},
+	}
+	cmd := m.Init()
+	if cmd == nil {
+		t.Fatal("Init should return a check cmd")
+	}
+	msg := cmd()
+	out, _ := m.Update(msg)
+	dm := out.(dashboardModel)
+	if dm.notice == nil || dm.notice.Latest != "v2" {
+		t.Fatalf("notice not applied: %+v", dm.notice)
+	}
+	out, _ = dm.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	if calls != 1 {
+		t.Errorf("CheckNotice calls = %d, want 1", calls)
+	}
+}
+
 func TestPadRight(t *testing.T) {
 	if padRight("abc", 6) != "abc   " {
 		t.Errorf("got %q", padRight("abc", 6))

--- a/cli/internal/tui/dashboard_test.go
+++ b/cli/internal/tui/dashboard_test.go
@@ -306,8 +306,8 @@ func TestRenderVersionNotice_GitHubAndHomebrew(t *testing.T) {
 		Latest:  "v2.52.0",
 		Channel: "beta",
 		Command: "brew uninstall humblskills-pre && brew install humblskills",
-	}, 100)
-	if !strings.Contains(switchBanner, "brew uninstall humblskills-pre && brew install humblskills") {
+	}, 140)
+	if !strings.Contains(switchBanner, "brew uninstall humblskills-pre") || !strings.Contains(switchBanner, "brew install humblskills") {
 		t.Errorf("switch banner missing brew commands:\n%s", switchBanner)
 	}
 }

--- a/cli/internal/tui/profile.go
+++ b/cli/internal/tui/profile.go
@@ -286,13 +286,13 @@ var groupByCategoryOpts = []struct {
 
 // channelOpts is the picker for Profile.Channel. Selecting "stable (default)"
 // writes the explicit stable value so the field is first-class on disk;
-// "beta" follows the latest GitHub prerelease and the humblskills-pre formula.
+// "beta" follows the newer of latest stable vs latest prerelease.
 var channelOpts = []struct {
 	label string
 	value string
 }{
 	{"stable (default) — latest release", profile.ChannelStable},
-	{"beta — latest pre-release", profile.ChannelBeta},
+	{"beta — newest version (stable or pre)", profile.ChannelBeta},
 }
 
 func intPtr(n int) *int    { return &n }
@@ -692,9 +692,11 @@ func (m profileModel) renderChannelOptions(bar string, width int) []string {
 	rows := make([]string, 0, len(channelOpts)+4)
 	rows = append(rows, detailLines(th, bar,
 		"Which CLI build upgrade fetches. Stable is GitHub /releases/latest and the "+
-			"humblskills brew formula (the default). Beta is the latest pre-release "+
-			"and the humblskills-pre formula. Same field Homebrew and `humblskills "+
-			"upgrade --channel` use — nothing else to configure.", width)...)
+			"humblskills brew formula (the default). Beta picks the newer of latest "+
+			"stable vs latest pre-release — always the newest version. If that winner "+
+			"is a stable, Homebrew users on humblskills-pre are switched with "+
+			"`brew uninstall humblskills-pre && brew install humblskills`. Same field "+
+			"`humblskills upgrade --channel` uses — nothing else to configure.", width)...)
 	rows = append(rows, bar)
 	rows = append(rows, bar+" "+th.SectionTitle.Render("OPTIONS"))
 	for i, opt := range channelOpts {

--- a/cli/internal/tui/upgrade.go
+++ b/cli/internal/tui/upgrade.go
@@ -23,6 +23,8 @@ const (
 	UpgradeStepCheckingLatest    UpgradeStep = "checking_latest"
 	UpgradeStepBrewUpdating      UpgradeStep = "brew_updating"
 	UpgradeStepBrewUpgrading     UpgradeStep = "brew_upgrading"
+	UpgradeStepBrewUninstalling  UpgradeStep = "brew_uninstalling"
+	UpgradeStepBrewInstalling    UpgradeStep = "brew_installing"
 	UpgradeStepDownloading       UpgradeStep = "downloading"
 	UpgradeStepVerifyingChecksum UpgradeStep = "verifying_checksum"
 	UpgradeStepInstalling        UpgradeStep = "installing"
@@ -37,6 +39,8 @@ var upgradeStepLabels = map[UpgradeStep]string{
 	UpgradeStepCheckingLatest:    "checking latest release",
 	UpgradeStepBrewUpdating:      "running brew update",
 	UpgradeStepBrewUpgrading:     "running brew upgrade",
+	UpgradeStepBrewUninstalling:  "running brew uninstall",
+	UpgradeStepBrewInstalling:    "running brew install",
 	UpgradeStepDownloading:       "downloading release archive",
 	UpgradeStepVerifyingChecksum: "verifying checksum",
 	UpgradeStepInstalling:        "installing",

--- a/docs/getting_started/installation-agent/SKILL.md
+++ b/docs/getting_started/installation-agent/SKILL.md
@@ -68,13 +68,15 @@ humblskills upgrade                 # profile channel (stable if unset)
 humblskills upgrade --channel beta  # this run only
 humblskills profile get channel
 humblskills profile set channel beta
-brew upgrade humblskills            # stable formula
-brew upgrade humblskills-pre        # beta formula
+brew upgrade humblskills                                          # stable formula
+brew upgrade humblskills-pre                                      # beta, winner is still a pre
+brew uninstall humblskills-pre && brew install humblskills        # beta, winner is a graduated stable
 ```
 
-On a brew install, `upgrade` runs `brew upgrade <formula>` for the resolved
-channel. Same `channel` field as `profile.json`. In the TUI: `humblskills` or
-`humblskills profile` → **install channel**.
+On a brew install, `upgrade` runs the brew commands for the resolved channel
+winner (beta = newer of latest stable vs latest prerelease). Same `channel`
+field as `profile.json`. In the TUI: `humblskills` or `humblskills profile` →
+**install channel**.
 
 `upgrade` updates the CLI binary; `update` updates installed skills.
 `humblskills install` installs **skills**, not the CLI.

--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -104,19 +104,29 @@ Or the same TUI editor that already exists (do not look for a second settings
 app): run `humblskills` and open **Profile**, or `humblskills profile`. The
 **install channel** row shows the current value; enter to switch stable ↔ beta.
 
-| Channel | GitHub | Homebrew formula |
-|---------|--------|------------------|
-| `stable` (default) | `/releases/latest` | `humblskills` |
-| `beta` | latest prerelease (`vX.Y.Z-pre.N`) | `humblskills-pre` |
+| Channel | GitHub | Homebrew |
+|---------|--------|----------|
+| `stable` (default) | `/releases/latest` only | `brew upgrade humblskills` |
+| `beta` | higher semver of latest stable vs latest prerelease | formula follows the winner (see below) |
 
-On a Homebrew-managed install, `upgrade` detects that, asks for confirmation, and
-runs `brew update && brew upgrade <formula>` for the resolved channel, so
-Homebrew's own Cellar bookkeeping stays correct. It only asks you to run brew
-yourself if `brew` isn't on `PATH`. You can of course still do it directly:
+**beta** means “always the newest version,” not “prereleases only.” After a
+stable graduates (`v2.52.0` > `v2.52.0-pre.1`) beta picks the stable. A newer
+pre (`v2.53.0-pre.1` > `v2.52.0`) stays on the pre.
+
+On a Homebrew-managed install, `upgrade` detects that, asks for confirmation,
+and runs brew itself so Cellar bookkeeping stays correct:
+
+- Winner is a pre, already on `humblskills-pre`: `brew upgrade humblskills-pre`
+- Winner is a stable, currently on `humblskills-pre`: `brew uninstall humblskills-pre && brew install humblskills`
+- Winner is a stable, already on `humblskills`: `brew upgrade humblskills`
+
+It only asks you to run brew yourself if `brew` isn't on `PATH`. You can of
+course still do it directly:
 
 ```sh
-brew upgrade humblskills       # stable
-brew upgrade humblskills-pre   # beta
+brew upgrade humblskills                                          # already on the stable formula
+brew upgrade humblskills-pre                                      # beta, winner is still a pre
+brew uninstall humblskills-pre && brew install humblskills        # beta, winner is a graduated stable
 ```
 
 `upgrade` updates the **CLI**; `humblskills update` updates your installed

--- a/docs/using_humblskills/updating.md
+++ b/docs/using_humblskills/updating.md
@@ -120,23 +120,30 @@ humblskills profile get channel
 humblskills profile set channel beta
 ```
 
-The upgrade checks GitHub releases (stable → `/releases/latest`; beta → latest
-prerelease), verifies the checksum, and replaces the running binary in place.
+The upgrade checks GitHub releases (stable → `/releases/latest` only; beta →
+the higher semver of latest stable vs latest prerelease), verifies the
+checksum, and replaces the running binary in place. Beta is “always the newest
+version”: `v2.52.0` beats `v2.52.0-pre.1`; `v2.53.0-pre.1` beats `v2.52.0`.
+
+The same resolver feeds the CLI update notice (stderr on `doctor` / `start` /
+`version` / …) and the TUI Dashboard banner.
 
 The channel is the same `profile.json` field Homebrew uses. Change it from the
 existing Profile TUI (`humblskills` → Profile → **install channel**) or
 `profile set` — there is no second settings surface.
 
-If you installed via Homebrew, `upgrade` detects that and delegates: it confirms
-with you, then runs `brew update && brew upgrade <formula>` (`humblskills` or
-`humblskills-pre`) itself, so Homebrew's own bookkeeping stays correct. It falls
-back to telling you to run brew by hand only when `brew` isn't on `PATH`. Doing
-it directly works too:
+If you installed via Homebrew, `upgrade` detects that and delegates. The
+formula follows beta’s winner, not the channel name:
 
 ```sh
-brew upgrade humblskills
-brew upgrade humblskills-pre
+brew upgrade humblskills                                          # stable winner, already on humblskills
+brew upgrade humblskills-pre                                      # beta winner is still a pre
+brew uninstall humblskills-pre && brew install humblskills        # beta winner is a graduated stable
 ```
+
+`upgrade` runs those commands itself after confirming, so Homebrew's own
+bookkeeping stays correct. It falls back to telling you to run brew by hand
+only when `brew` isn't on `PATH`.
 
 ## Related topics
 


### PR DESCRIPTION
## Summary
- Beta means newest version: max(latest stable, latest prerelease) by semver. Stable still ignores prereleases.
- Jennings dry-run: `2.52.0` > `2.52.0-pre.1`, so beta now picks stable `v2.52.0` instead of staying on an older pre.
- Homebrew follows the winner: pre stays on `humblskills-pre`; if beta chooses stable while on pre, `brew uninstall humblskills-pre && brew install humblskills`.
- Same resolver for `upgrade`, `--channel`, profile, CLI notice, and TUI banner.

## Test plan
- [ ] Beta with 2.52.0 vs 2.52.0-pre.1 chooses 2.52.0
- [ ] Beta with 2.53.0-pre.1 vs 2.52.0 chooses the pre
- [ ] Stable never chooses a pre
- [ ] Brew-pre user on beta gets uninstall/install stable when stable wins